### PR TITLE
feat: render Markdown tables and split label blocks for Notion/Discord

### DIFF
--- a/src/notifier/discord.py
+++ b/src/notifier/discord.py
@@ -31,6 +31,38 @@ def _wrap_tables_in_codeblock(text: str) -> str:
     return "".join(result)
 
 
+def _chunk_preserving_fences(text: str, chunk_size: int = 1900) -> list[str]:
+    """テキストを chunk_size 以内に分割する。コードフェンス（```）をまたぐ場合は
+    チャンク末尾でフェンスを閉じ、次チャンク先頭で再開することでバランスを保つ。"""
+    chunks: list[str] = []
+    current_lines: list[str] = []
+    current_len = 0
+    in_fence = False
+
+    for line in text.splitlines(keepends=True):
+        if line.rstrip() == "```":
+            in_fence = not in_fence
+
+        # 追加するとチャンクサイズを超える場合は flush
+        if current_len + len(line) > chunk_size and current_lines:
+            chunk = "".join(current_lines)
+            if in_fence:
+                chunk += "```\n"   # 開いているフェンスを閉じる
+            chunks.append(chunk)
+            current_lines = []
+            current_len = 0
+            if in_fence:
+                current_lines = ["```\n"]  # 次チャンクでフェンスを再開
+                current_len = 4
+
+        current_lines.append(line)
+        current_len += len(line)
+
+    if current_lines:
+        chunks.append("".join(current_lines))
+    return chunks or [""]
+
+
 def send_to_discord(text: str, token: str, channel_id: str):
     """Discord Bot API でチャンネルにメッセージ送信（2000文字制限を考慮して分割）"""
     if not token or not channel_id:
@@ -39,8 +71,7 @@ def send_to_discord(text: str, token: str, channel_id: str):
     url = f"https://discord.com/api/v10/channels/{channel_id}/messages"
     headers = {"Authorization": f"Bot {token}"}
     text = _wrap_tables_in_codeblock(text)
-    chunk_size = 1900
-    chunks = [text[i:i + chunk_size] for i in range(0, len(text), chunk_size)]
+    chunks = _chunk_preserving_fences(text)
     for i, chunk in enumerate(chunks, 1):
         res = requests.post(url, headers=headers, json={"content": chunk})
         res.raise_for_status()

--- a/src/notifier/discord.py
+++ b/src/notifier/discord.py
@@ -1,7 +1,34 @@
+import re
 import requests
 from src.logger import get_logger
 
 logger = get_logger(__name__)
+
+
+def _wrap_tables_in_codeblock(text: str) -> str:
+    """Markdown テーブルブロックをコードブロックで囲み、Discord で等幅表示にする。"""
+    lines = text.splitlines(keepends=True)
+    result = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.rstrip()
+        is_table = stripped.startswith("|") and stripped.endswith("|")
+        is_sep = bool(re.fullmatch(r"[\|\s\-:]+", stripped) and "|" in stripped)
+        if is_table or is_sep:
+            table_lines = []
+            while i < len(lines):
+                s = lines[i].rstrip()
+                if (s.startswith("|") and s.endswith("|")) or (re.fullmatch(r"[\|\s\-:]+", s) and "|" in s):
+                    table_lines.append(lines[i].rstrip("\n"))
+                    i += 1
+                else:
+                    break
+            result.append("```\n" + "\n".join(table_lines) + "\n```\n")
+            continue
+        result.append(line)
+        i += 1
+    return "".join(result)
 
 
 def send_to_discord(text: str, token: str, channel_id: str):
@@ -11,6 +38,7 @@ def send_to_discord(text: str, token: str, channel_id: str):
         return
     url = f"https://discord.com/api/v10/channels/{channel_id}/messages"
     headers = {"Authorization": f"Bot {token}"}
+    text = _wrap_tables_in_codeblock(text)
     chunk_size = 1900
     chunks = [text[i:i + chunk_size] for i in range(0, len(text), chunk_size)]
     for i, chunk in enumerate(chunks, 1):

--- a/src/notifier/notion.py
+++ b/src/notifier/notion.py
@@ -178,16 +178,17 @@ _LABEL_COLON_RE = re.compile(r"^([-*]\s+)?([^：\n]{1,30}：)(.{5,})")
 def _split_label_colon(line: str) -> list[str]:
     """「ラベル：内容」形式の行を2行に分割して返す。該当しない場合はそのまま返す。
 
-    例: "AI・クラウド：強い。..." → ["**AI・クラウド：**", "強い。..."]
-    箇条書き行 "- AI・クラウド：..." も同様に処理する。
+    例: "- **AI・クラウド：**強い。..." → ["**AI・クラウド：**", "強い。..."]
+    - ラベルは paragraph（太字）に、内容は別 paragraph に分割する
+    - 箇条書きプレフィックス（- / *）は除去する
+    - 既存の ** マーカーは除去してから付け直す（二重 ** 防止）
     """
     m = _LABEL_COLON_RE.match(line.rstrip())
     if not m:
         return [line]
-    prefix = m.group(1) or ""   # "- " or ""
-    label = m.group(2)          # "AI・クラウド："
-    content = m.group(3).strip()
-    return [f"{prefix}**{label}**", content]
+    label = m.group(2).strip("* ")              # 既存 ** を除去: "AI・クラウド："
+    content = re.sub(r"^\*+\s*", "", m.group(3).strip())  # 先頭の閉じ ** を除去
+    return [f"**{label}**", content]
 
 
 def _markdown_to_blocks(markdown: str) -> list[dict]:

--- a/src/notifier/notion.py
+++ b/src/notifier/notion.py
@@ -172,7 +172,7 @@ def _table_rows_to_block(rows: list[str]) -> dict:
     }
 
 
-_LABEL_COLON_RE = re.compile(r"^([-*]\s+)?([^：\n]{1,30}：)(.{5,})")
+_LABEL_COLON_RE = re.compile(r"^([-*]\s+)?([^：\n]{1,30}：)(.+)")
 
 
 def _split_label_colon(line: str) -> list[str]:
@@ -194,27 +194,25 @@ def _split_label_colon(line: str) -> list[str]:
 def _markdown_to_blocks(markdown: str) -> list[dict]:
     """Markdown 文字列を Notion ブロック辞書のリストに変換して返す。
     Markdown テーブルは Notion table ブロックに変換する。
-    「ラベル：内容」行はラベルと内容を別ブロックに分割する。"""
+    「ラベル：内容」行はラベルと内容を別ブロックに分割する（テーブル行は除く）。"""
     blocks = []
     raw_lines = markdown.splitlines()
-    # ラベル：内容 行を展開してから処理
-    lines: list[str] = []
-    for raw in raw_lines:
-        lines.extend(_split_label_colon(raw))
-
     i = 0
-    while i < len(lines):
-        line = lines[i]
-        if _is_table_row(line):
+    while i < len(raw_lines):
+        line = raw_lines[i]
+        # テーブル検出を先に行い、テーブル行はラベル分割しない
+        if _is_table_row(line) or _is_table_separator(line):
             table_lines = []
-            while i < len(lines) and (_is_table_row(lines[i]) or _is_table_separator(lines[i])):
-                table_lines.append(lines[i])
+            while i < len(raw_lines) and (_is_table_row(raw_lines[i]) or _is_table_separator(raw_lines[i])):
+                table_lines.append(raw_lines[i])
                 i += 1
             blocks.append(_table_rows_to_block(table_lines))
             continue
-        block = _line_to_block(line)
-        if block is not None:
-            blocks.append(block)
+        # テーブル以外の行にのみラベル分割を適用
+        for expanded in _split_label_colon(line):
+            block = _line_to_block(expanded)
+            if block is not None:
+                blocks.append(block)
         i += 1
     return blocks
 

--- a/src/notifier/notion.py
+++ b/src/notifier/notion.py
@@ -85,10 +85,6 @@ def _line_to_block(line: str) -> dict | None:
     if re.fullmatch(r"-{3,}", stripped):
         return {"object": "block", "type": "divider", "divider": {}}
 
-    # テーブル区切り行 |---|---| → スキップ
-    if re.fullmatch(r"[\|\s\-:]+", stripped) and "|" in stripped:
-        return None
-
     # 見出し ##
     m = re.match(r"^(#{1,3})\s+(.*)", stripped)
     if m:
@@ -99,12 +95,6 @@ def _line_to_block(line: str) -> dict | None:
             "type": block_type,
             block_type: {"rich_text": _parse_inline(m.group(2))},
         }
-
-    # テーブル行 | col | col | → 簡易的に段落として処理
-    if stripped.startswith("|"):
-        cells = [c.strip() for c in stripped.strip("|").split("|")]
-        plain = "  |  ".join(cells)
-        return _paragraph_block(plain)
 
     # 箇条書き - item
     m = re.match(r"^[-*]\s+(.*)", stripped)
@@ -136,13 +126,71 @@ def _paragraph_block(text: str) -> dict:
     }
 
 
+def _is_table_row(line: str) -> bool:
+    """Markdown テーブル行（`| ... |` 形式）かどうかを判定する。"""
+    stripped = line.rstrip()
+    return stripped.startswith("|") and stripped.endswith("|")
+
+
+def _is_table_separator(line: str) -> bool:
+    """Markdown テーブル区切り行（`|---|---|` 形式）かどうかを判定する。"""
+    stripped = line.rstrip()
+    return bool(re.fullmatch(r"[\|\s\-:]+", stripped) and "|" in stripped)
+
+
+def _table_rows_to_block(rows: list[str]) -> dict:
+    """連続する Markdown テーブル行を Notion table ブロックに変換する。
+    2行目が区切り行の場合は has_column_header=True とする。"""
+    data_rows = [r for r in rows if not _is_table_separator(r)]
+    has_header = len(rows) >= 2 and _is_table_separator(rows[1])
+
+    def parse_cells(row: str) -> list[list[dict]]:
+        cells = [c.strip() for c in row.strip().strip("|").split("|")]
+        return [_parse_inline(c) for c in cells]
+
+    table_width = max((len(parse_cells(r)) for r in data_rows), default=1)
+
+    children = []
+    for row in data_rows:
+        cells = parse_cells(row)
+        while len(cells) < table_width:
+            cells.append([{"type": "text", "text": {"content": ""}}])
+        children.append({
+            "type": "table_row",
+            "table_row": {"cells": cells},
+        })
+
+    return {
+        "object": "block",
+        "type": "table",
+        "table": {
+            "table_width": table_width,
+            "has_column_header": has_header,
+            "has_row_header": False,
+            "children": children,
+        },
+    }
+
+
 def _markdown_to_blocks(markdown: str) -> list[dict]:
-    """Markdown 文字列を Notion ブロック辞書のリストに変換して返す。"""
+    """Markdown 文字列を Notion ブロック辞書のリストに変換して返す。
+    Markdown テーブルは Notion table ブロックに変換する。"""
     blocks = []
-    for line in markdown.splitlines():
+    lines = markdown.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if _is_table_row(line):
+            table_lines = []
+            while i < len(lines) and (_is_table_row(lines[i]) or _is_table_separator(lines[i])):
+                table_lines.append(lines[i])
+                i += 1
+            blocks.append(_table_rows_to_block(table_lines))
+            continue
         block = _line_to_block(line)
         if block is not None:
             blocks.append(block)
+        i += 1
     return blocks
 
 

--- a/src/notifier/notion.py
+++ b/src/notifier/notion.py
@@ -172,11 +172,35 @@ def _table_rows_to_block(rows: list[str]) -> dict:
     }
 
 
+_LABEL_COLON_RE = re.compile(r"^([-*]\s+)?([^：\n]{1,30}：)(.{5,})")
+
+
+def _split_label_colon(line: str) -> list[str]:
+    """「ラベル：内容」形式の行を2行に分割して返す。該当しない場合はそのまま返す。
+
+    例: "AI・クラウド：強い。..." → ["**AI・クラウド：**", "強い。..."]
+    箇条書き行 "- AI・クラウド：..." も同様に処理する。
+    """
+    m = _LABEL_COLON_RE.match(line.rstrip())
+    if not m:
+        return [line]
+    prefix = m.group(1) or ""   # "- " or ""
+    label = m.group(2)          # "AI・クラウド："
+    content = m.group(3).strip()
+    return [f"{prefix}**{label}**", content]
+
+
 def _markdown_to_blocks(markdown: str) -> list[dict]:
     """Markdown 文字列を Notion ブロック辞書のリストに変換して返す。
-    Markdown テーブルは Notion table ブロックに変換する。"""
+    Markdown テーブルは Notion table ブロックに変換する。
+    「ラベル：内容」行はラベルと内容を別ブロックに分割する。"""
     blocks = []
-    lines = markdown.splitlines()
+    raw_lines = markdown.splitlines()
+    # ラベル：内容 行を展開してから処理
+    lines: list[str] = []
+    for raw in raw_lines:
+        lines.extend(_split_label_colon(raw))
+
     i = 0
     while i < len(lines):
         line = lines[i]

--- a/src/notifier/notion.py
+++ b/src/notifier/notion.py
@@ -187,7 +187,7 @@ def _split_label_colon(line: str) -> list[str]:
     if not m:
         return [line]
     label = m.group(2).strip("* ")              # 既存 ** を除去: "AI・クラウド："
-    content = re.sub(r"^\*+\s*", "", m.group(3).strip())  # 先頭の閉じ ** を除去
+    content = re.sub(r"^\*+\s*|\s*\*+$", "", m.group(3).strip())  # 先頭・末尾の ** を除去
     return [f"**{label}**", content]
 
 


### PR DESCRIPTION
## Summary

- **Notion**: Markdown テーブルを Notion `table` ブロックに変換（従来は段落として出力）
- **Notion**: `ラベル：内容` 形式の行をラベル（太字 paragraph）と内容の2ブロックに分割
- **Discord**: Markdown テーブルをコードブロック（` ``` `）で囲んで等幅表示

## Changes

### `src/notifier/notion.py`
- `_is_table_row()` / `_is_table_separator()` でテーブル行を判定
- `_table_rows_to_block()` で連続テーブル行を Notion `table` ブロックに変換（ヘッダー行対応）
- `_split_label_colon()` で `ラベル：内容` を2行に展開
  - 既存の `**` マーカー（先頭・末尾）を除去して付け直し、二重 `****` を防止
  - 箇条書きプレフィックス（`- `）を除去して paragraph として出力
- `_markdown_to_blocks()` をループ処理に変更しテーブルグループ化に対応

### `src/notifier/discord.py`
- `_wrap_tables_in_codeblock()` でテーブル行を ` ``` ` で囲んで送信前に変換

## Test plan

- [ ] セクター動向出力で `**AI・クラウド：**` がラベルブロック、内容が別ブロックで表示されること
- [ ] Notion でテーブルが table ブロックとして描画されること
- [ ] Discord でテーブルがコードブロック（等幅）で表示されること
- [ ] `bin/run.sh` を実行してタイムアウトなく完走すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Discord notifications now properly format and display tables in code blocks for improved readability and structure preservation
* Markdown tables are automatically converted to native Notion table blocks with automatic header detection and cell normalization
* Enhanced content preprocessing for consistent formatting and better handling of formatted data across different notification platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->