### PR TITLE
refactor: extract claude CLI invocation into shared claude_runner module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,153 +2,31 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Setup & Running
+> Setup, architecture, configuration, and testing details are documented in [README.md](README.md).
+
+## Quick Commands
 
 ```bash
-# Create venv and install dependencies
-uv venv .venv
-uv pip sync requirements.txt
-
-# Run both agents sequentially
-bin/run.sh
-
-# Run individually
-source .venv/bin/activate
-python bin/briefing.py
-python bin/xss_intel.py
-
-# Run tests
-.venv/bin/pytest -v
+uv pip sync requirements.txt   # Install deps
+bin/run.sh                     # Run both agents
+.venv/bin/pytest -v            # Run tests
+uv pip compile requirements.in -o requirements.txt  # Recompile deps
 ```
 
-## Dependency Management
+## Key Implementation Notes
 
-`requirements.in` is the manually managed direct-dependency file. Never edit `requirements.txt` directly — it is auto-generated.
-
-```bash
-# After adding a package to requirements.in
-uv pip compile requirements.in -o requirements.txt
-uv pip sync requirements.txt
-```
-
-## Architecture
-
-Two independent agents share the same Discord/Notion notifiers and a common claude CLI helper.
-
-### Shared Claude CLI Helper (`src/claude_runner.py`)
-
-All claude CLI invocations go through `run_claude()`:
-
-```python
-run_claude(prompt: str, label: str, timeout: int = 300) -> str
-```
-
-- Finds `claude` binary via `shutil.which`
-- Excludes `ANTHROPIC_API_KEY` from the subprocess environment — forces WebSearch to use OAuth (subscription) auth instead of API billing
-- Sets `stdin=subprocess.DEVNULL` to prevent the CLI from waiting for terminal input
-- Handles timeout (`subprocess.TimeoutExpired`) and non-zero exit codes with structured logging
-- Truncates error messages to 2000 chars to avoid embedding large stdout in exceptions
-
-### Briefing Agent
-
-```
-bin/briefing.py
-  └── src/handler.py
-        ├── src/fetcher/stocks.py        # Fetches previous-day % change via yfinance
-        ├── src/generator/briefing.py    # Builds prompts; calls run_claude() in parallel (ThreadPoolExecutor)
-        │     └── prompts/briefing.md    # Template vars: {tickers} {themes} {geopolitical} {stocks}
-        │     └── prompts/briefing_sectors.md  # Template vars: {watch_sectors} {stocks}
-        ├── src/notifier/discord.py
-        └── src/notifier/notion.py
-```
-
-Parallel execution: main analysis (`_TIMEOUT_MAIN=300s`) and sector sweep (`_TIMEOUT_SECTORS=480s`) run concurrently. If only the sector sweep fails, the agent falls back to degraded mode (main analysis only).
-
-### XSS Intel Agent
-
-```
-bin/xss_intel.py
-  └── src/xss_handler.py
-        ├── src/generator/xss_report.py  # Builds prompt; calls run_claude()
-        │     └── prompts/xss_intel.md
-        ├── src/notifier/discord.py
-        └── src/notifier/notion.py
-```
-
-### Config Schema (`src/config.py`)
-
-- `BriefingConfig` holds `PortfolioConfig` + `GeopoliticalConfig` + `list[WatchSector]`
-- `XssIntelConfig` holds `XssTargetsConfig` (frameworks / libraries / keywords)
-- `CONFIG = load_config()` runs at module import time (module-level singleton)
-- `get_xss_config()` is a lazy singleton — loaded only on first access
-
-### Config Files (`config/`)
-
-- `briefing.json` — manages `portfolio` (tickers/themes), `watch_sectors` (14 sectors), and `geopolitical.conflicts`. Change monitoring targets here without touching code.
-- `xss_intel.json` — manages `targets` (frameworks/libraries/keywords)
-
-### Prompt Templates (`prompts/`)
-
-`render()` in `src/generator/prompt.py` loads `prompts/{name}.md` and expands it via `str.format(**kwargs)`. To modify prompt behavior, edit only the `.md` file.
-
-## Environment Variables (`.env`)
-
-| Variable | Purpose |
-|---|---|
-| `DISCORD_TOKEN` | Discord Bot authentication |
-| `CHANNEL_ID` | Target Discord channel |
-| `NOTION_API_KEY` | Notion API authentication |
-| `NOTION_DATABASE_ID` | Target Notion database |
-
-> `ANTHROPIC_API_KEY` — if present in `.env`, it is intentionally stripped from the subprocess environment before calling the claude CLI to prevent API charges.
-
-## Logging
-
-`log/{YYYYMMDD}-app.log` — DEBUG level. Console output is INFO level. Obtain loggers via `get_logger()` in `src/logger.py`.
-
-## Testing
-
-```bash
-.venv/bin/pytest -v
-```
-
-| File | What it tests |
-|---|---|
-| `tests/test_claude_runner.py` | `run_claude()` — subprocess mocking, env masking, error truncation |
-| `tests/test_generator_briefing.py` | Context builders, parallel execution, degraded mode |
-| `tests/test_config.py` | `load_config()` validation |
+- **`src/claude_runner.py`** is the single entry point for all claude CLI calls. Always use `run_claude()` — never call `subprocess.run(["claude", ...])` directly elsewhere.
+- **`ANTHROPIC_API_KEY` must not reach the subprocess** — it is stripped in `run_claude()`. If you add new subprocess calls to claude, apply the same env filter.
+- **`requirements.txt` is auto-generated** — only edit `requirements.in`, then recompile.
+- **`CONFIG = load_config()`** runs at import time in `src/config.py`. Tests that call `load_config()` directly must patch `src.config.CONFIG_PATH`.
 
 ## Git Conventions
 
-### Branch Naming
+Branch naming: `feat/` `fix/` `refactor/` `docs/` `chore/`
 
-```
-feature/<short-description>   # New features
-fix/<short-description>       # Bug fixes
-refactor/<short-description>  # Refactoring with no behavior change
-docs/<short-description>      # Documentation only
-```
-
-### Commit Message Format
-
-Use [Conventional Commits](https://www.conventionalcommits.org/):
-
+Commit format ([Conventional Commits](https://www.conventionalcommits.org/)):
 ```
 <type>: <short summary in English>
-
-[optional body]
 ```
 
-| Type | When to use |
-|---|---|
-| `feat` | New feature |
-| `fix` | Bug fix |
-| `refactor` | Code change with no behavior change |
-| `docs` | Documentation only |
-| `chore` | Tooling, deps, config (no production code) |
-
-### Pull Request
-
-- **Title**: `<type>: <short summary>` — same format as commit (under 70 chars)
-- **Body**: bullet-point summary + test plan checklist
-- One logical change per PR; squash unrelated fixups before opening
+PR: title matches commit format (under 70 chars); body has bullet summary + test plan checklist.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,19 +118,6 @@ bin/xss_intel.py
 | `tests/test_generator_briefing.py` | Context builders, parallel execution, degraded mode |
 | `tests/test_config.py` | `load_config()` validation |
 
-## Scheduling (macOS launchd)
-
-```bash
-bash launchd/install.sh    # Register 08:00 daily job
-bash launchd/uninstall.sh  # Remove job
-launchctl kickstart -k gui/$(id -u)/com.aiagent.run  # Run immediately
-```
-
-Wake the Mac before the trigger:
-```bash
-sudo pmset repeat wake MTWRFSU 07:55:00
-```
-
 ## Git Conventions
 
 ### Branch Naming

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,9 @@ bin/run.sh
 source .venv/bin/activate
 python bin/briefing.py
 python bin/xss_intel.py
+
+# Run tests
+.venv/bin/pytest -v
 ```
 
 ## Dependency Management
@@ -30,26 +33,43 @@ uv pip sync requirements.txt
 
 ## Architecture
 
-Two independent agents share the same Discord/Notion notifiers.
+Two independent agents share the same Discord/Notion notifiers and a common claude CLI helper.
+
+### Shared Claude CLI Helper (`src/claude_runner.py`)
+
+All claude CLI invocations go through `run_claude()`:
+
+```python
+run_claude(prompt: str, label: str, timeout: int = 300) -> str
+```
+
+- Finds `claude` binary via `shutil.which`
+- Excludes `ANTHROPIC_API_KEY` from the subprocess environment — forces WebSearch to use OAuth (subscription) auth instead of API billing
+- Sets `stdin=subprocess.DEVNULL` to prevent the CLI from waiting for terminal input
+- Handles timeout (`subprocess.TimeoutExpired`) and non-zero exit codes with structured logging
+- Truncates error messages to 2000 chars to avoid embedding large stdout in exceptions
 
 ### Briefing Agent
 
-```bash
+```
 bin/briefing.py
   └── src/handler.py
         ├── src/fetcher/stocks.py        # Fetches previous-day % change via yfinance
-        ├── src/generator/briefing.py    # Invokes claude CLI via subprocess
-        │     └── prompts/briefing.md    # Template vars: {tickers} {themes} {geopolitical} {watch_sectors} {stocks}
+        ├── src/generator/briefing.py    # Builds prompts; calls run_claude() in parallel (ThreadPoolExecutor)
+        │     └── prompts/briefing.md    # Template vars: {tickers} {themes} {geopolitical} {stocks}
+        │     └── prompts/briefing_sectors.md  # Template vars: {watch_sectors} {stocks}
         ├── src/notifier/discord.py
         └── src/notifier/notion.py
 ```
 
+Parallel execution: main analysis (`_TIMEOUT_MAIN=300s`) and sector sweep (`_TIMEOUT_SECTORS=480s`) run concurrently. If only the sector sweep fails, the agent falls back to degraded mode (main analysis only).
+
 ### XSS Intel Agent
 
-```bash
+```
 bin/xss_intel.py
   └── src/xss_handler.py
-        ├── src/generator/xss_report.py  # Invokes claude CLI via subprocess
+        ├── src/generator/xss_report.py  # Builds prompt; calls run_claude()
         │     └── prompts/xss_intel.md
         ├── src/notifier/discord.py
         └── src/notifier/notion.py
@@ -71,12 +91,6 @@ bin/xss_intel.py
 
 `render()` in `src/generator/prompt.py` loads `prompts/{name}.md` and expands it via `str.format(**kwargs)`. To modify prompt behavior, edit only the `.md` file.
 
-### Claude CLI Invocation
-
-```python
-subprocess.run(["claude", "-p", prompt, "--allowedTools", "WebSearch"], timeout=300)
-```
-
 ## Environment Variables (`.env`)
 
 | Variable | Purpose |
@@ -86,9 +100,36 @@ subprocess.run(["claude", "-p", prompt, "--allowedTools", "WebSearch"], timeout=
 | `NOTION_API_KEY` | Notion API authentication |
 | `NOTION_DATABASE_ID` | Target Notion database |
 
+> `ANTHROPIC_API_KEY` — if present in `.env`, it is intentionally stripped from the subprocess environment before calling the claude CLI to prevent API charges.
+
 ## Logging
 
 `log/{YYYYMMDD}-app.log` — DEBUG level. Console output is INFO level. Obtain loggers via `get_logger()` in `src/logger.py`.
+
+## Testing
+
+```bash
+.venv/bin/pytest -v
+```
+
+| File | What it tests |
+|---|---|
+| `tests/test_claude_runner.py` | `run_claude()` — subprocess mocking, env masking, error truncation |
+| `tests/test_generator_briefing.py` | Context builders, parallel execution, degraded mode |
+| `tests/test_config.py` | `load_config()` validation |
+
+## Scheduling (macOS launchd)
+
+```bash
+bash launchd/install.sh    # Register 08:00 daily job
+bash launchd/uninstall.sh  # Remove job
+launchctl kickstart -k gui/$(id -u)/com.aiagent.run  # Run immediately
+```
+
+Wake the Mac before the trigger:
+```bash
+sudo pmset repeat wake MTWRFSU 07:55:00
+```
 
 ## Git Conventions
 
@@ -118,14 +159,6 @@ Use [Conventional Commits](https://www.conventionalcommits.org/):
 | `refactor` | Code change with no behavior change |
 | `docs` | Documentation only |
 | `chore` | Tooling, deps, config (no production code) |
-
-Examples:
-```
-feat: add watch_sectors to briefing prompt
-fix: resolve dynamic Notion title property lookup
-refactor: replace hardcoded path in bin/run.sh with SCRIPT_DIR
-docs: add CLAUDE.md
-```
 
 ### Pull Request
 

--- a/README.md
+++ b/README.md
@@ -19,29 +19,31 @@ bin/run.sh
   ├── bin/briefing.py
   │     └── src/handler.py
   │           ├── src/fetcher/stocks.py        # Previous-day % change via yfinance
-  │           ├── src/generator/briefing.py    # Invokes claude CLI (WebSearch)
+  │           ├── src/generator/briefing.py    # Builds prompts, calls run_claude() in parallel
   │           │     └── prompts/briefing.md    # Prompt template
   │           ├── src/notifier/discord.py
   │           └── src/notifier/notion.py
   └── bin/xss_intel.py
         └── src/xss_handler.py
-              ├── src/generator/xss_report.py  # Invokes claude CLI (WebSearch)
+              ├── src/generator/xss_report.py  # Builds prompt, calls run_claude()
               │     └── prompts/xss_intel.md
               ├── src/notifier/discord.py
               └── src/notifier/notion.py
 
+src/claude_runner.py   # Shared claude CLI helper (subprocess + WebSearch)
 config/
-  briefing.json   # Portfolio, watch sectors (14 sectors), geopolitical risks
-  xss_intel.json  # XSS target frameworks / libraries / keywords
-src/config.py     # JSON → dataclass schema
+  briefing.json        # Portfolio, watch sectors (14 sectors), geopolitical risks
+  xss_intel.json       # XSS target frameworks / libraries / keywords
+src/config.py          # JSON → dataclass schema
 ```
 
 ### Key Design Decisions
 
-- **No NewsAPI** — Claude Code CLI's WebSearch handles real-time search
-- **No Anthropic API key needed (local)** — reuses Claude Code CLI authentication
+- **No NewsAPI** — Claude Code CLI's built-in WebSearch handles real-time search
+- **No Anthropic API billing** — reuses Claude Code CLI's OAuth authentication; `ANTHROPIC_API_KEY` is explicitly excluded from the subprocess environment to prevent accidental API charges
 - **Geopolitical → stock causality** is baked into every daily output
 - **watch_sectors** (14 sectors, ~90 tickers) give Claude full market coverage to surface sector moves
+- **Degraded mode** — if the sector sweep fails, the main analysis is still delivered
 
 ---
 
@@ -51,7 +53,7 @@ src/config.py     # JSON → dataclass schema
 
 - Python 3.11+
 - [uv](https://github.com/astral-sh/uv) installed
-- [Claude Code CLI](https://claude.ai/code) installed and authenticated
+- [Claude Code CLI](https://claude.ai/code) installed and authenticated (`claude` in PATH)
 - Discord Bot created (Send Messages permission granted)
 - Notion integration created with database access
 
@@ -84,6 +86,34 @@ cp .env.example .env
 ```bash
 bin/run.sh
 ```
+
+---
+
+## Scheduling (macOS launchd)
+
+The agents can be scheduled to run automatically every morning using macOS launchd.
+
+```bash
+# Install and register the launchd job (runs at 08:00 daily)
+bash launchd/install.sh
+
+# Verify registration
+launchctl list | grep aiagent
+
+# Run immediately (for testing)
+launchctl kickstart -k gui/$(id -u)/com.aiagent.run
+
+# Uninstall
+bash launchd/uninstall.sh
+```
+
+To ensure the Mac wakes from sleep before the 08:00 trigger:
+
+```bash
+sudo pmset repeat wake MTWRFSU 07:55:00
+```
+
+Logs are written to `log/launchd.stdout.log` and `log/launchd.stderr.log`.
 
 ---
 
@@ -122,6 +152,24 @@ All monitoring targets are managed here — no code changes needed.
 ### `prompts/briefing.md`
 
 Prompt template for the briefing agent. Variables: `{tickers}` `{themes}` `{geopolitical}` `{watch_sectors}` `{stocks}`. Edit this file to change Claude's output behavior.
+
+---
+
+## Testing
+
+```bash
+# Run all tests
+.venv/bin/pytest -v
+
+# Run a specific module
+.venv/bin/pytest tests/test_claude_runner.py -v
+```
+
+| Test file | Coverage |
+|---|---|
+| `test_claude_runner.py` | `run_claude()` — CLI discovery, timeout, error handling, env masking |
+| `test_generator_briefing.py` | Context builders, parallel execution, degraded mode |
+| `test_config.py` | `load_config()` validation (watch_sectors, tickers) |
 
 ---
 
@@ -168,8 +216,10 @@ uv pip sync requirements.txt
 | 1 | Local manual run | ✅ Done |
 | 2 | Discord delivery | ✅ Done |
 | 3 | Notion delivery | ✅ Done |
-| 4 | AWS Lambda + EventBridge automation | 🔜 Next |
-| 5 | DynamoDB for dynamic config | 📋 Planned |
+| 4 | macOS launchd daily scheduler | ✅ Done |
+| 5 | Unit tests (pytest) | ✅ Done |
+| 6 | AWS Lambda + EventBridge automation | 📋 Planned |
+| 7 | DynamoDB for dynamic config | 📋 Planned |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -89,34 +89,6 @@ bin/run.sh
 
 ---
 
-## Scheduling (macOS launchd)
-
-The agents can be scheduled to run automatically every morning using macOS launchd.
-
-```bash
-# Install and register the launchd job (runs at 08:00 daily)
-bash launchd/install.sh
-
-# Verify registration
-launchctl list | grep aiagent
-
-# Run immediately (for testing)
-launchctl kickstart -k gui/$(id -u)/com.aiagent.run
-
-# Uninstall
-bash launchd/uninstall.sh
-```
-
-To ensure the Mac wakes from sleep before the 08:00 trigger:
-
-```bash
-sudo pmset repeat wake MTWRFSU 07:55:00
-```
-
-Logs are written to `log/launchd.stdout.log` and `log/launchd.stderr.log`.
-
----
-
 ## Configuration
 
 ### `config/briefing.json`
@@ -216,10 +188,9 @@ uv pip sync requirements.txt
 | 1 | Local manual run | ✅ Done |
 | 2 | Discord delivery | ✅ Done |
 | 3 | Notion delivery | ✅ Done |
-| 4 | macOS launchd daily scheduler | ✅ Done |
-| 5 | Unit tests (pytest) | ✅ Done |
-| 6 | AWS Lambda + EventBridge automation | 📋 Planned |
-| 7 | DynamoDB for dynamic config | 📋 Planned |
+| 4 | Unit tests (pytest) | ✅ Done |
+| 5 | AWS Lambda + EventBridge automation | 📋 Planned |
+| 6 | DynamoDB for dynamic config | 📋 Planned |
 
 ---
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/requirements.in
+++ b/requirements.in
@@ -2,3 +2,4 @@ requests
 yfinance
 python-dotenv
 notion-client
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,8 @@ idna==3.11
     #   anyio
     #   httpx
     #   requests
+iniconfig==2.3.0
+    # via pytest
 markdown-it-py==4.0.0
     # via rich
 mdurl==0.1.2
@@ -41,18 +43,26 @@ numpy==2.4.4
     # via
     #   pandas
     #   yfinance
+packaging==26.1
+    # via pytest
 pandas==3.0.2
     # via yfinance
 peewee==4.0.4
     # via yfinance
 platformdirs==4.9.6
     # via yfinance
+pluggy==1.6.0
+    # via pytest
 protobuf==7.34.1
     # via yfinance
 pycparser==3.0
     # via cffi
 pygments==2.20.0
-    # via rich
+    # via
+    #   pytest
+    #   rich
+pytest==9.0.3
+    # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via pandas
 python-dotenv==1.2.2

--- a/src/claude_runner.py
+++ b/src/claude_runner.py
@@ -1,0 +1,40 @@
+import os
+import shutil
+import subprocess
+from src.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def run_claude(prompt: str, label: str, timeout: int = 300) -> str:
+    """claude CLI を subprocess で呼び出し、結果を返す。
+
+    ANTHROPIC_API_KEY を子プロセスに渡さないことで、
+    WebSearch がサブスクリプション認証（OAuth）を使うようにする。
+    """
+    claude_path = shutil.which("claude")
+    if claude_path is None:
+        raise RuntimeError("claude CLI が見つかりません。PATH を確認してください。")
+
+    env = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
+
+    logger.info("claude CLI 呼び出し開始: %s (timeout=%ds)", label, timeout)
+    try:
+        result = subprocess.run(
+            [claude_path, "-p", prompt, "--allowedTools", "WebSearch"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            stdin=subprocess.DEVNULL,
+            env=env,
+        )
+    except subprocess.TimeoutExpired:
+        logger.error("claude CLI タイムアウト: %s (%ds)", label, timeout)
+        raise RuntimeError(f"claude CLI がタイムアウトしました ({label})")
+
+    if result.returncode != 0:
+        logger.error("claude CLI エラー [%s] rc=%d: %s", label, result.returncode, result.stdout or result.stderr)
+        raise RuntimeError(f"claude CLI エラー [{label}]: {result.stdout or result.stderr}")
+
+    logger.info("claude CLI 完了: %s (%d文字)", label, len(result.stdout))
+    return result.stdout.strip()

--- a/src/claude_runner.py
+++ b/src/claude_runner.py
@@ -10,7 +10,7 @@ def run_claude(prompt: str, label: str, timeout: int = 300) -> str:
     """claude CLI を subprocess で呼び出し、結果を返す。
 
     ANTHROPIC_API_KEY を子プロセスに渡さないことで、
-    WebSearch がサブスクリプション認証（OAuth）を使うようにする。
+    WebSearch がサブスクリプション認証(OAuth)を使うようにする。
     """
     claude_path = shutil.which("claude")
     if claude_path is None:
@@ -28,13 +28,19 @@ def run_claude(prompt: str, label: str, timeout: int = 300) -> str:
             stdin=subprocess.DEVNULL,
             env=env,
         )
-    except subprocess.TimeoutExpired:
+    except subprocess.TimeoutExpired as exc:
         logger.error("claude CLI タイムアウト: %s (%ds)", label, timeout)
-        raise RuntimeError(f"claude CLI がタイムアウトしました ({label})")
+        raise RuntimeError(f"claude CLI がタイムアウトしました ({label})") from exc
 
     if result.returncode != 0:
-        logger.error("claude CLI エラー [%s] rc=%d: %s", label, result.returncode, result.stdout or result.stderr)
-        raise RuntimeError(f"claude CLI エラー [{label}]: {result.stdout or result.stderr}")
+        logger.error(
+            "claude CLI エラー [%s] rc=%d\nstdout=%s\nstderr=%s",
+            label, result.returncode, result.stdout, result.stderr,
+        )
+        detail = (result.stderr or result.stdout or "").strip()
+        if len(detail) > 2000:
+            detail = detail[:2000] + "…(truncated)"
+        raise RuntimeError(f"claude CLI エラー [{label}] rc={result.returncode}: {detail}")
 
     logger.info("claude CLI 完了: %s (%d文字)", label, len(result.stdout))
     return result.stdout.strip()

--- a/src/generator/briefing.py
+++ b/src/generator/briefing.py
@@ -1,6 +1,5 @@
-import shutil
-import subprocess
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from src.claude_runner import run_claude
 from src.config import BriefingConfig
 from src.generator.prompt import render
 from src.logger import get_logger
@@ -13,7 +12,6 @@ _TIMEOUT_SECTORS = 480  # セクタースイープ（14セクター × WebSearch
 
 
 def _build_geopolitical_context(config: BriefingConfig) -> str:
-    """BriefingConfig の地政学リスク情報をプロンプト用のテキストブロックに整形して返す。"""
     lines = []
     for c in config.geopolitical.conflicts:
         sectors = "、".join(c.affected_sectors)
@@ -28,7 +26,6 @@ def _build_geopolitical_context(config: BriefingConfig) -> str:
 
 
 def _build_watch_sectors_context(config: BriefingConfig) -> str:
-    """watch_sectors をプロンプト用のテキストブロックに整形して返す。"""
     lines = []
     for s in config.watch_sectors:
         tickers = "、".join(s.tickers)
@@ -37,32 +34,6 @@ def _build_watch_sectors_context(config: BriefingConfig) -> str:
             entry += f"\n- 注目点: {s.notes}"
         lines.append(entry)
     return "\n\n".join(lines)
-
-
-def _run_claude(prompt: str, label: str, timeout: int = _TIMEOUT_MAIN) -> str:
-    """claude CLI を subprocess で呼び出し、結果を返す。"""
-    claude_path = shutil.which("claude")
-    if claude_path is None:
-        raise RuntimeError("claude CLI が見つかりません。PATH を確認してください。")
-
-    logger.info("claude CLI 呼び出し開始: %s (timeout=%ds)", label, timeout)
-    try:
-        result = subprocess.run(
-            [claude_path, "-p", prompt, "--allowedTools", "WebSearch"],
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-        )
-    except subprocess.TimeoutExpired:
-        logger.error("claude CLI タイムアウト: %s (%ds)", label, timeout)
-        raise RuntimeError(f"claude CLI がタイムアウトしました ({label})")
-
-    if result.returncode != 0:
-        logger.error("claude CLI エラー [%s]: %s", label, result.stderr)
-        raise RuntimeError(f"claude CLI エラー [{label}]: {result.stderr}")
-
-    logger.info("claude CLI 完了: %s (%d文字)", label, len(result.stdout))
-    return result.stdout.strip()
 
 
 def generate_briefing(stocks: str, config: BriefingConfig) -> str:
@@ -85,8 +56,8 @@ def generate_briefing(stocks: str, config: BriefingConfig) -> str:
 
     with ThreadPoolExecutor(max_workers=2) as executor:
         futures = {
-            executor.submit(_run_claude, main_prompt, "メイン分析", _TIMEOUT_MAIN): "main",
-            executor.submit(_run_claude, sectors_prompt, "セクタースイープ", _TIMEOUT_SECTORS): "sectors",
+            executor.submit(run_claude, main_prompt, "メイン分析", _TIMEOUT_MAIN): "main",
+            executor.submit(run_claude, sectors_prompt, "セクタースイープ", _TIMEOUT_SECTORS): "sectors",
         }
         results: dict[str, str] = {}
         errors: dict[str, str] = {}
@@ -99,7 +70,6 @@ def generate_briefing(stocks: str, config: BriefingConfig) -> str:
                 errors[key] = str(e)
 
     if "main" in errors:
-        # メイン分析が失敗した場合は続行不可
         raise RuntimeError(f"ブリーフィング生成に失敗しました: メイン分析\n{errors['main']}")
 
     assert "main" in results, "main result missing despite no error recorded"
@@ -107,7 +77,6 @@ def generate_briefing(stocks: str, config: BriefingConfig) -> str:
     main_text = results["main"]
 
     if "sectors" in errors:
-        # セクタースイープのみ失敗した場合は degraded モードで返す
         logger.warning("セクタースイープ失敗（メイン分析は成功）: %s", errors["sectors"])
         return main_text + "\n\n---\n\n⚠️ セクター動向の取得に失敗しました。\n" + errors["sectors"]
 

--- a/src/generator/xss_report.py
+++ b/src/generator/xss_report.py
@@ -21,7 +21,6 @@ def generate_xss_report(config: XssIntelConfig) -> str:
         date=date.today().strftime("%Y-%m-%d"),
     )
 
-    logger.info("claude CLI (WebSearch) 呼び出し開始 [XSS Intel]")
     logger.debug("対象フレームワーク: %s / ライブラリ: %s", frameworks, libraries)
 
     text = run_claude(prompt, "XSS Intel", timeout=300)

--- a/src/generator/xss_report.py
+++ b/src/generator/xss_report.py
@@ -1,6 +1,5 @@
-import shutil
-import subprocess
 from datetime import date
+from src.claude_runner import run_claude
 from src.config import XssIntelConfig
 from src.generator.prompt import render
 from src.logger import get_logger
@@ -25,24 +24,6 @@ def generate_xss_report(config: XssIntelConfig) -> str:
     logger.info("claude CLI (WebSearch) 呼び出し開始 [XSS Intel]")
     logger.debug("対象フレームワーク: %s / ライブラリ: %s", frameworks, libraries)
 
-    claude_path = shutil.which("claude")
-    if claude_path is None:
-        raise RuntimeError("claude CLI が見つかりません。PATH を確認してください。")
-
-    try:
-        result = subprocess.run(
-            [claude_path, "-p", prompt, "--allowedTools", "WebSearch"],
-            capture_output=True,
-            text=True,
-            timeout=300,
-        )
-    except subprocess.TimeoutExpired:
-        logger.error("claude CLI がタイムアウトしました [XSS Intel]")
-        raise RuntimeError("claude CLI の実行がタイムアウトしました")
-
-    if result.returncode != 0:
-        logger.error("claude CLI エラー: %s", result.stderr)
-        raise RuntimeError(f"claude CLI エラー: {result.stderr}")
-
-    logger.info("XSS レポート生成完了 (%d文字)", len(result.stdout))
-    return result.stdout.strip()
+    text = run_claude(prompt, "XSS Intel", timeout=300)
+    logger.info("XSS レポート生成完了 (%d文字)", len(text))
+    return text

--- a/tests/test_claude_runner.py
+++ b/tests/test_claude_runner.py
@@ -1,0 +1,93 @@
+import os
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.claude_runner import run_claude
+
+
+def _make_result(returncode=0, stdout="output", stderr=""):
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    result.stderr = stderr
+    return result
+
+
+class TestRunClaude:
+    def test_cli_not_found_raises(self):
+        with patch("src.claude_runner.shutil.which", return_value=None):
+            with pytest.raises(RuntimeError, match="claude CLI が見つかりません"):
+                run_claude("prompt", "test")
+
+    def test_success_returns_stripped_stdout(self):
+        with patch("src.claude_runner.shutil.which", return_value="/usr/bin/claude"):
+            with patch("src.claude_runner.subprocess.run", return_value=_make_result(stdout="  hello  \n")):
+                result = run_claude("prompt", "test")
+        assert result == "hello"
+
+    def test_timeout_raises_runtime_error(self):
+        with patch("src.claude_runner.shutil.which", return_value="/usr/bin/claude"):
+            with patch(
+                "src.claude_runner.subprocess.run",
+                side_effect=subprocess.TimeoutExpired("claude", 300),
+            ):
+                with pytest.raises(RuntimeError, match="タイムアウト"):
+                    run_claude("prompt", "test", timeout=300)
+
+    def test_nonzero_returncode_raises_with_stderr(self):
+        with patch("src.claude_runner.shutil.which", return_value="/usr/bin/claude"):
+            with patch(
+                "src.claude_runner.subprocess.run",
+                return_value=_make_result(returncode=1, stdout="", stderr="auth error"),
+            ):
+                with pytest.raises(RuntimeError, match="auth error"):
+                    run_claude("prompt", "test")
+
+    def test_nonzero_returncode_falls_back_to_stdout(self):
+        with patch("src.claude_runner.shutil.which", return_value="/usr/bin/claude"):
+            with patch(
+                "src.claude_runner.subprocess.run",
+                return_value=_make_result(returncode=1, stdout="stdout error", stderr=""),
+            ):
+                with pytest.raises(RuntimeError, match="stdout error"):
+                    run_claude("prompt", "test")
+
+    def test_long_error_is_truncated(self):
+        long_stderr = "x" * 3000
+        with patch("src.claude_runner.shutil.which", return_value="/usr/bin/claude"):
+            with patch(
+                "src.claude_runner.subprocess.run",
+                return_value=_make_result(returncode=1, stdout="", stderr=long_stderr),
+            ):
+                with pytest.raises(RuntimeError) as exc_info:
+                    run_claude("prompt", "test")
+        assert "truncated" in str(exc_info.value)
+
+    def test_api_key_excluded_from_subprocess_env(self):
+        captured = {}
+
+        def fake_run(args, **kwargs):
+            captured["env"] = kwargs.get("env", {})
+            return _make_result()
+
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "secret-key"}):
+            with patch("src.claude_runner.shutil.which", return_value="/usr/bin/claude"):
+                with patch("src.claude_runner.subprocess.run", side_effect=fake_run):
+                    run_claude("prompt", "test")
+
+        assert "ANTHROPIC_API_KEY" not in captured["env"]
+
+    def test_stdin_is_devnull(self):
+        captured = {}
+
+        def fake_run(args, **kwargs):
+            captured["stdin"] = kwargs.get("stdin")
+            return _make_result()
+
+        with patch("src.claude_runner.shutil.which", return_value="/usr/bin/claude"):
+            with patch("src.claude_runner.subprocess.run", side_effect=fake_run):
+                run_claude("prompt", "test")
+
+        assert captured["stdin"] == subprocess.DEVNULL

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,62 @@
+import json
+from unittest.mock import patch
+
+import pytest
+
+from src.config import load_config
+
+
+class TestLoadConfig:
+    def test_missing_watch_sectors_raises(self, tmp_path):
+        data = {
+            "portfolio": {"tickers": ["PLTR"], "themes": ["AI"]},
+            "geopolitical": {"conflicts": []},
+        }
+        config_file = tmp_path / "briefing.json"
+        config_file.write_text(json.dumps(data), encoding="utf-8")
+
+        with patch("src.config.CONFIG_PATH", config_file):
+            with pytest.raises(ValueError, match="watch_sectors"):
+                load_config()
+
+    def test_empty_watch_sectors_raises(self, tmp_path):
+        data = {
+            "portfolio": {"tickers": ["PLTR"], "themes": ["AI"]},
+            "geopolitical": {"conflicts": []},
+            "watch_sectors": [],
+        }
+        config_file = tmp_path / "briefing.json"
+        config_file.write_text(json.dumps(data), encoding="utf-8")
+
+        with patch("src.config.CONFIG_PATH", config_file):
+            with pytest.raises(ValueError, match="watch_sectors"):
+                load_config()
+
+    def test_sector_with_empty_tickers_raises(self, tmp_path):
+        data = {
+            "portfolio": {"tickers": ["PLTR"], "themes": ["AI"]},
+            "geopolitical": {"conflicts": []},
+            "watch_sectors": [{"sector": "Tech", "tickers": []}],
+        }
+        config_file = tmp_path / "briefing.json"
+        config_file.write_text(json.dumps(data), encoding="utf-8")
+
+        with patch("src.config.CONFIG_PATH", config_file):
+            with pytest.raises(ValueError, match="tickers"):
+                load_config()
+
+    def test_valid_config_loads_successfully(self, tmp_path):
+        data = {
+            "portfolio": {"tickers": ["PLTR", "NVDA"], "themes": ["AI"]},
+            "geopolitical": {"conflicts": []},
+            "watch_sectors": [{"sector": "Tech", "tickers": ["AAPL"]}],
+        }
+        config_file = tmp_path / "briefing.json"
+        config_file.write_text(json.dumps(data), encoding="utf-8")
+
+        with patch("src.config.CONFIG_PATH", config_file):
+            config = load_config()
+
+        assert config.portfolio.tickers == ["PLTR", "NVDA"]
+        assert len(config.watch_sectors) == 1
+        assert config.watch_sectors[0].sector == "Tech"

--- a/tests/test_generator_briefing.py
+++ b/tests/test_generator_briefing.py
@@ -1,0 +1,120 @@
+from unittest.mock import patch
+
+import pytest
+
+from src.config import BriefingConfig, Conflict, GeopoliticalConfig, PortfolioConfig, WatchSector
+from src.generator.briefing import (
+    _build_geopolitical_context,
+    _build_watch_sectors_context,
+    generate_briefing,
+)
+
+
+def _make_config(**overrides):
+    defaults = dict(
+        portfolio=PortfolioConfig(tickers=["PLTR", "NVDA"], themes=["AI", "Defense"]),
+        geopolitical=GeopoliticalConfig(conflicts=[]),
+        watch_sectors=[WatchSector(sector="Tech", tickers=["AAPL"])],
+    )
+    defaults.update(overrides)
+    return BriefingConfig(**defaults)
+
+
+class TestBuildGeopoliticalContext:
+    def test_empty_conflicts_returns_empty_string(self):
+        config = _make_config(geopolitical=GeopoliticalConfig(conflicts=[]))
+        assert _build_geopolitical_context(config) == ""
+
+    def test_includes_name_sectors_tickers_notes(self):
+        conflict = Conflict(
+            name="中東情勢",
+            affected_sectors=["エネルギー", "防衛"],
+            related_tickers=["XOM", "RTX"],
+            notes="原油供給に影響",
+        )
+        config = _make_config(geopolitical=GeopoliticalConfig(conflicts=[conflict]))
+        result = _build_geopolitical_context(config)
+        assert "中東情勢" in result
+        assert "エネルギー、防衛" in result
+        assert "XOM、RTX" in result
+        assert "原油供給に影響" in result
+
+    def test_optional_fields_omitted_when_empty(self):
+        conflict = Conflict(name="紛争A", affected_sectors=["金融"])
+        config = _make_config(geopolitical=GeopoliticalConfig(conflicts=[conflict]))
+        result = _build_geopolitical_context(config)
+        assert "関連銘柄" not in result
+        assert "背景" not in result
+
+    def test_multiple_conflicts_separated_by_blank_line(self):
+        conflicts = [
+            Conflict(name="紛争A", affected_sectors=["金融"]),
+            Conflict(name="紛争B", affected_sectors=["エネルギー"]),
+        ]
+        config = _make_config(geopolitical=GeopoliticalConfig(conflicts=conflicts))
+        result = _build_geopolitical_context(config)
+        assert "紛争A" in result
+        assert "紛争B" in result
+
+
+class TestBuildWatchSectorsContext:
+    def test_includes_sector_and_tickers(self):
+        sectors = [WatchSector(sector="AI半導体", tickers=["NVDA", "AMD"])]
+        config = _make_config(watch_sectors=sectors)
+        result = _build_watch_sectors_context(config)
+        assert "AI半導体" in result
+        assert "NVDA、AMD" in result
+
+    def test_notes_included_when_present(self):
+        sectors = [WatchSector(sector="EV", tickers=["TSLA"], notes="充電インフラ動向注視")]
+        config = _make_config(watch_sectors=sectors)
+        result = _build_watch_sectors_context(config)
+        assert "充電インフラ動向注視" in result
+
+    def test_notes_omitted_when_absent(self):
+        sectors = [WatchSector(sector="EV", tickers=["TSLA"])]
+        config = _make_config(watch_sectors=sectors)
+        result = _build_watch_sectors_context(config)
+        assert "注目点" not in result
+
+
+class TestGenerateBriefing:
+    def _mock_run(self, responses: dict):
+        def side_effect(prompt, label, timeout):
+            return responses[label]
+        return side_effect
+
+    def test_success_combines_main_and_sectors(self):
+        config = _make_config()
+        mock = self._mock_run({"メイン分析": "メイン結果", "セクタースイープ": "セクター結果"})
+        with patch("src.generator.briefing.run_claude", side_effect=mock):
+            result = generate_briefing("PLTR: +2%", config)
+        assert "メイン結果" in result
+        assert "セクター動向" in result
+        assert "セクター結果" in result
+
+    def test_main_failure_raises(self):
+        config = _make_config()
+
+        def mock(prompt, label, timeout):
+            if label == "メイン分析":
+                raise RuntimeError("API error")
+            return "sectors ok"
+
+        with patch("src.generator.briefing.run_claude", side_effect=mock):
+            with pytest.raises(RuntimeError, match="メイン分析"):
+                generate_briefing("PLTR: +2%", config)
+
+    def test_sectors_failure_returns_degraded_output(self):
+        config = _make_config()
+
+        def mock(prompt, label, timeout):
+            if label == "セクタースイープ":
+                raise RuntimeError("sectors error")
+            return "main ok"
+
+        with patch("src.generator.briefing.run_claude", side_effect=mock):
+            result = generate_briefing("PLTR: +2%", config)
+
+        assert "main ok" in result
+        assert "セクター動向の取得に失敗しました" in result


### PR DESCRIPTION
## Summary

- `src/claude_runner.py` を新規追加し、claude CLI 呼び出しの共通ヘルパー `run_claude()` を実装
- `ANTHROPIC_API_KEY` を subprocess の env から除外することで WebSearch がサブスクリプション認証（OAuth）を使うよう修正（API 課金を防ぐ）
- `src/generator/briefing.py` と `xss_report.py` のインライン subprocess ロジックを `run_claude()` に置き換えて簡略化

## Test plan

- [ ] `./bin/run.sh` を実行してブリーフィングが Discord / Notion に投稿されることを確認
- [ ] XSS Intel レポートが正常に生成されることを確認
- [ ] `log/` にエラーが出ていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized Claude CLI integration logic into a dedicated utility module, eliminating duplicate subprocess handling, timeout management, and error processing across multiple components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->