### PR TITLE
feat: add GitHub Actions pytest CI and dev branch protection

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,26 @@
+name: pytest
+
+on:
+  pull_request:
+    branches:
+      - dev
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Install dependencies
+        run: uv pip sync requirements.txt --system
+
+      - name: Run pytest
+        run: pytest -v


### PR DESCRIPTION
## Summary

- `.github/workflows/pytest.yml` を追加 — `dev` への PR 時に pytest を自動実行
- `dev` ブランチ保護ルールを設定 — `test` ジョブが通過しないとマージ不可

## Test plan

- [ ] このPRのCIが green になることを確認
- [ ] 別ブランチから `dev` への PR を作成し、pytest 失敗時にマージブロックされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)