### PR TITLE
feat: add Tags multi-select property to Notion pages

### DIFF
--- a/src/handler.py
+++ b/src/handler.py
@@ -30,6 +30,7 @@ def lambda_handler(event=None, context=None):
         CONFIG.notion_api_key,
         CONFIG.notion_database_id,
         title=f"マーケットブリーフィング — {date.today().strftime('%Y-%m-%d')}",
+        tags=["agent"],
     )
     if page_url:
         logger.info("Notion ページ: %s", page_url)

--- a/src/notifier/notion.py
+++ b/src/notifier/notion.py
@@ -241,7 +241,13 @@ def _resolve_title_prop(notion: Client, database_id: str, sample_title: str) -> 
 # 公開 API
 # ---------------------------------------------------------------------------
 
-def send_to_notion(text: str, api_key: str, database_id: str, title: str | None = None) -> str:
+def send_to_notion(
+    text: str,
+    api_key: str,
+    database_id: str,
+    title: str | None = None,
+    tags: list[str] | None = None,
+) -> str:
     """Notion データベースに新規ページとしてレポートを投稿する。作成したページの URL を返す。"""
     if not api_key or not database_id:
         logger.error("NOTION_API_KEY または NOTION_DATABASE_ID が未設定")
@@ -275,14 +281,18 @@ def send_to_notion(text: str, api_key: str, database_id: str, title: str | None 
     first_batch = blocks[:100]
     remaining = blocks[100:]
 
+    properties: dict = {
+        title_prop_name: {
+            "title": [{"type": "text", "text": {"content": page_title}}]
+        }
+    }
+    if tags:
+        properties["Tags"] = {"multi_select": [{"name": t} for t in tags]}
+
     try:
         response = notion.pages.create(
             parent={"database_id": database_id},
-            properties={
-                title_prop_name: {
-                    "title": [{"type": "text", "text": {"content": page_title}}]
-                }
-            },
+            properties=properties,
             children=first_batch,
         )
     except Exception:

--- a/src/xss_handler.py
+++ b/src/xss_handler.py
@@ -39,6 +39,7 @@ def lambda_handler(event=None, context=None):
             config.notion_api_key,
             config.notion_database_id,
             title=f"XSS 脆弱性インテリジェンス — {date.today().strftime('%Y-%m-%d')}",
+            tags=["agent"],
         )
         if page_url:
             logger.info("Notion ページ: %s", page_url)

--- a/tests/test_notion.py
+++ b/tests/test_notion.py
@@ -1,0 +1,61 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.notifier.notion import send_to_notion
+
+
+def _make_notion_mock(title_prop="Name", page_url="https://notion.so/page-1"):
+    """notion.Client のモックを返す共通ファクトリ。"""
+    mock = MagicMock()
+    mock.databases.retrieve.return_value = {
+        "properties": {title_prop: {"type": "title"}}
+    }
+    mock.pages.create.return_value = {"id": "page-id", "url": page_url}
+    return mock
+
+
+@pytest.fixture
+def mock_notion():
+    with patch("src.notifier.notion.Client") as MockClient:
+        notion = _make_notion_mock()
+        MockClient.return_value = notion
+        yield notion
+
+
+class TestSendToNotionMissingCredentials:
+    def test_empty_api_key_returns_empty(self):
+        result = send_to_notion("text", api_key="", database_id="db-id")
+        assert result == ""
+
+    def test_empty_database_id_returns_empty(self):
+        result = send_to_notion("text", api_key="key", database_id="")
+        assert result == ""
+
+
+class TestSendToNotionTags:
+    def test_no_tags_omits_tags_property(self, mock_notion):
+        send_to_notion("hello", api_key="key", database_id="db-id", tags=None)
+
+        _, kwargs = mock_notion.pages.create.call_args
+        assert "Tags" not in kwargs["properties"]
+
+    def test_single_tag_sets_multi_select(self, mock_notion):
+        send_to_notion("hello", api_key="key", database_id="db-id", tags=["agent"])
+
+        _, kwargs = mock_notion.pages.create.call_args
+        assert kwargs["properties"]["Tags"] == {
+            "multi_select": [{"name": "agent"}]
+        }
+
+    def test_multiple_tags_all_included(self, mock_notion):
+        send_to_notion("hello", api_key="key", database_id="db-id", tags=["agent", "xss"])
+
+        _, kwargs = mock_notion.pages.create.call_args
+        assert kwargs["properties"]["Tags"] == {
+            "multi_select": [{"name": "agent"}, {"name": "xss"}]
+        }
+
+    def test_returns_page_url(self, mock_notion):
+        url = send_to_notion("hello", api_key="key", database_id="db-id", tags=["agent"])
+        assert url == "https://notion.so/page-1"


### PR DESCRIPTION
## Summary

- `send_to_notion()` に `tags: list[str] | None = None` パラメータを追加
- `Tags` multi-select プロパティを Notion ページ作成時に付与できるように対応
- `handler.py` / `xss_handler.py` 両方から `tags=["agent"]` を渡すよう更新

## Test plan

- [ ] `pytest -v` がすべてパスすること
- [x] Notion に投稿されたページに `Tags: agent` が付与されていること（ブリーフィング・XSS 両エージェント）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notion pages created by the notification system now include automatic tags for better organization and filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->