### PR TITLE
feat: record numeric metrics as Notion properties for trend analysis

### DIFF
--- a/src/handler.py
+++ b/src/handler.py
@@ -1,6 +1,7 @@
 from src.config import CONFIG
 from src.fetcher.stocks import fetch_stock_moves
 from src.generator.briefing import generate_briefing
+from src.metrics.briefing import extract_briefing_metrics
 from src.notifier.discord import send_to_discord
 from src.notifier.notion import send_to_notion
 from src.logger import get_logger
@@ -25,12 +26,14 @@ def lambda_handler(event=None, context=None):
 
     logger.info("Notion にページ作成中...")
     from datetime import date
+    metrics = extract_briefing_metrics(briefing, CONFIG.portfolio.tickers)
     page_url = send_to_notion(
         briefing,
         CONFIG.notion_api_key,
         CONFIG.notion_database_id,
         title=f"マーケットブリーフィング — {date.today().strftime('%Y-%m-%d')}",
         tags=["agent"],
+        extra_properties=metrics,
     )
     if page_url:
         logger.info("Notion ページ: %s", page_url)

--- a/src/handler.py
+++ b/src/handler.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from src.config import CONFIG
 from src.fetcher.stocks import fetch_stock_moves
 from src.generator.briefing import generate_briefing
@@ -25,7 +27,6 @@ def lambda_handler(event=None, context=None):
     send_to_discord(briefing, CONFIG.discord_token, CONFIG.discord_channel_id)
 
     logger.info("Notion にページ作成中...")
-    from datetime import date
     metrics = extract_briefing_metrics(briefing, CONFIG.portfolio.tickers)
     page_url = send_to_notion(
         briefing,

--- a/src/metrics/briefing.py
+++ b/src/metrics/briefing.py
@@ -1,0 +1,15 @@
+"""ブリーフィングテキストから Notion 数値プロパティ用のメトリクスを抽出する。"""
+
+
+def extract_briefing_metrics(text: str, tickers: list[str]) -> dict:
+    """文字数・言及銘柄数を Notion extra_properties 形式で返す。
+
+    Returns:
+        {"CharCount": {"number": N}, "TickerCount": {"number": M}}
+    """
+    char_count = len(text)
+    ticker_count = sum(1 for t in tickers if t.upper() in text.upper())
+    return {
+        "CharCount": {"number": char_count},
+        "TickerCount": {"number": ticker_count},
+    }

--- a/src/metrics/briefing.py
+++ b/src/metrics/briefing.py
@@ -1,14 +1,19 @@
 """ブリーフィングテキストから Notion 数値プロパティ用のメトリクスを抽出する。"""
+import re
 
 
 def extract_briefing_metrics(text: str, tickers: list[str]) -> dict:
     """文字数・言及銘柄数を Notion extra_properties 形式で返す。
 
+    ティッカーは単語境界（\b）で照合し、部分文字列の誤カウントを防ぐ。
+
     Returns:
         {"CharCount": {"number": N}, "TickerCount": {"number": M}}
     """
     char_count = len(text)
-    ticker_count = sum(1 for t in tickers if t.upper() in text.upper())
+    ticker_count = sum(
+        1 for t in tickers if re.search(rf"\b{re.escape(t)}\b", text, re.IGNORECASE)
+    )
     return {
         "CharCount": {"number": char_count},
         "TickerCount": {"number": ticker_count},

--- a/src/metrics/briefing.py
+++ b/src/metrics/briefing.py
@@ -5,14 +5,21 @@ import re
 def extract_briefing_metrics(text: str, tickers: list[str]) -> dict:
     """文字数・言及銘柄数を Notion extra_properties 形式で返す。
 
-    ティッカーは単語境界（\b）で照合し、部分文字列の誤カウントを防ぐ。
+    ティッカーは ASCII 英数字・アンダースコアの lookaround で照合する。
+    \b では日本語助詞に直接隣接するケース（例: "PLTRは上昇"）を検出できないため、
+    (?<![A-Za-z0-9_])TICKER(?![A-Za-z0-9_]) を使用する。
 
     Returns:
         {"CharCount": {"number": N}, "TickerCount": {"number": M}}
     """
     char_count = len(text)
     ticker_count = sum(
-        1 for t in tickers if re.search(rf"\b{re.escape(t)}\b", text, re.IGNORECASE)
+        1 for t in tickers
+        if re.search(
+            rf"(?<![A-Za-z0-9_]){re.escape(t)}(?![A-Za-z0-9_])",
+            text,
+            re.IGNORECASE,
+        )
     )
     return {
         "CharCount": {"number": char_count},

--- a/src/metrics/xss.py
+++ b/src/metrics/xss.py
@@ -1,0 +1,20 @@
+"""XSS レポートテキストから Notion 数値プロパティ用のメトリクスを抽出する。"""
+import re
+
+
+def extract_xss_metrics(text: str) -> dict:
+    """重要度別（High/Medium/Low）の件数を Notion extra_properties 形式で返す。
+
+    レポート内の "High" / "Medium" / "Low" キーワード出現数をカウントする。
+
+    Returns:
+        {"HighCount": {"number": N}, "MediumCount": {"number": M}, "LowCount": {"number": L}}
+    """
+    def count(pattern: str) -> int:
+        return len(re.findall(pattern, text, re.IGNORECASE))
+
+    return {
+        "HighCount": {"number": count(r"\bhigh\b")},
+        "MediumCount": {"number": count(r"\bmedium\b")},
+        "LowCount": {"number": count(r"\blow\b")},
+    }

--- a/src/metrics/xss.py
+++ b/src/metrics/xss.py
@@ -5,16 +5,17 @@ import re
 def extract_xss_metrics(text: str) -> dict:
     """重要度別（High/Medium/Low）の件数を Notion extra_properties 形式で返す。
 
-    レポート内の "High" / "Medium" / "Low" キーワード出現数をカウントする。
+    プロンプト出力の構造化行 「深刻度: <level>」 のみをカウントし、
+    散文中の high/low といった一般語による誤カウントを防ぐ。
 
     Returns:
         {"HighCount": {"number": N}, "MediumCount": {"number": M}, "LowCount": {"number": L}}
     """
-    def count(pattern: str) -> int:
-        return len(re.findall(pattern, text, re.IGNORECASE))
+    def count(level: str) -> int:
+        return len(re.findall(rf"深刻度[:：]\s*{level}", text, re.IGNORECASE))
 
     return {
-        "HighCount": {"number": count(r"\bhigh\b")},
-        "MediumCount": {"number": count(r"\bmedium\b")},
-        "LowCount": {"number": count(r"\blow\b")},
+        "HighCount": {"number": count("High")},
+        "MediumCount": {"number": count("Medium")},
+        "LowCount": {"number": count("Low")},
     }

--- a/src/notifier/notion.py
+++ b/src/notifier/notion.py
@@ -247,6 +247,7 @@ def send_to_notion(
     database_id: str,
     title: str | None = None,
     tags: list[str] | None = None,
+    extra_properties: dict | None = None,
 ) -> str:
     """Notion データベースに新規ページとしてレポートを投稿する。作成したページの URL を返す。"""
     if not api_key or not database_id:
@@ -288,6 +289,8 @@ def send_to_notion(
     }
     if tags:
         properties["Tags"] = {"multi_select": [{"name": t} for t in tags]}
+    if extra_properties:
+        properties.update(extra_properties)
 
     try:
         response = notion.pages.create(

--- a/src/xss_handler.py
+++ b/src/xss_handler.py
@@ -1,6 +1,7 @@
 from datetime import date
 from src.config import get_xss_config
 from src.generator.xss_report import generate_xss_report
+from src.metrics.xss import extract_xss_metrics
 from src.notifier.discord import send_to_discord
 from src.notifier.notion import send_to_notion
 from src.logger import get_logger
@@ -34,12 +35,14 @@ def lambda_handler(event=None, context=None):
 
     logger.info("Notion にページ作成中...")
     try:
+        metrics = extract_xss_metrics(report)
         page_url = send_to_notion(
             report,
             config.notion_api_key,
             config.notion_database_id,
             title=f"XSS 脆弱性インテリジェンス — {date.today().strftime('%Y-%m-%d')}",
             tags=["agent"],
+            extra_properties=metrics,
         )
         if page_url:
             logger.info("Notion ページ: %s", page_url)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,56 @@
+from src.metrics.briefing import extract_briefing_metrics
+from src.metrics.xss import extract_xss_metrics
+
+
+class TestExtractBriefingMetrics:
+    def test_char_count(self):
+        result = extract_briefing_metrics("hello", tickers=[])
+        assert result["CharCount"] == {"number": 5}
+
+    def test_ticker_count_case_insensitive(self):
+        result = extract_briefing_metrics("PLTR は上昇、nvda は横ばい", tickers=["PLTR", "NVDA"])
+        assert result["TickerCount"] == {"number": 2}
+
+    def test_ticker_not_mentioned(self):
+        result = extract_briefing_metrics("市場は安定", tickers=["PLTR", "NVDA"])
+        assert result["TickerCount"] == {"number": 0}
+
+    def test_partial_match_not_counted(self):
+        # "NVDA" を含む単語 "NVDA-related" でも部分一致はカウントされる（IN 検索）
+        # ただし "PLTR2" は "PLTR" を含むのでカウントされることを確認
+        result = extract_briefing_metrics("PLTR2 mentioned", tickers=["PLTR"])
+        assert result["TickerCount"] == {"number": 1}
+
+    def test_returns_number_format(self):
+        result = extract_briefing_metrics("abc", tickers=[])
+        assert set(result.keys()) == {"CharCount", "TickerCount"}
+        assert "number" in result["CharCount"]
+        assert "number" in result["TickerCount"]
+
+
+class TestExtractXssMetrics:
+    def test_counts_high(self):
+        result = extract_xss_metrics("This is a High severity issue and another High one.")
+        assert result["HighCount"] == {"number": 2}
+
+    def test_counts_medium(self):
+        result = extract_xss_metrics("Medium risk found.")
+        assert result["MediumCount"] == {"number": 1}
+
+    def test_counts_low(self):
+        result = extract_xss_metrics("Low impact vulnerability.")
+        assert result["LowCount"] == {"number": 1}
+
+    def test_case_insensitive(self):
+        result = extract_xss_metrics("HIGH, high, High")
+        assert result["HighCount"] == {"number": 3}
+
+    def test_zero_when_absent(self):
+        result = extract_xss_metrics("No severity keywords here.")
+        assert result["HighCount"] == {"number": 0}
+        assert result["MediumCount"] == {"number": 0}
+        assert result["LowCount"] == {"number": 0}
+
+    def test_returns_all_keys(self):
+        result = extract_xss_metrics("")
+        assert set(result.keys()) == {"HighCount", "MediumCount", "LowCount"}

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -16,9 +16,12 @@ class TestExtractBriefingMetrics:
         assert result["TickerCount"] == {"number": 0}
 
     def test_partial_match_not_counted(self):
-        # "NVDA" を含む単語 "NVDA-related" でも部分一致はカウントされる（IN 検索）
-        # ただし "PLTR2" は "PLTR" を含むのでカウントされることを確認
+        # "PLTR2" は単語境界でマッチしないため PLTR としてカウントされない
         result = extract_briefing_metrics("PLTR2 mentioned", tickers=["PLTR"])
+        assert result["TickerCount"] == {"number": 0}
+
+    def test_exact_match_counted(self):
+        result = extract_briefing_metrics("PLTR mentioned", tickers=["PLTR"])
         assert result["TickerCount"] == {"number": 1}
 
     def test_returns_number_format(self):
@@ -29,24 +32,38 @@ class TestExtractBriefingMetrics:
 
 
 class TestExtractXssMetrics:
-    def test_counts_high(self):
-        result = extract_xss_metrics("This is a High severity issue and another High one.")
+    def test_counts_structured_high(self):
+        result = extract_xss_metrics("深刻度: High\n深刻度: High")
         assert result["HighCount"] == {"number": 2}
 
-    def test_counts_medium(self):
-        result = extract_xss_metrics("Medium risk found.")
+    def test_counts_structured_medium(self):
+        result = extract_xss_metrics("深刻度: Medium")
         assert result["MediumCount"] == {"number": 1}
 
-    def test_counts_low(self):
-        result = extract_xss_metrics("Low impact vulnerability.")
+    def test_counts_structured_low(self):
+        result = extract_xss_metrics("深刻度: Low")
         assert result["LowCount"] == {"number": 1}
 
-    def test_case_insensitive(self):
-        result = extract_xss_metrics("HIGH, high, High")
-        assert result["HighCount"] == {"number": 3}
+    def test_prose_high_not_counted(self):
+        # 散文中の "high" は深刻度ラベルではないのでカウントしない
+        result = extract_xss_metrics("This is a high risk issue with high-profile impact.")
+        assert result["HighCount"] == {"number": 0}
+
+    def test_prose_low_not_counted(self):
+        result = extract_xss_metrics("Low likelihood of exploitation.")
+        assert result["LowCount"] == {"number": 0}
+
+    def test_case_insensitive_label(self):
+        result = extract_xss_metrics("深刻度: HIGH\n深刻度: high")
+        assert result["HighCount"] == {"number": 2}
+
+    def test_fullwidth_colon(self):
+        # プロンプト出力が全角コロンになるケース
+        result = extract_xss_metrics("深刻度：High")
+        assert result["HighCount"] == {"number": 1}
 
     def test_zero_when_absent(self):
-        result = extract_xss_metrics("No severity keywords here.")
+        result = extract_xss_metrics("No severity labels here.")
         assert result["HighCount"] == {"number": 0}
         assert result["MediumCount"] == {"number": 0}
         assert result["LowCount"] == {"number": 0}

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -11,6 +11,11 @@ class TestExtractBriefingMetrics:
         result = extract_briefing_metrics("PLTR は上昇、nvda は横ばい", tickers=["PLTR", "NVDA"])
         assert result["TickerCount"] == {"number": 2}
 
+    def test_ticker_adjacent_to_japanese_particle(self):
+        # スペースなしで日本語助詞が続くケース（\b では検出できない）
+        result = extract_briefing_metrics("PLTRは上昇中", tickers=["PLTR"])
+        assert result["TickerCount"] == {"number": 1}
+
     def test_ticker_not_mentioned(self):
         result = extract_briefing_metrics("市場は安定", tickers=["PLTR", "NVDA"])
         assert result["TickerCount"] == {"number": 0}

--- a/tests/test_notion.py
+++ b/tests/test_notion.py
@@ -59,3 +59,33 @@ class TestSendToNotionTags:
     def test_returns_page_url(self, mock_notion):
         url = send_to_notion("hello", api_key="key", database_id="db-id", tags=["agent"])
         assert url == "https://notion.so/page-1"
+
+
+class TestSendToNotionExtraProperties:
+    def test_extra_properties_merged(self, mock_notion):
+        send_to_notion(
+            "hello",
+            api_key="key",
+            database_id="db-id",
+            extra_properties={"CharCount": {"number": 5}},
+        )
+        _, kwargs = mock_notion.pages.create.call_args
+        assert kwargs["properties"]["CharCount"] == {"number": 5}
+
+    def test_extra_properties_and_tags_both_set(self, mock_notion):
+        send_to_notion(
+            "hello",
+            api_key="key",
+            database_id="db-id",
+            tags=["agent"],
+            extra_properties={"HighCount": {"number": 3}},
+        )
+        _, kwargs = mock_notion.pages.create.call_args
+        props = kwargs["properties"]
+        assert props["Tags"] == {"multi_select": [{"name": "agent"}]}
+        assert props["HighCount"] == {"number": 3}
+
+    def test_none_extra_properties_no_effect(self, mock_notion):
+        send_to_notion("hello", api_key="key", database_id="db-id", extra_properties=None)
+        _, kwargs = mock_notion.pages.create.call_args
+        assert "CharCount" not in kwargs["properties"]


### PR DESCRIPTION
## Summary

- `send_to_notion()` に `extra_properties: dict | None = None` を追加し、任意の Notion プロパティを差し込めるように拡張
- `src/metrics/briefing.py` — `CharCount`（文字数）・`TickerCount`（言及銘柄数）を抽出
- `src/metrics/xss.py` — `HighCount` / `MediumCount` / `LowCount`（重要度別件数）を抽出
- 両ハンドラで毎回メトリクスを Notion ページに記録し、週次・月次グラフの元データを蓄積

## Notion DB に必要なプロパティ

| プロパティ名 | 型 | エージェント |
|---|---|---|
| `CharCount` | Number | ブリーフィング |
| `TickerCount` | Number | ブリーフィング |
| `HighCount` | Number | XSS |
| `MediumCount` | Number | XSS |
| `LowCount` | Number | XSS |

## Test plan

- [x] `pytest -v` 全20件パス
- [ ] Notion DB に上記プロパティを追加して実行確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Briefing records now capture character count and ticker-mention metrics.
  * Report records now capture severity counts (High/Medium/Low).
  * Notion publishing now accepts and stores these extra metric properties alongside title, content, and tags.

* **Tests**
  * Added comprehensive tests for both metrics extraction and Notion extra-property handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->