### PR TITLE
fix: fix code fence tracking for language-specified blocks in Discord chunker

### DIFF
--- a/src/notifier/discord.py
+++ b/src/notifier/discord.py
@@ -40,10 +40,8 @@ def _chunk_preserving_fences(text: str, chunk_size: int = 1900) -> list[str]:
     in_fence = False
 
     for line in text.splitlines(keepends=True):
-        if line.rstrip() == "```":
-            in_fence = not in_fence
-
-        # 追加するとチャンクサイズを超える場合は flush
+        # フェンス状態の更新より先に overflow を判定する（閉じフェンス行自体が
+        # 境界を超えるケースで、まだ開いている状態のまま flush できるように）
         if current_len + len(line) > chunk_size and current_lines:
             chunk = "".join(current_lines)
             if in_fence:
@@ -54,6 +52,14 @@ def _chunk_preserving_fences(text: str, chunk_size: int = 1900) -> list[str]:
             if in_fence:
                 current_lines = ["```\n"]  # 次チャンクでフェンスを再開
                 current_len = 4
+
+        # 言語指定（```python 等）も含めてフェンス開閉を追跡する
+        stripped = line.rstrip()
+        if in_fence:
+            if stripped == "```":
+                in_fence = False
+        elif stripped.startswith("```"):
+            in_fence = True
 
         current_lines.append(line)
         current_len += len(line)

--- a/src/notifier/discord.py
+++ b/src/notifier/discord.py
@@ -38,6 +38,7 @@ def _chunk_preserving_fences(text: str, chunk_size: int = 1900) -> list[str]:
     current_lines: list[str] = []
     current_len = 0
     in_fence = False
+    fence_opener = "```"
 
     for line in text.splitlines(keepends=True):
         # フェンス状態の更新より先に overflow を判定する（閉じフェンス行自体が
@@ -50,16 +51,19 @@ def _chunk_preserving_fences(text: str, chunk_size: int = 1900) -> list[str]:
             current_lines = []
             current_len = 0
             if in_fence:
-                current_lines = ["```\n"]  # 次チャンクでフェンスを再開
-                current_len = 4
+                reopen = fence_opener + "\n"
+                current_lines = [reopen]  # 元の言語指定を保ってフェンスを再開
+                current_len = len(reopen)
 
         # 言語指定（```python 等）も含めてフェンス開閉を追跡する
         stripped = line.rstrip()
         if in_fence:
             if stripped == "```":
                 in_fence = False
+                fence_opener = "```"
         elif stripped.startswith("```"):
             in_fence = True
+            fence_opener = stripped
 
         current_lines.append(line)
         current_len += len(line)

--- a/tests/test_discord.py
+++ b/tests/test_discord.py
@@ -63,6 +63,18 @@ class TestChunkPreservingFences:
             count = chunk.count("```")
             assert count % 2 == 0, f"chunk {i + 1}: フェンス数が奇数 ({count})"
 
+    def test_language_specifier_preserved_on_reopen(self):
+        # チャンク分割後の継続チャンクが元の言語指定フェンスで再開される
+        fence_text = "```python\n" + "x = 1\n" * 100 + "```\n"
+        chunks = _chunk_preserving_fences(fence_text, chunk_size=500)
+        assert len(chunks) > 1
+        # 最初のチャンク以外（継続チャンク）は ```python で始まる
+        for chunk in chunks[1:]:
+            if chunk.startswith("```"):
+                assert chunk.startswith("```python\n"), (
+                    f"継続チャンクが言語指定なしで再開: {repr(chunk[:30])}"
+                )
+
     def test_fence_state_correct_when_closing_fence_causes_overflow(self):
         # 閉じフェンス行自体がチャンク境界を超えるとき、前チャンクが正しく閉じられる
         # "```\n"(4) + 247 * "x\n"(2) = 498 chars → 閉じ"```\n"(4) で 502 > 500

--- a/tests/test_discord.py
+++ b/tests/test_discord.py
@@ -53,6 +53,27 @@ class TestChunkPreservingFences:
         for chunk in chunks[:-1]:
             assert chunk.endswith("```\n")
 
+    def test_language_fence_closed_at_chunk_boundary(self):
+        # ```python のような言語指定フェンスがチャンク境界をまたぐとき
+        # 各チャンクのフェンス数は偶数（= バランスが取れている）
+        fence_text = "```python\n" + "x = 1\n" * 100 + "```\n"
+        chunks = _chunk_preserving_fences(fence_text, chunk_size=500)
+        assert len(chunks) > 1
+        for i, chunk in enumerate(chunks):
+            count = chunk.count("```")
+            assert count % 2 == 0, f"chunk {i + 1}: フェンス数が奇数 ({count})"
+
+    def test_fence_state_correct_when_closing_fence_causes_overflow(self):
+        # 閉じフェンス行自体がチャンク境界を超えるとき、前チャンクが正しく閉じられる
+        # "```\n"(4) + 247 * "x\n"(2) = 498 chars → 閉じ"```\n"(4) で 502 > 500
+        inner = "x\n" * 247  # 494 文字
+        fence_text = "```\n" + inner + "```\n"
+        chunks = _chunk_preserving_fences(fence_text, chunk_size=500)
+        assert len(chunks) > 1
+        for i, chunk in enumerate(chunks):
+            count = chunk.count("```")
+            assert count % 2 == 0, f"chunk {i + 1}: フェンス数が奇数 ({count})"
+
 
 class TestSendToDiscord:
     def test_missing_token_returns_early(self):


### PR DESCRIPTION
## Summary

- `_chunk_preserving_fences` was ignoring code fences with language specifiers (e.g. ` ```python `), leaving `in_fence=False` inside the block — chunks split mid-block were sent to Discord without closing/reopening fences, producing malformed markdown
- The overflow check ran **after** the fence-state toggle, so a closing ` ``` ` line that itself caused a chunk overflow was flushed with `in_fence=False`, leaving the preceding chunk unclosed
- Fixed both issues: moved overflow check before fence-state update, and replaced `== "```"` toggle with `startswith("```")` for openers / `== "```"` for closers (CommonMark semantics)

## Test plan

- [x] `test_language_fence_closed_at_chunk_boundary` — new, was failing before fix
- [x] `test_fence_state_correct_when_closing_fence_causes_overflow` — new, was failing before fix
- [x] All pre-existing 11 Discord tests still pass
- [x] Full suite: 115 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code fence detection and preservation when splitting Discord notification messages across multiple chunks to maintain balanced code block formatting.

* **Tests**
  * Added comprehensive test coverage for code fence handling when splitting messages across chunk boundaries, including scenarios with language specifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->