### PR TITLE
feat: fallback to MD file output when Notion/Discord credentials are missing

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -113,26 +113,16 @@ class XssIntelConfig:
 
 
 def load_xss_config() -> XssIntelConfig:
-    """xss_intel.json と環境変数から XssIntelConfig を構築して返す。必須変数が未設定の場合は ValueError を送出する。"""
+    """xss_intel.json と環境変数から XssIntelConfig を構築して返す。"""
     raw = json.loads(XSS_INTEL_CONFIG_PATH.read_text(encoding="utf-8"))
     targets = XssTargetsConfig(**raw["targets"])
 
-    required = {
-        "DISCORD_TOKEN": os.getenv("DISCORD_TOKEN", ""),
-        "CHANNEL_ID": os.getenv("CHANNEL_ID", ""),
-        "NOTION_API_KEY": os.getenv("NOTION_API_KEY", ""),
-        "NOTION_DATABASE_ID": os.getenv("NOTION_DATABASE_ID", ""),
-    }
-    missing = [k for k, v in required.items() if not v]
-    if missing:
-        raise ValueError(f"必須環境変数が未設定です: {', '.join(missing)}")
-
     return XssIntelConfig(
         targets=targets,
-        discord_token=required["DISCORD_TOKEN"],
-        discord_channel_id=required["CHANNEL_ID"],
-        notion_api_key=required["NOTION_API_KEY"],
-        notion_database_id=required["NOTION_DATABASE_ID"],
+        discord_token=os.getenv("DISCORD_TOKEN", ""),
+        discord_channel_id=os.getenv("CHANNEL_ID", ""),
+        notion_api_key=os.getenv("NOTION_API_KEY", ""),
+        notion_database_id=os.getenv("NOTION_DATABASE_ID", ""),
     )
 
 

--- a/src/handler.py
+++ b/src/handler.py
@@ -1,4 +1,5 @@
 from datetime import date
+from pathlib import Path
 
 from src.claude_runner import get_model
 from src.config import CONFIG
@@ -10,6 +11,19 @@ from src.notifier.notion import send_to_notion
 from src.logger import get_logger
 
 logger = get_logger(__name__)
+
+_OUTPUT_DIR = Path(__file__).parents[1] / "output"
+
+
+def _is_configured(*values: str) -> bool:
+    return all(values)
+
+
+def _write_md_fallback(text: str, filename: str) -> Path:
+    _OUTPUT_DIR.mkdir(exist_ok=True)
+    path = _OUTPUT_DIR / filename
+    path.write_text(text, encoding="utf-8")
+    return path
 
 
 def lambda_handler(event=None, context=None):
@@ -24,23 +38,40 @@ def lambda_handler(event=None, context=None):
 
     logger.debug("ブリーフィング生成完了 (length=%d)", len(briefing))
 
-    logger.info("Discord に送信中...")
-    send_to_discord(briefing, CONFIG.discord_token, CONFIG.discord_channel_id)
+    discord_ok = _is_configured(CONFIG.discord_token, CONFIG.discord_channel_id)
+    notion_ok = _is_configured(CONFIG.notion_api_key, CONFIG.notion_database_id)
 
-    logger.info("Notion にページ作成中...")
+    if discord_ok:
+        logger.info("Discord に送信中...")
+        send_to_discord(briefing, CONFIG.discord_token, CONFIG.discord_channel_id)
+    else:
+        logger.warning("DISCORD_TOKEN または CHANNEL_ID が未設定 — Discord 通知をスキップします")
+
     model = get_model()
     notion_text = briefing + f"\n\n---\nModel: {model}"
-    metrics = extract_briefing_metrics(briefing, CONFIG.portfolio.tickers)
-    page_url = send_to_notion(
-        notion_text,
-        CONFIG.notion_api_key,
-        CONFIG.notion_database_id,
-        title=f"マーケットブリーフィング — {date.today().strftime('%Y-%m-%d')}",
-        tags=["agent"],
-        extra_properties=metrics,
-    )
-    if page_url:
-        logger.info("Notion ページ: %s", page_url)
+
+    if notion_ok:
+        logger.info("Notion にページ作成中...")
+        metrics = extract_briefing_metrics(briefing, CONFIG.portfolio.tickers)
+        page_url = send_to_notion(
+            notion_text,
+            CONFIG.notion_api_key,
+            CONFIG.notion_database_id,
+            title=f"マーケットブリーフィング — {date.today().strftime('%Y-%m-%d')}",
+            tags=["agent"],
+            extra_properties=metrics,
+        )
+        if page_url:
+            logger.info("Notion ページ: %s", page_url)
+    else:
+        logger.warning("NOTION_API_KEY または NOTION_DATABASE_ID が未設定 — Notion 通知をスキップします")
+
+    wrote_md = False
+    if not discord_ok or not notion_ok:
+        filename = f"briefing_{date.today().strftime('%Y-%m-%d')}.md"
+        path = _write_md_fallback(notion_text, filename)
+        logger.info("MD ファイルに出力しました: %s", path)
+        wrote_md = True
 
     logger.info("=== 完了 ===")
-    return {"statusCode": 200, "body": "Briefing sent."}
+    return {"statusCode": 200, "body": "Briefing sent.", "md_fallback": wrote_md}

--- a/src/xss_handler.py
+++ b/src/xss_handler.py
@@ -1,4 +1,6 @@
 from datetime import date
+from pathlib import Path
+
 from src.config import get_xss_config
 from src.generator.xss_report import generate_xss_report
 from src.metrics.xss import extract_xss_metrics
@@ -7,6 +9,19 @@ from src.notifier.notion import send_to_notion
 from src.logger import get_logger
 
 logger = get_logger(__name__)
+
+_OUTPUT_DIR = Path(__file__).parents[1] / "output"
+
+
+def _is_configured(*values: str) -> bool:
+    return all(values)
+
+
+def _write_md_fallback(text: str, filename: str) -> Path:
+    _OUTPUT_DIR.mkdir(exist_ok=True)
+    path = _OUTPUT_DIR / filename
+    path.write_text(text, encoding="utf-8")
+    return path
 
 
 def lambda_handler(event=None, context=None):
@@ -25,36 +40,52 @@ def lambda_handler(event=None, context=None):
         result["generation"] = str(e)
         return {"statusCode": 500, "body": result}
 
-    logger.info("Discord に送信中...")
-    try:
-        send_to_discord(report, config.discord_token, config.discord_channel_id)
-        result["discord"] = "ok"
-    except Exception as e:
-        logger.exception("Discord 送信に失敗しました")
-        result["discord"] = str(e)
+    discord_ok = _is_configured(config.discord_token, config.discord_channel_id)
+    notion_ok = _is_configured(config.notion_api_key, config.notion_database_id)
 
-    logger.info("Notion にページ作成中...")
-    try:
-        metrics = extract_xss_metrics(report)
-        page_url = send_to_notion(
-            report,
-            config.notion_api_key,
-            config.notion_database_id,
-            title=f"XSS 脆弱性インテリジェンス — {date.today().strftime('%Y-%m-%d')}",
-            tags=["agent"],
-            extra_properties=metrics,
-        )
-        if page_url:
-            logger.info("Notion ページ: %s", page_url)
-        result["notion"] = page_url or "ok"
-    except Exception as e:
-        logger.exception("Notion 送信に失敗しました")
-        result["notion"] = str(e)
+    if discord_ok:
+        logger.info("Discord に送信中...")
+        try:
+            send_to_discord(report, config.discord_token, config.discord_channel_id)
+            result["discord"] = "ok"
+        except Exception as e:
+            logger.exception("Discord 送信に失敗しました")
+            result["discord"] = str(e)
+    else:
+        logger.warning("DISCORD_TOKEN または CHANNEL_ID が未設定 — Discord 通知をスキップします")
+        result["discord"] = "skipped"
+
+    if notion_ok:
+        logger.info("Notion にページ作成中...")
+        try:
+            metrics = extract_xss_metrics(report)
+            page_url = send_to_notion(
+                report,
+                config.notion_api_key,
+                config.notion_database_id,
+                title=f"XSS 脆弱性インテリジェンス — {date.today().strftime('%Y-%m-%d')}",
+                tags=["agent"],
+                extra_properties=metrics,
+            )
+            if page_url:
+                logger.info("Notion ページ: %s", page_url)
+            result["notion"] = page_url or "ok"
+        except Exception as e:
+            logger.exception("Notion 送信に失敗しました")
+            result["notion"] = str(e)
+    else:
+        logger.warning("NOTION_API_KEY または NOTION_DATABASE_ID が未設定 — Notion 通知をスキップします")
+        result["notion"] = "skipped"
+
+    if not discord_ok or not notion_ok:
+        filename = f"xss_intel_{date.today().strftime('%Y-%m-%d')}.md"
+        path = _write_md_fallback(report, filename)
+        logger.info("MD ファイルに出力しました: %s", path)
+        result["md_fallback"] = str(path)
 
     logger.info("=== 完了 ===")
 
-    all_notifiers_failed = result.get("discord", "ok") != "ok" and result.get("notion", "ok") != "ok"
+    notifier_values = [result.get("discord", "ok"), result.get("notion", "ok")]
+    all_notifiers_failed = all(v not in ("ok", "skipped") and v is not None for v in notifier_values)
     status_code = 500 if all_notifiers_failed else 200
     return {"statusCode": status_code, "body": result}
-
-

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,4 +1,5 @@
-from unittest.mock import MagicMock, call, patch
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -15,6 +16,24 @@ def _notion_mock():
     m.databases.retrieve.return_value = {"properties": {"Name": {"type": "title"}}}
     m.pages.create.return_value = {"id": "pid", "url": "https://notion.so/p"}
     return m
+
+
+def _full_config_mock():
+    cfg = MagicMock()
+    cfg.discord_token = "tok"
+    cfg.discord_channel_id = "ch"
+    cfg.notion_api_key = "key"
+    cfg.notion_database_id = "db"
+    return cfg
+
+
+def _no_api_config_mock():
+    cfg = MagicMock()
+    cfg.discord_token = ""
+    cfg.discord_channel_id = ""
+    cfg.notion_api_key = ""
+    cfg.notion_database_id = ""
+    return cfg
 
 
 # ---------------------------------------------------------------------------
@@ -54,24 +73,60 @@ class TestBriefingHandler:
             with pytest.raises(RuntimeError, match="claude error"):
                 briefing_handler()
 
+    def test_no_credentials_writes_md_and_skips_notifiers(self, tmp_path):
+        with (
+            patch("src.handler.fetch_stock_moves", return_value="PLTR: ↑1.0%"),
+            patch("src.handler.generate_briefing", return_value="ブリーフィング本文"),
+            patch("src.handler.CONFIG") as mock_cfg,
+            patch("src.handler.send_to_discord") as mock_discord,
+            patch("src.handler.send_to_notion") as mock_notion,
+            patch("src.handler._OUTPUT_DIR", tmp_path),
+        ):
+            mock_cfg.portfolio.tickers = ["PLTR"]
+            mock_cfg.discord_token = ""
+            mock_cfg.discord_channel_id = ""
+            mock_cfg.notion_api_key = ""
+            mock_cfg.notion_database_id = ""
+            result = briefing_handler()
+
+        assert result["statusCode"] == 200
+        assert result["md_fallback"] is True
+        mock_discord.assert_not_called()
+        mock_notion.assert_not_called()
+        md_files = list(tmp_path.glob("briefing_*.md"))
+        assert len(md_files) == 1
+
+    def test_discord_only_writes_md_for_missing_notion(self, tmp_path):
+        with (
+            patch("src.handler.fetch_stock_moves", return_value="PLTR: ↑1.0%"),
+            patch("src.handler.generate_briefing", return_value="ブリーフィング本文"),
+            patch("src.handler.CONFIG") as mock_cfg,
+            patch("src.handler.send_to_discord") as mock_discord,
+            patch("src.handler.send_to_notion") as mock_notion,
+            patch("src.handler._OUTPUT_DIR", tmp_path),
+        ):
+            mock_cfg.portfolio.tickers = ["PLTR"]
+            mock_cfg.discord_token = "tok"
+            mock_cfg.discord_channel_id = "ch"
+            mock_cfg.notion_api_key = ""
+            mock_cfg.notion_database_id = ""
+            result = briefing_handler()
+
+        assert result["statusCode"] == 200
+        assert result["md_fallback"] is True
+        mock_discord.assert_called_once()
+        mock_notion.assert_not_called()
+        assert len(list(tmp_path.glob("briefing_*.md"))) == 1
+
 
 # ---------------------------------------------------------------------------
 # XSS handler
 # ---------------------------------------------------------------------------
 
-def _xss_config_mock():
-    cfg = MagicMock()
-    cfg.discord_token = "tok"
-    cfg.discord_channel_id = "ch"
-    cfg.notion_api_key = "key"
-    cfg.notion_database_id = "db"
-    return cfg
-
-
 class TestXssHandler:
     def test_success_returns_200(self):
         with (
-            patch("src.xss_handler.get_xss_config", return_value=_xss_config_mock()),
+            patch("src.xss_handler.get_xss_config", return_value=_full_config_mock()),
             patch("src.xss_handler.generate_xss_report", return_value="XSSレポート本文"),
             patch("src.xss_handler.send_to_discord"),
             patch("src.notifier.notion.Client", return_value=_notion_mock()),
@@ -81,7 +136,7 @@ class TestXssHandler:
 
     def test_report_generation_failure_returns_500(self):
         with (
-            patch("src.xss_handler.get_xss_config", return_value=_xss_config_mock()),
+            patch("src.xss_handler.get_xss_config", return_value=_full_config_mock()),
             patch("src.xss_handler.generate_xss_report", side_effect=RuntimeError("fail")),
         ):
             result = xss_handler()
@@ -90,10 +145,27 @@ class TestXssHandler:
 
     def test_all_notifiers_fail_returns_500(self):
         with (
-            patch("src.xss_handler.get_xss_config", return_value=_xss_config_mock()),
+            patch("src.xss_handler.get_xss_config", return_value=_full_config_mock()),
             patch("src.xss_handler.generate_xss_report", return_value="report"),
             patch("src.xss_handler.send_to_discord", side_effect=Exception("discord fail")),
             patch("src.xss_handler.send_to_notion", side_effect=Exception("notion fail")),
         ):
             result = xss_handler()
         assert result["statusCode"] == 500
+
+    def test_no_credentials_writes_md_and_skips_notifiers(self, tmp_path):
+        with (
+            patch("src.xss_handler.get_xss_config", return_value=_no_api_config_mock()),
+            patch("src.xss_handler.generate_xss_report", return_value="XSSレポート本文"),
+            patch("src.xss_handler.send_to_discord") as mock_discord,
+            patch("src.xss_handler.send_to_notion") as mock_notion,
+            patch("src.xss_handler._OUTPUT_DIR", tmp_path),
+        ):
+            result = xss_handler()
+
+        assert result["statusCode"] == 200
+        assert "md_fallback" in result["body"]
+        mock_discord.assert_not_called()
+        mock_notion.assert_not_called()
+        md_files = list(tmp_path.glob("xss_intel_*.md"))
+        assert len(md_files) == 1

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -45,9 +45,15 @@ class TestBriefingHandler:
         with (
             patch("src.handler.fetch_stock_moves", return_value="PLTR: ↑1.0%"),
             patch("src.handler.generate_briefing", return_value="ブリーフィング本文"),
+            patch("src.handler.CONFIG") as mock_cfg,
             patch("src.handler.send_to_discord"),
             patch("src.notifier.notion.Client", return_value=_notion_mock()),
         ):
+            mock_cfg.portfolio.tickers = ["PLTR"]
+            mock_cfg.discord_token = "tok"
+            mock_cfg.discord_channel_id = "ch"
+            mock_cfg.notion_api_key = "key"
+            mock_cfg.notion_database_id = "db"
             result = briefing_handler()
         assert result["statusCode"] == 200
 
@@ -56,10 +62,16 @@ class TestBriefingHandler:
         with (
             patch("src.handler.fetch_stock_moves", return_value="PLTR: ↑1.0%"),
             patch("src.handler.generate_briefing", return_value=briefing_text),
+            patch("src.handler.CONFIG") as mock_cfg,
             patch("src.handler.send_to_discord"),
             patch("src.handler.send_to_notion", return_value="https://notion.so/p") as mock_notion,
             patch("src.handler.get_model", return_value="claude-haiku-4-5-20251001"),
         ):
+            mock_cfg.portfolio.tickers = ["PLTR"]
+            mock_cfg.discord_token = "tok"
+            mock_cfg.discord_channel_id = "ch"
+            mock_cfg.notion_api_key = "key"
+            mock_cfg.notion_database_id = "db"
             briefing_handler()
         expected_text = briefing_text + "\n\n---\nModel: claude-haiku-4-5-20251001"
         assert mock_notion.call_args[0][0] == expected_text


### PR DESCRIPTION
## Summary

- Added `_is_configured(*values)` helper to both `handler.py` and `xss_handler.py` to detect missing API credentials at dispatch time
- When Discord or Notion credentials are absent, a WARNING is logged and the notifier is skipped; output is written to `output/briefing_YYYY-MM-DD.md` (or `xss_intel_YYYY-MM-DD.md`) instead
- Removed the `ValueError` raise from `load_xss_config()` — credential validation is now handled gracefully in the handler layer
- Added 4 new tests covering: no-credential MD fallback (briefing + xss), partial-credential (Discord only) scenario

## Behaviour matrix

| DISCORD_TOKEN set | NOTION_API_KEY set | Result |
|---|---|---|
| ✓ | ✓ | Send to both (unchanged) |
| ✓ | ✗ | Send to Discord + write MD |
| ✗ | ✓ | Write MD + send to Notion |
| ✗ | ✗ | Write MD only |

## Test plan

- [x] `pytest tests/test_handlers.py` — 9 passed
- [x] Full suite `pytest` — 119 passed, 0 failed

Closes #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * System now gracefully handles missing API credentials without failing operations instead of throwing errors.

* **New Features**
  * Briefings and reports are automatically saved as local Markdown files when Discord or Notion services are unavailable or unconfigured.
  * Conditional notification delivery—Discord and Notion are only used when their respective credentials are configured.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KazusaNakagawa/ai-agent-cli/pull/26)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->