### PR TITLE
fix: move briefing MD output to output/briefing/ subdirectory

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -14,6 +14,7 @@ LOG_RETENTION_DAYS = 7
 
 # Output directory for MD fallback
 OUTPUT_DIR = Path(__file__).parent.parent / "output"
+BRIEFING_OUTPUT_DIR = OUTPUT_DIR / "briefing"
 
 # Notion
 NOTION_CHAR_LIMIT = 2000

--- a/src/handler.py
+++ b/src/handler.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from src.claude_runner import get_model
 from src.config import CONFIG
-from src.constants import OUTPUT_DIR
+from src.constants import BRIEFING_OUTPUT_DIR
 from src.fetcher.stocks import fetch_stock_moves
 from src.generator.briefing import generate_briefing
 from src.metrics.briefing import extract_briefing_metrics
@@ -19,8 +19,8 @@ def _is_configured(*values: str) -> bool:
 
 
 def _write_md_fallback(text: str, filename: str) -> Path:
-    OUTPUT_DIR.mkdir(exist_ok=True)
-    path = OUTPUT_DIR / filename
+    BRIEFING_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    path = BRIEFING_OUTPUT_DIR / filename
     path.write_text(text, encoding="utf-8")
     return path
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -92,7 +92,7 @@ class TestBriefingHandler:
             patch("src.handler.CONFIG") as mock_cfg,
             patch("src.handler.send_to_discord") as mock_discord,
             patch("src.handler.send_to_notion") as mock_notion,
-            patch("src.handler.OUTPUT_DIR", tmp_path),
+            patch("src.handler.BRIEFING_OUTPUT_DIR", tmp_path),
         ):
             mock_cfg.portfolio.tickers = ["PLTR"]
             mock_cfg.discord_token = ""
@@ -115,7 +115,7 @@ class TestBriefingHandler:
             patch("src.handler.CONFIG") as mock_cfg,
             patch("src.handler.send_to_discord") as mock_discord,
             patch("src.handler.send_to_notion") as mock_notion,
-            patch("src.handler.OUTPUT_DIR", tmp_path),
+            patch("src.handler.BRIEFING_OUTPUT_DIR", tmp_path),
         ):
             mock_cfg.portfolio.tickers = ["PLTR"]
             mock_cfg.discord_token = "tok"
@@ -155,7 +155,7 @@ class TestBriefingHandler:
             patch("src.handler.generate_briefing", return_value="本文"),
             patch("src.handler.get_model", return_value="claude-sonnet-4-6"),
             patch("src.handler.send_to_notion"),
-            patch("src.handler.OUTPUT_DIR", Path("/tmp")),
+            patch("src.handler.BRIEFING_OUTPUT_DIR", Path("/tmp")),
         ):
             mock_cfg.portfolio.tickers = ["PLTR"]
             mock_cfg.discord_token = ""


### PR DESCRIPTION
## Summary

- Added `BRIEFING_OUTPUT_DIR = OUTPUT_DIR / "briefing"` constant in `src/constants.py`
- Updated `src/handler.py` to write briefing MD files to `output/briefing/briefing_YYYY-MM-DD.md`
- Changed `mkdir()` to use `parents=True` so the subdirectory is created automatically
- Updated test patches from `OUTPUT_DIR` to `BRIEFING_OUTPUT_DIR`

## Test plan

- [x] All 122 tests pass
- [x] `BRIEFING_OUTPUT_DIR` is auto-created on first run (`parents=True, exist_ok=True`)
- [x] XSS handler output path (`OUTPUT_DIR`) is unchanged

Closes #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured output directory organization to separate briefing files into a dedicated subdirectory.

* **Tests**
  * Updated test suite to reflect changes to output directory structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KazusaNakagawa/ai-agent-cli/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->