### PR TITLE
feat: add bin/chat.sh for interactive briefing Q&A

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,21 @@ cp .env.example .env
 bin/run.sh
 ```
 
+### Interactive Q&A on today's briefing
+
+```bash
+bin/chat.sh
+```
+
+Opens an interactive Claude session with today's `output/briefing/briefing_YYYY-MM-DD.md` loaded as context.
+Ask questions about any stock, sector, or event mentioned in the briefing.
+
+```bash
+bin/chat.sh 2026-05-16   # Chat about a specific past briefing
+```
+
+Exits with an error if the briefing file for the specified date does not exist.
+
 ### Dry-run (validate credentials without executing)
 
 ```bash

--- a/bin/chat.sh
+++ b/bin/chat.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Interactive Q&A session using a daily briefing as context.
+# Usage: bin/chat.sh [YYYY-MM-DD]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+ENV_FILE="$PROJECT_ROOT/.env"
+if [ -f "$ENV_FILE" ]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "$ENV_FILE"
+    set +a
+fi
+
+BRIEFING_DIR="$PROJECT_ROOT/output/briefing"
+TARGET_DATE="${1:-$(date +%Y-%m-%d)}"
+BRIEFING_FILE="$BRIEFING_DIR/briefing_${TARGET_DATE}.md"
+
+if [ ! -f "$BRIEFING_FILE" ]; then
+    echo "Error: briefing file not found: $BRIEFING_FILE" >&2
+    echo "Usage: $(basename "$0") [YYYY-MM-DD]" >&2
+    exit 1
+fi
+
+BRIEFING_CONTENT="$(cat "$BRIEFING_FILE")"
+
+CONTEXT="以下は ${TARGET_DATE} のマーケットブリーフィングです。このブリーフィングをコンテキストとして、ユーザーの質問に日本語で回答してください。
+
+=== マーケットブリーフィング (${TARGET_DATE}) ===
+${BRIEFING_CONTENT}
+=== END ==="
+
+SESSION_NAME="briefing-chat-${TARGET_DATE}"
+
+echo "Loaded: $BRIEFING_FILE"
+echo "Session: $SESSION_NAME"
+echo "(type your question, Ctrl+C or /exit to quit)"
+echo ""
+
+exec claude \
+    --name "$SESSION_NAME" \
+    --append-system-prompt "$CONTEXT"


### PR DESCRIPTION
## Summary

- Adds `bin/chat.sh` — a shell script that loads a daily briefing MD and starts an interactive Claude session with the content as context
- Uses `--append-system-prompt` to inject the briefing without replacing Claude's default capabilities
- Uses `--name briefing-chat-YYYY-MM-DD` to give the session a stable, identifiable name (groundwork for #32 session persistence)
- Exits with a clear error message if the briefing file is missing
- Documents the command in README under "### Interactive Q&A on today's briefing"

## Usage

```bash
bin/chat.sh            # today's briefing
bin/chat.sh 2026-05-16 # specific date
```

## Test plan

- [x] `bash -n bin/chat.sh` passes syntax check
- [x] Running with a nonexistent date prints error and exits 1
- [x] Running with no arg and no today's file prints error and exits 1
- [x] All 122 existing tests pass
- [x] Manual: `bin/chat.sh 2026-05-16` opens interactive Claude session with briefing context

Closes #31