### PR TITLE
feat: add notion-import skill and skills/ directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,7 @@
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 > Setup, architecture, configuration, and testing details are documented in [README.md](README.md).
+> Custom Claude Code skills used in this project: [skills/](skills/README.md).
 
 ## Quick Commands
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Bloomberg and NewsPicks surface raw data. This agent ties every event to your ho
 
 ## Architecture
 
-```
+```bash
 bin/run.sh
   ├── bin/briefing.py
   │     └── src/handler.py
@@ -35,7 +35,10 @@ config/
   briefing.json        # Portfolio, watch sectors (14 sectors), geopolitical risks
   xss_intel.json       # XSS target frameworks / libraries / keywords
 src/config.py          # JSON → dataclass schema
+skills/                # Claude Code custom skills — see skills/README.md
 ```
+
+See [skills/](skills/README.md) for custom Claude Code skills bundled with this repo.
 
 ### Key Design Decisions
 
@@ -178,7 +181,7 @@ Prompt template for the briefing agent. Variables: `{tickers}` `{themes}` `{geop
 
 ## Sample Output
 
-```
+```markdown
 ## Today's Summary (1 sentence)
 ...
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,31 @@
+# Skills
+
+Source-of-truth backup of Claude Code custom skills used in this project.
+
+These skill files are not auto-discovered from this location. Claude Code looks under `~/.claude/skills/`, so install via symlink or copy.
+
+## Available Skills
+
+| Skill | Description |
+|---|---|
+| [notion-import](./notion-import/SKILL.md) | Save the previous research/answer to a local markdown file under `output/`, then append it to today's Notion briefing page. |
+
+## Install
+
+Symlink (recommended — edits stay in sync with the repo):
+
+```bash
+ln -s "$(pwd)/skills/notion-import" ~/.claude/skills/notion-import
+```
+
+Or copy (one-shot snapshot — repo and `~/.claude/skills/` will drift):
+
+```bash
+cp -r skills/notion-import ~/.claude/skills/
+```
+
+After installation, the skill is invocable via `/notion-import <topic-slug>` in Claude Code.
+
+## Updating a Skill
+
+Edit the file under `skills/<name>/SKILL.md`, commit the change, and (if you used `cp`) re-copy to `~/.claude/skills/`. Symlinked installs pick up edits automatically.

--- a/skills/notion-import/SKILL.md
+++ b/skills/notion-import/SKILL.md
@@ -11,7 +11,7 @@ allowed-tools: Write, mcp__claude_ai_Notion__notion-search, mcp__claude_ai_Notio
 
 ## Usage
 
-```
+```bash
 /notion-import <topic-slug>
 ```
 

--- a/skills/notion-import/SKILL.md
+++ b/skills/notion-import/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: notion-import
+description: Use when the user wants to save the previous research/answer to a local markdown file and append it to today's Notion briefing page
+argument-hint: "<topic-slug>"
+allowed-tools: Write, mcp__claude_ai_Notion__notion-search, mcp__claude_ai_Notion__notion-update-page
+---
+
+# Notion Import
+
+会話の直前の調査結果・回答内容を、ローカル md ファイルに保存しつつ、今日の Notion ブリーフィングページ末尾に追記する。
+
+## Usage
+
+```
+/notion-import <topic-slug>
+```
+
+- `<topic-slug>` はファイル名用の kebab-case 識別子（例: `distyl-ai-ipo-check`, `tsmc-2nm-update`）
+- 追記する内容は **直前の assistant 回答** を正本とする（ユーザーから別途指定がなければ）
+
+## Workflow
+
+### 1. ローカル md ファイル作成
+
+パス: `output/<topic-slug>_<YYYY-MM-DD>.md`
+
+- 日付は今日（`MEMORY.md` の `currentDate` または `date +%F` で確認）
+- セクション構成（推奨テンプレート）:
+  ```markdown
+  # <タイトル> (<YYYY-MM-DD>)
+
+  ## 結論
+  <1〜2文の要点>
+
+  ## <セクション>
+  <本文・表・箇条書き>
+
+  ## ソース
+  - [<タイトル>](<URL>)
+  ```
+- ソース URL は会話中に WebSearch などで得たものだけを使用（捏造しない）
+
+### 2. 今日の Notion ブリーフィングページを特定
+
+`mcp__claude_ai_Notion__notion-search` で以下を検索:
+
+- クエリ: `マーケットブリーフィング YYYY-MM-DD`（今日の日付）
+- `page_size: 5`, `max_highlight_length: 0`
+- タイトルが `マーケットブリーフィング — YYYY-MM-DD` に一致するページの `id` を取得
+
+ヒットしない場合は、その旨をユーザーに報告して停止（勝手に別のページに書き込まない）。
+
+### 3. ページ末尾に追記
+
+`mcp__claude_ai_Notion__notion-update-page` を以下で呼ぶ:
+
+- `command: insert_content`
+- `position: {"type": "end"}`
+- `content`: 区切り線 + 見出しから始める
+
+content の冒頭テンプレート:
+
+```markdown
+---
+
+## 追記: <タイトル> (<YYYY-MM-DD>)
+
+<本文>
+```
+
+本文はステップ1で書いた md と同等の内容（先頭の `# <タイトル>` は重複するので削る）。
+
+### 4. 完了報告
+
+ユーザーに 1〜2 行で:
+- 保存した md パス
+- Notion ページの URL（`https://www.notion.so/<id-without-dashes>`）
+
+## Notes
+
+- **直前の回答が長い場合**: 全文ではなく要約版を作るのではなく、構造を保ったまま転記する（ユーザーが「いい感じ」と評価した形式を維持）
+- **ローカル md と Notion 本文の差分**: ローカル md には `# トップタイトル` を残し、Notion 側は `## 追記:` 見出しから始める（ブリーフィング本文との階層整合のため）
+- **複数追記**: 同じ日に2回以上呼ばれた場合も、毎回 `---` + `## 追記:` で末尾に積む
+- **失敗時のフォールバック**: Notion 検索が失敗してもローカル md は既に保存済みなので、ユーザーには「ローカルは保存済み、Notion 追記は失敗」と明示


### PR DESCRIPTION
## Summary

- Add `skills/notion-import/SKILL.md` — saves the previous research/answer to `output/<slug>_<date>.md` and appends it to today's Notion briefing page (`マーケットブリーフィング — YYYY-MM-DD`)
- Add `skills/README.md` — install instructions (symlink or `cp` into `~/.claude/skills/`) so the skill is discoverable by Claude Code
- Link `skills/` from `README.md` (architecture tree) and `CLAUDE.md` (header pointer)

## Test plan

- [x] Skill invoked end-to-end during development (`/notion-import distyl-ai-ipo-check`, `/notion-import cbrs-drop-check`) — both produced local md and appended to today's Notion page
- [ ] After merge, install via `ln -s "\$(pwd)/skills/notion-import" ~/.claude/skills/notion-import` on a fresh checkout to verify discoverability
- [ ] Confirm Notion page lookup still works (title pattern: `マーケットブリーフィング — YYYY-MM-DD`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive setup documentation for Claude Code custom skills, including installation methods via symlink or direct copy
  * Introduced documentation for a new Notion import skill enabling content import from Notion with local file and Notion page output
  * Updated project README with explicit references to available custom skills

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KazusaNakagawa/ai-agent-cli/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->