### PR TITLE
feat(web): add /api/config GET/PUT with Pydantic v2 schemas

### DIFF
--- a/apps/python/tests/test_api_config.py
+++ b/apps/python/tests/test_api_config.py
@@ -109,6 +109,35 @@ async def test_put_config_requires_bearer(temp_config):
 
 
 @pytest.mark.asyncio
+async def test_get_config_returns_500_on_corrupt_json(temp_config):
+    temp_config.write_text("not json {{{", encoding="utf-8")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            "/api/config",
+            headers={"Authorization": "Bearer test-token-123"},
+        )
+    assert response.status_code == 500
+    assert "corrupt" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_get_config_returns_500_on_schema_mismatch(temp_config):
+    temp_config.write_text(
+        json.dumps({"portfolio": "not-an-object", "watch_sectors": []}),
+        encoding="utf-8",
+    )
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            "/api/config",
+            headers={"Authorization": "Bearer test-token-123"},
+        )
+    assert response.status_code == 500
+    assert "schema" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
 async def test_put_config_leaves_no_tmp_file_on_failure(monkeypatch, temp_config):
     """When the atomic write fails mid-flight, no .tmp file may remain."""
 

--- a/apps/python/tests/test_api_config.py
+++ b/apps/python/tests/test_api_config.py
@@ -1,0 +1,135 @@
+import json
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from web.app import app
+from web import auth
+
+
+@pytest.fixture(autouse=True)
+def fixed_token(monkeypatch, tmp_path):
+    token_file = tmp_path / "token"
+    token_file.write_text("test-token-123")
+    monkeypatch.setattr(auth, "TOKEN_FILE", token_file)
+    monkeypatch.setattr(auth, "_token_cache", None, raising=False)
+
+
+@pytest.fixture
+def temp_config(monkeypatch, tmp_path):
+    config_path = tmp_path / "briefing.json"
+    initial = {
+        "portfolio": {"tickers": ["PLTR"], "themes": ["AI"]},
+        "geopolitical": {"conflicts": []},
+        "watch_sectors": [{"sector": "AI", "tickers": ["NVDA"], "notes": None}],
+        "watch_events": [],
+    }
+    config_path.write_text(json.dumps(initial), encoding="utf-8")
+    monkeypatch.setenv("BRIEFING_CONFIG_PATH", str(config_path))
+    yield config_path
+
+
+@pytest.mark.asyncio
+async def test_get_config_returns_current(temp_config):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            "/api/config",
+            headers={"Authorization": "Bearer test-token-123"},
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["portfolio"]["tickers"] == ["PLTR"]
+
+
+@pytest.mark.asyncio
+async def test_get_config_requires_bearer(temp_config):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/api/config")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_put_config_updates_file(temp_config):
+    new_config = {
+        "portfolio": {"tickers": ["NVDA", "AMZN"], "themes": ["Cloud"]},
+        "geopolitical": {"conflicts": []},
+        "watch_sectors": [{"sector": "Cloud", "tickers": ["MSFT"], "notes": None}],
+        "watch_events": [],
+    }
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.put(
+            "/api/config",
+            headers={"Authorization": "Bearer test-token-123"},
+            json=new_config,
+        )
+    assert response.status_code == 200
+    saved = json.loads(temp_config.read_text(encoding="utf-8"))
+    assert saved["portfolio"]["tickers"] == ["NVDA", "AMZN"]
+
+
+@pytest.mark.asyncio
+async def test_put_config_rejects_empty_tickers(temp_config):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.put(
+            "/api/config",
+            headers={"Authorization": "Bearer test-token-123"},
+            json={
+                "portfolio": {"tickers": [], "themes": []},
+                "watch_sectors": [{"sector": "AI", "tickers": ["NVDA"], "notes": None}],
+            },
+        )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_put_config_rejects_empty_watch_sectors(temp_config):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.put(
+            "/api/config",
+            headers={"Authorization": "Bearer test-token-123"},
+            json={
+                "portfolio": {"tickers": ["PLTR"], "themes": ["AI"]},
+                "watch_sectors": [],
+            },
+        )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_put_config_requires_bearer(temp_config):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.put("/api/config", json={})
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_put_config_leaves_no_tmp_file_on_failure(monkeypatch, temp_config):
+    """When the atomic write fails mid-flight, no .tmp file may remain."""
+
+    def _boom(src, dst):
+        raise OSError("simulated disk full")
+
+    monkeypatch.setattr("web.routers.config.os.replace", _boom)
+
+    payload = {
+        "portfolio": {"tickers": ["PLTR"], "themes": ["AI"]},
+        "geopolitical": {"conflicts": []},
+        "watch_sectors": [{"sector": "AI", "tickers": ["NVDA"], "notes": None}],
+        "watch_events": [],
+    }
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.put(
+            "/api/config",
+            headers={"Authorization": "Bearer test-token-123"},
+            json=payload,
+        )
+    assert response.status_code >= 500
+    leftover = [p for p in temp_config.parent.iterdir() if p.suffix == ".tmp"]
+    assert leftover == [], f"tmp file not cleaned up: {leftover}"

--- a/apps/python/tests/test_schemas.py
+++ b/apps/python/tests/test_schemas.py
@@ -1,0 +1,36 @@
+import pytest
+from pydantic import ValidationError
+
+from web.schemas import BriefingConfigSchema, PortfolioSchema, WatchSectorSchema
+
+
+def test_valid_briefing_config():
+    config = BriefingConfigSchema(
+        portfolio=PortfolioSchema(tickers=["PLTR"], themes=["AI"]),
+        watch_sectors=[
+            WatchSectorSchema(sector="AI & Cloud", tickers=["NVDA"], notes=None),
+        ],
+        geopolitical={"conflicts": []},
+        watch_events=[],
+    )
+    assert config.portfolio.tickers == ["PLTR"]
+
+
+def test_watch_sector_rejects_empty_tickers():
+    with pytest.raises(ValidationError):
+        WatchSectorSchema(sector="AI", tickers=[])
+
+
+def test_portfolio_rejects_empty_tickers():
+    with pytest.raises(ValidationError):
+        PortfolioSchema(tickers=[], themes=["AI"])
+
+
+def test_briefing_config_requires_at_least_one_watch_sector():
+    with pytest.raises(ValidationError):
+        BriefingConfigSchema(
+            portfolio=PortfolioSchema(tickers=["PLTR"], themes=["AI"]),
+            watch_sectors=[],
+            geopolitical={"conflicts": []},
+            watch_events=[],
+        )

--- a/apps/python/web/app.py
+++ b/apps/python/web/app.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 
-from web.routers import health
+from web.routers import config, health
 
 app = FastAPI(title="ai-agent Web API", version="0.1.0")
 app.include_router(health.router, prefix="/api")
+app.include_router(config.router, prefix="/api")

--- a/apps/python/web/routers/config.py
+++ b/apps/python/web/routers/config.py
@@ -1,10 +1,18 @@
-"""GET / PUT /api/config — briefing.json の読み書き。"""
+"""GET / PUT /api/config — briefing.json の読み書き。
+
+PUT は disk に書き込むだけで、起動中プロセスの ``src.config.CONFIG`` グローバル
+（import 時に ``load_config()`` 実行）はリロードしない。Phase 1 のブリーフィング
+は cron から ``bin/run.sh`` 経由で別 Python プロセスを起こすので、PUT は次回
+batch 実行時に自動で反映される。リアルタイム反映が必要になったら、ここで
+``CONFIG`` を更新するか、別途リロード用エンドポイントを足す方針。
+"""
 import json
 import os
 import tempfile
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import ValidationError
 
 from web.auth import require_bearer
 from web.schemas import BriefingConfigSchema
@@ -21,12 +29,26 @@ def _config_path() -> Path:
     )
 
 
-@router.get("/config", dependencies=[Depends(require_bearer)])
-def get_config() -> dict:
+@router.get(
+    "/config",
+    response_model=BriefingConfigSchema,
+    dependencies=[Depends(require_bearer)],
+)
+def get_config() -> BriefingConfigSchema:
     path = _config_path()
     if not path.exists():
         raise HTTPException(status_code=404, detail="briefing.json not found")
-    return json.loads(path.read_text(encoding="utf-8"))
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        raise HTTPException(status_code=500, detail="briefing.json is corrupt") from e
+    try:
+        return BriefingConfigSchema.model_validate(data)
+    except ValidationError as e:
+        raise HTTPException(
+            status_code=500,
+            detail="briefing.json does not match the expected schema",
+        ) from e
 
 
 @router.put("/config", dependencies=[Depends(require_bearer)])

--- a/apps/python/web/routers/config.py
+++ b/apps/python/web/routers/config.py
@@ -1,0 +1,45 @@
+"""GET / PUT /api/config — briefing.json の読み書き。"""
+import json
+import os
+import tempfile
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from web.auth import require_bearer
+from web.schemas import BriefingConfigSchema
+
+router = APIRouter()
+
+
+def _config_path() -> Path:
+    return Path(
+        os.getenv(
+            "BRIEFING_CONFIG_PATH",
+            str(Path(__file__).resolve().parents[2] / "config" / "briefing.json"),
+        )
+    )
+
+
+@router.get("/config", dependencies=[Depends(require_bearer)])
+def get_config() -> dict:
+    path = _config_path()
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="briefing.json not found")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@router.put("/config", dependencies=[Depends(require_bearer)])
+def put_config(payload: BriefingConfigSchema) -> dict:
+    path = _config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = payload.model_dump(mode="json")
+    fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+        os.replace(tmp_path, path)
+    except Exception:
+        Path(tmp_path).unlink(missing_ok=True)
+        raise
+    return data

--- a/apps/python/web/schemas.py
+++ b/apps/python/web/schemas.py
@@ -1,0 +1,39 @@
+"""API 境界の Pydantic v2 スキーマ。src.config のデータクラスを変更せず、JSON ⇔ dict 変換を担う。"""
+from pydantic import BaseModel, Field
+
+
+class ConflictSchema(BaseModel):
+    name: str
+    affected_sectors: list[str]
+    related_tickers: list[str] = Field(default_factory=list)
+    notes: str | None = None
+
+
+class GeopoliticalSchema(BaseModel):
+    conflicts: list[ConflictSchema] = Field(default_factory=list)
+
+
+class PortfolioSchema(BaseModel):
+    tickers: list[str] = Field(min_length=1)
+    themes: list[str]
+
+
+class WatchSectorSchema(BaseModel):
+    sector: str
+    tickers: list[str] = Field(min_length=1)
+    notes: str | None = None
+
+
+class WatchEventSchema(BaseModel):
+    name: str
+    trigger: str
+    affected_sectors: list[str]
+    related_tickers: list[str] = Field(default_factory=list)
+    notes: str | None = None
+
+
+class BriefingConfigSchema(BaseModel):
+    portfolio: PortfolioSchema
+    geopolitical: GeopoliticalSchema = Field(default_factory=GeopoliticalSchema)
+    watch_sectors: list[WatchSectorSchema] = Field(min_length=1)
+    watch_events: list[WatchEventSchema] = Field(default_factory=list)


### PR DESCRIPTION
## Summary

- Add `web/schemas.py` with Pydantic v2 models: `PortfolioSchema`, `WatchSectorSchema`, `WatchEventSchema`, `ConflictSchema`, `GeopoliticalSchema`, `BriefingConfigSchema`. `tickers` and `watch_sectors` enforce `min_length=1` so empty payloads are rejected at the schema layer.
- Add `web/routers/config.py` with `GET /api/config` and `PUT /api/config`, both protected by `require_bearer`.
- `GET` reads from `BRIEFING_CONFIG_PATH` (env override) or `apps/python/config/briefing.json`, returns 404 if absent.
- `PUT` validates via `BriefingConfigSchema`, writes to a sibling tempfile, and `os.replace()`s into place. The tempfile is `unlink()`ed on any failure so no `.tmp` leftover remains.
- Wire both into `web/app.py`.

## Test plan

- [x] `tests/test_schemas.py` covers happy path + empty-tickers rejection (portfolio and watch_sector) + empty-watch_sectors rejection.
- [x] `tests/test_api_config.py` covers GET happy path, GET auth, PUT happy path with on-disk verification, PUT empty-tickers (422), PUT empty-watch_sectors (422), PUT auth, and tmp-file cleanup when `os.replace` fails.
- [x] Full suite: `cd apps/python && .venv/bin/pytest` — 169 passed.
- [x] Manual: `uvicorn web.app:app` → curl GET/PUT against `/api/config` with bearer returns expected status codes and payload.

Closes #45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)