### PR TITLE
[codex] fix stale briefing chat sessions

### DIFF
--- a/apps/python/bin/chat.py
+++ b/apps/python/bin/chat.py
@@ -11,12 +11,6 @@ PROJECT_ROOT = Path(__file__).parents[1]
 BRIEFING_DIR = PROJECT_ROOT / "output" / "briefing"
 SESSIONS_DIR = BRIEFING_DIR / ".sessions"
 
-sys.path.insert(0, str(PROJECT_ROOT))
-
-from src.logger import get_logger
-
-logger = get_logger(__name__)
-
 
 def claude_env() -> dict[str, str]:
     """Return the parent environment without Anthropic API credentials."""
@@ -85,14 +79,14 @@ def run_claude(target_date: str, briefing_file: Path, session_file: Path) -> int
         return 0
 
     if "No conversation found" in stderr:
-        logger.warning("%s", stderr.strip())
-        logger.warning("Saved session is stale; starting a new session.")
+        print(stderr.strip(), file=sys.stderr)
+        print("Saved session is stale; starting a new session.", file=sys.stderr)
         session_file.unlink(missing_ok=True)
         new_cmd = build_cmd(target_date, briefing_file, session_file)
         return subprocess.run(new_cmd, env=env).returncode
 
     if stderr:
-        logger.error("%s", stderr.strip())
+        print(stderr.strip(), file=sys.stderr)
     return result.returncode
 
 

--- a/apps/python/bin/chat.py
+++ b/apps/python/bin/chat.py
@@ -1,6 +1,7 @@
 """Interactive Q&A session using a daily briefing as context."""
 import argparse
 import os
+import subprocess
 import sys
 import uuid
 from datetime import date
@@ -9,6 +10,19 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).parents[1]
 BRIEFING_DIR = PROJECT_ROOT / "output" / "briefing"
 SESSIONS_DIR = BRIEFING_DIR / ".sessions"
+
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def claude_env() -> dict[str, str]:
+    """Return the parent environment without Anthropic API credentials."""
+    env = os.environ.copy()
+    env.pop("ANTHROPIC_API_KEY", None)
+    return env
 
 
 def list_sessions(sessions_dir: Path) -> None:
@@ -52,6 +66,36 @@ def build_cmd(target_date: str, briefing_file: Path, session_file: Path) -> list
     ]
 
 
+def run_claude(target_date: str, briefing_file: Path, session_file: Path) -> int:
+    """Run claude CLI and recreate the session if the saved id is stale.
+
+    target_date selects the briefing/session label, briefing_file provides the
+    initial context for new sessions, and session_file stores the saved Claude
+    session id. Returns the final subprocess exit code.
+    """
+    env = claude_env()
+    cmd = build_cmd(target_date, briefing_file, session_file)
+    if "--resume" not in cmd:
+        return subprocess.run(cmd, env=env).returncode
+
+    result = subprocess.run(cmd, stderr=subprocess.PIPE, text=True, env=env)
+    stderr = result.stderr or ""
+
+    if result.returncode == 0:
+        return 0
+
+    if "No conversation found" in stderr:
+        logger.warning("%s", stderr.strip())
+        logger.warning("Saved session is stale; starting a new session.")
+        session_file.unlink(missing_ok=True)
+        new_cmd = build_cmd(target_date, briefing_file, session_file)
+        return subprocess.run(new_cmd, env=env).returncode
+
+    if stderr:
+        logger.error("%s", stderr.strip())
+    return result.returncode
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Chat about a daily briefing")
     parser.add_argument(
@@ -77,8 +121,7 @@ def main() -> None:
         sys.exit(1)
 
     SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
-    cmd = build_cmd(target_date, briefing_file, session_file)
-    os.execvp(cmd[0], cmd)
+    sys.exit(run_claude(target_date, briefing_file, session_file))
 
 
 if __name__ == "__main__":

--- a/apps/python/tests/test_chat.py
+++ b/apps/python/tests/test_chat.py
@@ -1,5 +1,6 @@
 """Tests for bin/chat.py — session management and command building."""
 import importlib.util
+import subprocess
 import uuid
 from pathlib import Path
 
@@ -93,3 +94,52 @@ class TestBuildCmd:
         assert "--resume" in cmd
         assert "--name" in cmd
         assert "briefing-chat-2026-05-16" in cmd
+
+
+class TestRunClaude:
+    def test_claude_subprocess_strips_anthropic_api_key(self, tmp_path, monkeypatch):
+        briefing = tmp_path / "briefing_2026-05-16.md"
+        briefing.write_text("本文テスト")
+        session_file = tmp_path / "2026-05-16"
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            return subprocess.CompletedProcess(cmd, 0, stderr="")
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "secret")
+        monkeypatch.setattr(chat.subprocess, "run", fake_run)
+
+        exit_code = chat.run_claude("2026-05-16", briefing, session_file)
+
+        assert exit_code == 0
+        assert calls[0][1]["env"].get("ANTHROPIC_API_KEY") is None
+
+    def test_stale_resume_session_falls_back_to_new_session(self, tmp_path, monkeypatch, caplog):
+        briefing = tmp_path / "briefing_2026-05-16.md"
+        briefing.write_text("本文テスト")
+        session_file = tmp_path / "2026-05-16"
+        session_file.write_text("stale-uuid")
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            if "--resume" in cmd:
+                return subprocess.CompletedProcess(
+                    cmd,
+                    1,
+                    stderr="No conversation found with session ID: stale-uuid\n",
+                )
+            return subprocess.CompletedProcess(cmd, 0, stderr="")
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "secret")
+        monkeypatch.setattr(chat.subprocess, "run", fake_run)
+
+        exit_code = chat.run_claude("2026-05-16", briefing, session_file)
+
+        assert exit_code == 0
+        assert "--resume" in calls[0][0]
+        assert "--session-id" in calls[1][0]
+        assert all(call[1]["env"].get("ANTHROPIC_API_KEY") is None for call in calls)
+        assert session_file.read_text().strip() != "stale-uuid"
+        assert "Saved session is stale; starting a new session." in caplog.text

--- a/apps/python/tests/test_chat.py
+++ b/apps/python/tests/test_chat.py
@@ -115,7 +115,7 @@ class TestRunClaude:
         assert exit_code == 0
         assert calls[0][1]["env"].get("ANTHROPIC_API_KEY") is None
 
-    def test_stale_resume_session_falls_back_to_new_session(self, tmp_path, monkeypatch, caplog):
+    def test_stale_resume_session_falls_back_to_new_session(self, tmp_path, monkeypatch, capsys):
         briefing = tmp_path / "briefing_2026-05-16.md"
         briefing.write_text("本文テスト")
         session_file = tmp_path / "2026-05-16"
@@ -141,5 +141,5 @@ class TestRunClaude:
         assert "--resume" in calls[0][0]
         assert "--session-id" in calls[1][0]
         assert all(call[1]["env"].get("ANTHROPIC_API_KEY") is None for call in calls)
-        assert session_file.read_text().strip() != "stale-uuid"
-        assert "Saved session is stale; starting a new session." in caplog.text
+        uuid.UUID(session_file.read_text().strip())
+        assert "Saved session is stale; starting a new session." in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- Detect stale saved briefing chat session IDs when claude --resume reports No conversation found
- Delete the stale session file and start a fresh Claude session automatically
- Add a regression test covering the fallback path

## Root Cause
chat.py treated the presence of output/briefing/.sessions/<date> as proof that the Claude conversation still existed. If Claude had no persisted conversation for that UUID, every later launch attempted to resume a non-existent session and failed.

## Validation
- ../../.venv/bin/python -m pytest -q from apps/python: 172 passed in 1.60s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Spawned chat subprocesses now run with sensitive API keys removed from the environment to avoid leaking credentials.

* **Bug Fixes**
  * Improved session handling: stale or invalid resumed sessions are detected, cleared, and replaced with a fresh session automatically.

* **Tests**
  * Added tests covering environment sanitization and fallback from stale resume sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KazusaNakagawa/ai-agent-cli/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->