### PR TITLE
feat(web): add credentials module and /api/credentials CRUD

### DIFF
--- a/apps/python/src/credentials.py
+++ b/apps/python/src/credentials.py
@@ -9,6 +9,7 @@
 保管されないようにするためのガード。
 """
 import os
+from typing import Any
 
 import keyring
 
@@ -21,7 +22,7 @@ ALLOWED_KEYS: tuple[str, ...] = (
     "ANTHROPIC_API_KEY",
 )
 
-_backend = keyring
+_backend: Any = keyring
 
 
 def _ensure_allowed(name: str) -> None:
@@ -34,8 +35,7 @@ def get_credential(name: str) -> str | None:
     value = _backend.get_password(SERVICE, name)
     if value:
         return value
-    env_value = os.environ.get(name)
-    return env_value if env_value else None
+    return os.environ.get(name) or None
 
 
 def set_credential(name: str, value: str) -> None:

--- a/apps/python/src/credentials.py
+++ b/apps/python/src/credentials.py
@@ -1,0 +1,52 @@
+"""OS Keychain ラッパ + .env フォールバック。
+
+`python-keyring` 経由で OS のキーチェーンに資格情報を保存する。読み出し時に
+キーチェーンが ``None`` を返した場合のみ、同名の環境変数にフォールバックする。
+書き込みは常にキーチェーンへ行う（.env は不変）。
+
+許可された名前 (`ALLOWED_KEYS`) 以外は ``ValueError``。これは
+``/api/credentials`` の入力サニタイズと、運用ミスでよく分からないキーが
+保管されないようにするためのガード。
+"""
+import os
+
+import keyring
+
+SERVICE = "ai-agent"
+ALLOWED_KEYS: tuple[str, ...] = (
+    "DISCORD_TOKEN",
+    "CHANNEL_ID",
+    "NOTION_API_KEY",
+    "NOTION_DATABASE_ID",
+    "ANTHROPIC_API_KEY",
+)
+
+_backend = keyring
+
+
+def _ensure_allowed(name: str) -> None:
+    if name not in ALLOWED_KEYS:
+        raise ValueError(f"Unknown credential key: {name}")
+
+
+def get_credential(name: str) -> str | None:
+    _ensure_allowed(name)
+    value = _backend.get_password(SERVICE, name)
+    if value:
+        return value
+    env_value = os.environ.get(name)
+    return env_value if env_value else None
+
+
+def set_credential(name: str, value: str) -> None:
+    _ensure_allowed(name)
+    _backend.set_password(SERVICE, name, value)
+
+
+def delete_credential(name: str) -> None:
+    _ensure_allowed(name)
+    _backend.delete_password(SERVICE, name)
+
+
+def list_credentials() -> dict[str, bool]:
+    return {name: get_credential(name) is not None for name in ALLOWED_KEYS}

--- a/apps/python/tests/test_api_credentials.py
+++ b/apps/python/tests/test_api_credentials.py
@@ -1,0 +1,130 @@
+"""Tests for /api/credentials — Keychain CRUD endpoints."""
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from src import credentials
+from web import auth
+from web.app import app
+
+
+@pytest.fixture(autouse=True)
+def fixed_token(monkeypatch, tmp_path):
+    token_file = tmp_path / "token"
+    token_file.write_text("test-token-123")
+    monkeypatch.setattr(auth, "TOKEN_FILE", token_file)
+    monkeypatch.setattr(auth, "_token_cache", None, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def isolated_keyring(monkeypatch):
+    store: dict[tuple[str, str], str] = {}
+
+    class _Fake:
+        def get_password(self, service, name):
+            return store.get((service, name))
+
+        def set_password(self, service, name, value):
+            store[(service, name)] = value
+
+        def delete_password(self, service, name):
+            store.pop((service, name), None)
+
+    monkeypatch.setattr(credentials, "_backend", _Fake())
+
+
+@pytest.fixture(autouse=True)
+def clear_credential_env(monkeypatch):
+    for name in credentials.ALLOWED_KEYS:
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.mark.asyncio
+async def test_get_credentials_returns_set_status():
+    credentials.set_credential("DISCORD_TOKEN", "x")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            "/api/credentials",
+            headers={"Authorization": "Bearer test-token-123"},
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["DISCORD_TOKEN"] is True
+    assert body["NOTION_API_KEY"] is False
+    assert set(body.keys()) == set(credentials.ALLOWED_KEYS)
+
+
+@pytest.mark.asyncio
+async def test_get_credentials_requires_bearer():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/api/credentials")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_put_credential_saves_value_and_returns_204():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.put(
+            "/api/credentials/NOTION_API_KEY",
+            headers={"Authorization": "Bearer test-token-123"},
+            json={"value": "secret-key"},
+        )
+    assert response.status_code == 204
+    assert credentials.get_credential("NOTION_API_KEY") == "secret-key"
+
+
+@pytest.mark.asyncio
+async def test_delete_credential_removes_value_and_returns_204():
+    credentials.set_credential("CHANNEL_ID", "123")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.delete(
+            "/api/credentials/CHANNEL_ID",
+            headers={"Authorization": "Bearer test-token-123"},
+        )
+    assert response.status_code == 204
+    assert credentials.get_credential("CHANNEL_ID") is None
+
+
+@pytest.mark.asyncio
+async def test_put_unknown_key_returns_400():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.put(
+            "/api/credentials/HACKER_KEY",
+            headers={"Authorization": "Bearer test-token-123"},
+            json={"value": "x"},
+        )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_delete_unknown_key_returns_400():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.delete(
+            "/api/credentials/HACKER_KEY",
+            headers={"Authorization": "Bearer test-token-123"},
+        )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_put_credential_requires_bearer():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.put(
+            "/api/credentials/NOTION_API_KEY",
+            json={"value": "x"},
+        )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_delete_credential_requires_bearer():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.delete("/api/credentials/NOTION_API_KEY")
+    assert response.status_code == 401

--- a/apps/python/tests/test_api_credentials.py
+++ b/apps/python/tests/test_api_credentials.py
@@ -89,6 +89,19 @@ async def test_delete_credential_removes_value_and_returns_204():
 
 
 @pytest.mark.asyncio
+async def test_put_empty_value_returns_422():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.put(
+            "/api/credentials/DISCORD_TOKEN",
+            headers={"Authorization": "Bearer test-token-123"},
+            json={"value": ""},
+        )
+    assert response.status_code == 422
+    assert credentials.get_credential("DISCORD_TOKEN") is None
+
+
+@pytest.mark.asyncio
 async def test_put_unknown_key_returns_400():
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:

--- a/apps/python/tests/test_credentials_module.py
+++ b/apps/python/tests/test_credentials_module.py
@@ -1,0 +1,78 @@
+"""Tests for src/credentials.py — Keychain wrapper with .env fallback."""
+import pytest
+
+from src import credentials
+
+
+@pytest.fixture(autouse=True)
+def isolated_keyring(monkeypatch):
+    """Replace the keyring backend with an in-memory dict."""
+    store: dict[tuple[str, str], str] = {}
+
+    class _Fake:
+        def get_password(self, service, name):
+            return store.get((service, name))
+
+        def set_password(self, service, name, value):
+            store[(service, name)] = value
+
+        def delete_password(self, service, name):
+            store.pop((service, name), None)
+
+    monkeypatch.setattr(credentials, "_backend", _Fake())
+
+
+@pytest.fixture(autouse=True)
+def clear_credential_env(monkeypatch):
+    """Strip any inherited env values for allow-listed credentials."""
+    for name in credentials.ALLOWED_KEYS:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_set_and_get_credential():
+    credentials.set_credential("DISCORD_TOKEN", "abc123")
+    assert credentials.get_credential("DISCORD_TOKEN") == "abc123"
+
+
+def test_get_returns_none_when_unset():
+    assert credentials.get_credential("NOTION_API_KEY") is None
+
+
+def test_delete_removes_credential():
+    credentials.set_credential("CHANNEL_ID", "999")
+    credentials.delete_credential("CHANNEL_ID")
+    assert credentials.get_credential("CHANNEL_ID") is None
+
+
+def test_list_returns_set_status_for_known_keys():
+    credentials.set_credential("DISCORD_TOKEN", "x")
+    listing = credentials.list_credentials()
+    assert listing["DISCORD_TOKEN"] is True
+    assert listing["NOTION_API_KEY"] is False
+    assert set(listing.keys()) == set(credentials.ALLOWED_KEYS)
+
+
+def test_env_fallback_when_keychain_returns_none(monkeypatch):
+    monkeypatch.setenv("NOTION_API_KEY", "from-env")
+    assert credentials.get_credential("NOTION_API_KEY") == "from-env"
+
+
+def test_keychain_takes_priority_over_env(monkeypatch):
+    monkeypatch.setenv("NOTION_API_KEY", "from-env")
+    credentials.set_credential("NOTION_API_KEY", "from-keychain")
+    assert credentials.get_credential("NOTION_API_KEY") == "from-keychain"
+
+
+def test_get_rejects_unknown_key():
+    with pytest.raises(ValueError):
+        credentials.get_credential("HACKER_KEY")
+
+
+def test_set_rejects_unknown_key():
+    with pytest.raises(ValueError):
+        credentials.set_credential("HACKER_KEY", "x")
+
+
+def test_delete_rejects_unknown_key():
+    with pytest.raises(ValueError):
+        credentials.delete_credential("HACKER_KEY")

--- a/apps/python/web/app.py
+++ b/apps/python/web/app.py
@@ -1,7 +1,8 @@
 from fastapi import FastAPI
 
-from web.routers import config, health
+from web.routers import config, credentials, health
 
 app = FastAPI(title="ai-agent Web API", version="0.1.0")
 app.include_router(health.router, prefix="/api")
 app.include_router(config.router, prefix="/api")
+app.include_router(credentials.router, prefix="/api")

--- a/apps/python/web/routers/credentials.py
+++ b/apps/python/web/routers/credentials.py
@@ -5,7 +5,7 @@ GET は ``{name: bool}`` の形式で各 allow-listed キーの「設定済み�
 PUT/DELETE は 204。allow-list 外のキーは 400。すべて Bearer 必須。
 """
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from src import credentials as cred_mod
 from web.auth import require_bearer
@@ -14,7 +14,7 @@ router = APIRouter()
 
 
 class CredentialBody(BaseModel):
-    value: str
+    value: str = Field(min_length=1)
 
 
 @router.get("/credentials", dependencies=[Depends(require_bearer)])

--- a/apps/python/web/routers/credentials.py
+++ b/apps/python/web/routers/credentials.py
@@ -1,0 +1,46 @@
+"""GET / PUT / DELETE /api/credentials — Keychain CRUD。
+
+GET は ``{name: bool}`` の形式で各 allow-listed キーの「設定済みか」を返す。
+値そのものは返さない（漏洩防止と、UI 側で fingerprint だけ表示するため）。
+PUT/DELETE は 204。allow-list 外のキーは 400。すべて Bearer 必須。
+"""
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+
+from src import credentials as cred_mod
+from web.auth import require_bearer
+
+router = APIRouter()
+
+
+class CredentialBody(BaseModel):
+    value: str
+
+
+@router.get("/credentials", dependencies=[Depends(require_bearer)])
+def list_credentials() -> dict[str, bool]:
+    return cred_mod.list_credentials()
+
+
+@router.put(
+    "/credentials/{name}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(require_bearer)],
+)
+def put_credential(name: str, body: CredentialBody) -> None:
+    try:
+        cred_mod.set_credential(name, body.value)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+@router.delete(
+    "/credentials/{name}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(require_bearer)],
+)
+def delete_credential(name: str) -> None:
+    try:
+        cred_mod.delete_credential(name)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e


### PR DESCRIPTION
## Summary

- `src/credentials.py`: thin wrapper around `python-keyring` with a strict allow-list (`DISCORD_TOKEN`, `CHANNEL_ID`, `NOTION_API_KEY`, `NOTION_DATABASE_ID`, `ANTHROPIC_API_KEY`). Reads fall back to the same-named env var only when the Keychain returns `None`; writes always go to the Keychain. Unknown keys raise `ValueError`.
- `web/routers/credentials.py`: `GET /api/credentials` returns `{name: bool}` set-status (never the value), `PUT /api/credentials/{name}` accepts `{"value": "..."}` and returns 204, `DELETE /api/credentials/{name}` returns 204. Unknown allow-list keys → 400. All routes require Bearer auth.
- `web/app.py`: register the new router.

## Design notes

- The set-status-only GET keeps the API safe by construction — even with a leaked bearer token, no plaintext credential leaves the host. The actual values only flow out via the Keychain to the briefing subprocess via `claude_runner._build_env(auth_mode="api")` (Task 12, future PR).
- Tests use an in-memory dict swapped in via `monkeypatch.setattr(credentials, "_backend", _Fake())` so no real Keychain access happens in CI or local pytest runs. `clear_credential_env` autouse fixture strips any host env that could otherwise satisfy a `.env`-fallback read and skew the assertion.

## Test plan

- [x] `tests/test_credentials_module.py`: 9 tests covering set/get/delete/list, env fallback, Keychain priority over env, and the 3 reject-unknown-key paths.
- [x] `tests/test_api_credentials.py`: 8 tests covering GET set-status, PUT/DELETE 204, both unknown-key 400s, and Bearer enforcement on every route.
- [x] Full suite: `cd apps/python && .venv/bin/pytest` → **190 passed** (was 173 on dev).

Closes #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)