### PR TITLE
refactor(web): centralize test fixtures and router-level auth deps

### DIFF
--- a/apps/python/tests/conftest.py
+++ b/apps/python/tests/conftest.py
@@ -1,5 +1,77 @@
 import os
 from pathlib import Path
 
-# テスト実行時は tests/config/briefing.json を使用し、本番設定を読まない
+# テスト実行時は tests/config/briefing.json を使用し、本番設定を読まない。
+# src.config の import 前に環境変数を立てる必要があるので、conftest 最上位で実行する。
 os.environ.setdefault("BRIEFING_CONFIG_PATH", str(Path(__file__).parent / "config" / "briefing.json"))
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from src import credentials
+from web import auth
+from web.app import app
+
+TEST_TOKEN = "test-token-123"
+
+
+@pytest.fixture
+def fixed_token(monkeypatch, tmp_path):
+    """Pin auth.TOKEN_FILE to a tmp path with a known token."""
+    token_file = tmp_path / "token"
+    token_file.write_text(TEST_TOKEN)
+    monkeypatch.setattr(auth, "TOKEN_FILE", token_file)
+    monkeypatch.setattr(auth, "_token_cache", None, raising=False)
+
+
+@pytest.fixture
+def isolated_keyring(monkeypatch):
+    """Swap the keyring backend for an in-memory dict so tests never touch the real Keychain."""
+    store: dict[tuple[str, str], str] = {}
+
+    class _Fake:
+        def get_password(self, service, name):
+            return store.get((service, name))
+
+        def set_password(self, service, name, value):
+            store[(service, name)] = value
+
+        def delete_password(self, service, name):
+            store.pop((service, name), None)
+
+    monkeypatch.setattr(credentials, "_backend", _Fake())
+
+
+@pytest.fixture
+def clear_credential_env(monkeypatch):
+    """Strip any inherited env values for allow-listed credentials so .env fallback can't leak in."""
+    for name in credentials.ALLOWED_KEYS:
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.fixture
+async def async_client(fixed_token):
+    """Bare httpx AsyncClient with no Authorization header. Use for 401 / unauth tests."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+@pytest.fixture
+async def authed_client(fixed_token):
+    """httpx AsyncClient pre-loaded with the test Bearer token."""
+    transport = ASGITransport(app=app)
+    headers = {"Authorization": f"Bearer {TEST_TOKEN}"}
+    async with AsyncClient(transport=transport, base_url="http://test", headers=headers) as client:
+        yield client
+
+
+@pytest.fixture
+async def authed_client_no_raise(fixed_token):
+    """Like authed_client but lets the app's unhandled exceptions bubble up as 5xx responses
+    instead of being re-raised through the ASGI transport. Use for tests that simulate
+    crash-paths inside route handlers."""
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    headers = {"Authorization": f"Bearer {TEST_TOKEN}"}
+    async with AsyncClient(transport=transport, base_url="http://test", headers=headers) as client:
+        yield client

--- a/apps/python/tests/test_api_auth.py
+++ b/apps/python/tests/test_api_auth.py
@@ -1,38 +1,20 @@
 import pytest
-from httpx import AsyncClient, ASGITransport
 
-from web.app import app
 from web import auth
 
 
-@pytest.fixture(autouse=True)
-def fixed_token(monkeypatch, tmp_path):
-    token_file = tmp_path / "token"
-    token_file.write_text("test-token-123")
-    monkeypatch.setattr(auth, "TOKEN_FILE", token_file)
-    monkeypatch.setattr(auth, "_token_cache", None, raising=False)
-
-
-@pytest.mark.asyncio
-async def test_health_does_not_require_auth():
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.get("/api/health")
+async def test_health_does_not_require_auth(async_client):
+    response = await async_client.get("/api/health")
     assert response.status_code == 200
 
 
-@pytest.mark.asyncio
-async def test_protected_route_rejects_without_bearer():
-    # /api/config is a placeholder for "auth-protected" — implemented in #45.
-    # Until then a missing route returns 404, which is still a non-200 acceptance.
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.get("/api/config")
+async def test_protected_route_rejects_without_bearer(async_client):
+    response = await async_client.get("/api/config")
     assert response.status_code in (401, 404)
 
 
 def test_token_file_has_mode_600(tmp_path, monkeypatch):
-    # Use a fresh path so the autouse fixed_token fixture doesn't pre-create it.
+    # Fresh path so the conftest fixed_token fixture doesn't pre-create it.
     token_file = tmp_path / "fresh-token"
     monkeypatch.setattr(auth, "TOKEN_FILE", token_file)
     monkeypatch.setattr(auth, "_token_cache", None, raising=False)
@@ -44,7 +26,7 @@ def test_token_file_has_mode_600(tmp_path, monkeypatch):
     assert mode == 0o600, f"expected 0o600, got {oct(mode)}"
 
 
-def test_require_bearer_rejects_missing_header():
+def test_require_bearer_rejects_missing_header(fixed_token):
     from fastapi import HTTPException
 
     with pytest.raises(HTTPException) as exc_info:
@@ -52,7 +34,7 @@ def test_require_bearer_rejects_missing_header():
     assert exc_info.value.status_code == 401
 
 
-def test_require_bearer_rejects_wrong_token():
+def test_require_bearer_rejects_wrong_token(fixed_token):
     from fastapi import HTTPException
 
     with pytest.raises(HTTPException) as exc_info:
@@ -60,5 +42,5 @@ def test_require_bearer_rejects_wrong_token():
     assert exc_info.value.status_code == 401
 
 
-def test_require_bearer_accepts_correct_token():
+def test_require_bearer_accepts_correct_token(fixed_token):
     auth.require_bearer(authorization="Bearer test-token-123")

--- a/apps/python/tests/test_api_config.py
+++ b/apps/python/tests/test_api_config.py
@@ -1,18 +1,6 @@
 import json
 
 import pytest
-from httpx import AsyncClient, ASGITransport
-
-from web.app import app
-from web import auth
-
-
-@pytest.fixture(autouse=True)
-def fixed_token(monkeypatch, tmp_path):
-    token_file = tmp_path / "token"
-    token_file.write_text("test-token-123")
-    monkeypatch.setattr(auth, "TOKEN_FILE", token_file)
-    monkeypatch.setattr(auth, "_token_cache", None, raising=False)
 
 
 @pytest.fixture
@@ -29,116 +17,78 @@ def temp_config(monkeypatch, tmp_path):
     yield config_path
 
 
-@pytest.mark.asyncio
-async def test_get_config_returns_current(temp_config):
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.get(
-            "/api/config",
-            headers={"Authorization": "Bearer test-token-123"},
-        )
+async def test_get_config_returns_current(authed_client, temp_config):
+    response = await authed_client.get("/api/config")
     assert response.status_code == 200
     body = response.json()
     assert body["portfolio"]["tickers"] == ["PLTR"]
 
 
-@pytest.mark.asyncio
-async def test_get_config_requires_bearer(temp_config):
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.get("/api/config")
+async def test_get_config_requires_bearer(async_client, temp_config):
+    response = await async_client.get("/api/config")
     assert response.status_code == 401
 
 
-@pytest.mark.asyncio
-async def test_put_config_updates_file(temp_config):
+async def test_put_config_updates_file(authed_client, temp_config):
     new_config = {
         "portfolio": {"tickers": ["NVDA", "AMZN"], "themes": ["Cloud"]},
         "geopolitical": {"conflicts": []},
         "watch_sectors": [{"sector": "Cloud", "tickers": ["MSFT"], "notes": None}],
         "watch_events": [],
     }
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.put(
-            "/api/config",
-            headers={"Authorization": "Bearer test-token-123"},
-            json=new_config,
-        )
+    response = await authed_client.put("/api/config", json=new_config)
     assert response.status_code == 200
     saved = json.loads(temp_config.read_text(encoding="utf-8"))
     assert saved["portfolio"]["tickers"] == ["NVDA", "AMZN"]
 
 
-@pytest.mark.asyncio
-async def test_put_config_rejects_empty_tickers(temp_config):
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.put(
-            "/api/config",
-            headers={"Authorization": "Bearer test-token-123"},
-            json={
-                "portfolio": {"tickers": [], "themes": []},
-                "watch_sectors": [{"sector": "AI", "tickers": ["NVDA"], "notes": None}],
-            },
-        )
+async def test_put_config_rejects_empty_tickers(authed_client, temp_config):
+    response = await authed_client.put(
+        "/api/config",
+        json={
+            "portfolio": {"tickers": [], "themes": []},
+            "watch_sectors": [{"sector": "AI", "tickers": ["NVDA"], "notes": None}],
+        },
+    )
     assert response.status_code == 422
 
 
-@pytest.mark.asyncio
-async def test_put_config_rejects_empty_watch_sectors(temp_config):
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.put(
-            "/api/config",
-            headers={"Authorization": "Bearer test-token-123"},
-            json={
-                "portfolio": {"tickers": ["PLTR"], "themes": ["AI"]},
-                "watch_sectors": [],
-            },
-        )
+async def test_put_config_rejects_empty_watch_sectors(authed_client, temp_config):
+    response = await authed_client.put(
+        "/api/config",
+        json={
+            "portfolio": {"tickers": ["PLTR"], "themes": ["AI"]},
+            "watch_sectors": [],
+        },
+    )
     assert response.status_code == 422
 
 
-@pytest.mark.asyncio
-async def test_put_config_requires_bearer(temp_config):
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.put("/api/config", json={})
+async def test_put_config_requires_bearer(async_client, temp_config):
+    response = await async_client.put("/api/config", json={})
     assert response.status_code == 401
 
 
-@pytest.mark.asyncio
-async def test_get_config_returns_500_on_corrupt_json(temp_config):
+async def test_get_config_returns_500_on_corrupt_json(authed_client, temp_config):
     temp_config.write_text("not json {{{", encoding="utf-8")
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.get(
-            "/api/config",
-            headers={"Authorization": "Bearer test-token-123"},
-        )
+    response = await authed_client.get("/api/config")
     assert response.status_code == 500
     assert "corrupt" in response.json()["detail"].lower()
 
 
-@pytest.mark.asyncio
-async def test_get_config_returns_500_on_schema_mismatch(temp_config):
+async def test_get_config_returns_500_on_schema_mismatch(authed_client, temp_config):
     temp_config.write_text(
         json.dumps({"portfolio": "not-an-object", "watch_sectors": []}),
         encoding="utf-8",
     )
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.get(
-            "/api/config",
-            headers={"Authorization": "Bearer test-token-123"},
-        )
+    response = await authed_client.get("/api/config")
     assert response.status_code == 500
     assert "schema" in response.json()["detail"].lower()
 
 
-@pytest.mark.asyncio
-async def test_put_config_leaves_no_tmp_file_on_failure(monkeypatch, temp_config):
+async def test_put_config_leaves_no_tmp_file_on_failure(
+    authed_client_no_raise, monkeypatch, temp_config
+):
     """When the atomic write fails mid-flight, no .tmp file may remain."""
 
     def _boom(src, dst):
@@ -152,13 +102,7 @@ async def test_put_config_leaves_no_tmp_file_on_failure(monkeypatch, temp_config
         "watch_sectors": [{"sector": "AI", "tickers": ["NVDA"], "notes": None}],
         "watch_events": [],
     }
-    transport = ASGITransport(app=app, raise_app_exceptions=False)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.put(
-            "/api/config",
-            headers={"Authorization": "Bearer test-token-123"},
-            json=payload,
-        )
+    response = await authed_client_no_raise.put("/api/config", json=payload)
     assert response.status_code >= 500
     leftover = [p for p in temp_config.parent.iterdir() if p.suffix == ".tmp"]
     assert leftover == [], f"tmp file not cleaned up: {leftover}"

--- a/apps/python/tests/test_api_credentials.py
+++ b/apps/python/tests/test_api_credentials.py
@@ -1,52 +1,14 @@
 """Tests for /api/credentials — Keychain CRUD endpoints."""
 import pytest
-from httpx import AsyncClient, ASGITransport
 
 from src import credentials
-from web import auth
-from web.app import app
+
+pytestmark = pytest.mark.usefixtures("isolated_keyring", "clear_credential_env")
 
 
-@pytest.fixture(autouse=True)
-def fixed_token(monkeypatch, tmp_path):
-    token_file = tmp_path / "token"
-    token_file.write_text("test-token-123")
-    monkeypatch.setattr(auth, "TOKEN_FILE", token_file)
-    monkeypatch.setattr(auth, "_token_cache", None, raising=False)
-
-
-@pytest.fixture(autouse=True)
-def isolated_keyring(monkeypatch):
-    store: dict[tuple[str, str], str] = {}
-
-    class _Fake:
-        def get_password(self, service, name):
-            return store.get((service, name))
-
-        def set_password(self, service, name, value):
-            store[(service, name)] = value
-
-        def delete_password(self, service, name):
-            store.pop((service, name), None)
-
-    monkeypatch.setattr(credentials, "_backend", _Fake())
-
-
-@pytest.fixture(autouse=True)
-def clear_credential_env(monkeypatch):
-    for name in credentials.ALLOWED_KEYS:
-        monkeypatch.delenv(name, raising=False)
-
-
-@pytest.mark.asyncio
-async def test_get_credentials_returns_set_status():
+async def test_get_credentials_returns_set_status(authed_client):
     credentials.set_credential("DISCORD_TOKEN", "x")
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.get(
-            "/api/credentials",
-            headers={"Authorization": "Bearer test-token-123"},
-        )
+    response = await authed_client.get("/api/credentials")
     assert response.status_code == 200
     body = response.json()
     assert body["DISCORD_TOKEN"] is True
@@ -54,90 +16,57 @@ async def test_get_credentials_returns_set_status():
     assert set(body.keys()) == set(credentials.ALLOWED_KEYS)
 
 
-@pytest.mark.asyncio
-async def test_get_credentials_requires_bearer():
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.get("/api/credentials")
+async def test_get_credentials_requires_bearer(async_client):
+    response = await async_client.get("/api/credentials")
     assert response.status_code == 401
 
 
-@pytest.mark.asyncio
-async def test_put_credential_saves_value_and_returns_204():
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.put(
-            "/api/credentials/NOTION_API_KEY",
-            headers={"Authorization": "Bearer test-token-123"},
-            json={"value": "secret-key"},
-        )
+async def test_put_credential_saves_value_and_returns_204(authed_client):
+    response = await authed_client.put(
+        "/api/credentials/NOTION_API_KEY",
+        json={"value": "secret-key"},
+    )
     assert response.status_code == 204
     assert credentials.get_credential("NOTION_API_KEY") == "secret-key"
 
 
-@pytest.mark.asyncio
-async def test_delete_credential_removes_value_and_returns_204():
+async def test_delete_credential_removes_value_and_returns_204(authed_client):
     credentials.set_credential("CHANNEL_ID", "123")
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.delete(
-            "/api/credentials/CHANNEL_ID",
-            headers={"Authorization": "Bearer test-token-123"},
-        )
+    response = await authed_client.delete("/api/credentials/CHANNEL_ID")
     assert response.status_code == 204
     assert credentials.get_credential("CHANNEL_ID") is None
 
 
-@pytest.mark.asyncio
-async def test_put_empty_value_returns_422():
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.put(
-            "/api/credentials/DISCORD_TOKEN",
-            headers={"Authorization": "Bearer test-token-123"},
-            json={"value": ""},
-        )
+async def test_put_empty_value_returns_422(authed_client):
+    response = await authed_client.put(
+        "/api/credentials/DISCORD_TOKEN",
+        json={"value": ""},
+    )
     assert response.status_code == 422
     assert credentials.get_credential("DISCORD_TOKEN") is None
 
 
-@pytest.mark.asyncio
-async def test_put_unknown_key_returns_400():
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.put(
-            "/api/credentials/HACKER_KEY",
-            headers={"Authorization": "Bearer test-token-123"},
-            json={"value": "x"},
-        )
+async def test_put_unknown_key_returns_400(authed_client):
+    response = await authed_client.put(
+        "/api/credentials/HACKER_KEY",
+        json={"value": "x"},
+    )
     assert response.status_code == 400
 
 
-@pytest.mark.asyncio
-async def test_delete_unknown_key_returns_400():
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.delete(
-            "/api/credentials/HACKER_KEY",
-            headers={"Authorization": "Bearer test-token-123"},
-        )
+async def test_delete_unknown_key_returns_400(authed_client):
+    response = await authed_client.delete("/api/credentials/HACKER_KEY")
     assert response.status_code == 400
 
 
-@pytest.mark.asyncio
-async def test_put_credential_requires_bearer():
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.put(
-            "/api/credentials/NOTION_API_KEY",
-            json={"value": "x"},
-        )
+async def test_put_credential_requires_bearer(async_client):
+    response = await async_client.put(
+        "/api/credentials/NOTION_API_KEY",
+        json={"value": "x"},
+    )
     assert response.status_code == 401
 
 
-@pytest.mark.asyncio
-async def test_delete_credential_requires_bearer():
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.delete("/api/credentials/NOTION_API_KEY")
+async def test_delete_credential_requires_bearer(async_client):
+    response = await async_client.delete("/api/credentials/NOTION_API_KEY")
     assert response.status_code == 401

--- a/apps/python/tests/test_api_health.py
+++ b/apps/python/tests/test_api_health.py
@@ -1,13 +1,4 @@
-import pytest
-from httpx import AsyncClient, ASGITransport
-
-from web.app import app
-
-
-@pytest.mark.asyncio
-async def test_health_returns_ok():
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.get("/api/health")
+async def test_health_returns_ok(async_client):
+    response = await async_client.get("/api/health")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}

--- a/apps/python/tests/test_credentials_module.py
+++ b/apps/python/tests/test_credentials_module.py
@@ -3,30 +3,7 @@ import pytest
 
 from src import credentials
 
-
-@pytest.fixture(autouse=True)
-def isolated_keyring(monkeypatch):
-    """Replace the keyring backend with an in-memory dict."""
-    store: dict[tuple[str, str], str] = {}
-
-    class _Fake:
-        def get_password(self, service, name):
-            return store.get((service, name))
-
-        def set_password(self, service, name, value):
-            store[(service, name)] = value
-
-        def delete_password(self, service, name):
-            store.pop((service, name), None)
-
-    monkeypatch.setattr(credentials, "_backend", _Fake())
-
-
-@pytest.fixture(autouse=True)
-def clear_credential_env(monkeypatch):
-    """Strip any inherited env values for allow-listed credentials."""
-    for name in credentials.ALLOWED_KEYS:
-        monkeypatch.delenv(name, raising=False)
+pytestmark = pytest.mark.usefixtures("isolated_keyring", "clear_credential_env")
 
 
 def test_set_and_get_credential():

--- a/apps/python/web/routers/config.py
+++ b/apps/python/web/routers/config.py
@@ -17,7 +17,7 @@ from pydantic import ValidationError
 from web.auth import require_bearer
 from web.schemas import BriefingConfigSchema
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(require_bearer)])
 
 
 def _config_path() -> Path:
@@ -29,11 +29,7 @@ def _config_path() -> Path:
     )
 
 
-@router.get(
-    "/config",
-    response_model=BriefingConfigSchema,
-    dependencies=[Depends(require_bearer)],
-)
+@router.get("/config", response_model=BriefingConfigSchema)
 def get_config() -> BriefingConfigSchema:
     path = _config_path()
     if not path.exists():
@@ -51,7 +47,7 @@ def get_config() -> BriefingConfigSchema:
         ) from e
 
 
-@router.put("/config", dependencies=[Depends(require_bearer)])
+@router.put("/config")
 def put_config(payload: BriefingConfigSchema) -> dict:
     path = _config_path()
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/apps/python/web/routers/credentials.py
+++ b/apps/python/web/routers/credentials.py
@@ -10,23 +10,19 @@ from pydantic import BaseModel, Field
 from src import credentials as cred_mod
 from web.auth import require_bearer
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(require_bearer)])
 
 
 class CredentialBody(BaseModel):
     value: str = Field(min_length=1)
 
 
-@router.get("/credentials", dependencies=[Depends(require_bearer)])
+@router.get("/credentials")
 def list_credentials() -> dict[str, bool]:
     return cred_mod.list_credentials()
 
 
-@router.put(
-    "/credentials/{name}",
-    status_code=status.HTTP_204_NO_CONTENT,
-    dependencies=[Depends(require_bearer)],
-)
+@router.put("/credentials/{name}", status_code=status.HTTP_204_NO_CONTENT)
 def put_credential(name: str, body: CredentialBody) -> None:
     try:
         cred_mod.set_credential(name, body.value)
@@ -34,11 +30,7 @@ def put_credential(name: str, body: CredentialBody) -> None:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
 
-@router.delete(
-    "/credentials/{name}",
-    status_code=status.HTTP_204_NO_CONTENT,
-    dependencies=[Depends(require_bearer)],
-)
+@router.delete("/credentials/{name}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_credential(name: str) -> None:
     try:
         cred_mod.delete_credential(name)


### PR DESCRIPTION
## Summary

Three small follow-ups identified while reviewing #55. Pure refactor — no behavior change, 191 tests still pass.

### 1. Centralize repeated test fixtures in `conftest.py`
- `fixed_token`: was duplicated in `test_api_auth.py`, `test_api_config.py`, `test_api_credentials.py`.
- `isolated_keyring`: was duplicated in `test_credentials_module.py`, `test_api_credentials.py`.
- `clear_credential_env`: same two files.

Each test file now opts in via `pytestmark = pytest.mark.usefixtures(...)` or by taking the fixture as a parameter.

### 2. Add HTTP client fixtures
- `async_client` — bare `httpx.AsyncClient` (for 401 / unauth tests).
- `authed_client` — same client pre-loaded with the test Bearer header.
- `authed_client_no_raise` — variant with `raise_app_exceptions=False` for tests that simulate crash-paths inside handlers (currently just `test_put_config_leaves_no_tmp_file_on_failure`).

Each API test now reads as one to three lines instead of five-plus of `ASGITransport` / `AsyncClient` context-manager boilerplate.

### 3. Pull `require_bearer` up to the router level
For both `web/routers/config.py` and `web/routers/credentials.py`:

```python
router = APIRouter(dependencies=[Depends(require_bearer)])
```

Drops five inline `dependencies=[Depends(require_bearer)]` declarations and removes the per-route foot-gun: any new route added to those routers is auth-protected by default.

## Diff stat

```
8 files changed, 154 insertions(+), 271 deletions(-)
```

Net 117 lines removed — conftest grew by ~74, but test files shed ~191.

## Test plan

- [x] `cd apps/python && .venv/bin/pytest` → **191 passed** (same as dev).
- [x] No production code path touched except the two router init lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)