### PR TITLE
feat: add bin/serve.sh to launch the Web API

### DIFF
--- a/apps/python/bin/serve.sh
+++ b/apps/python/bin/serve.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PYTHON_APP="$(dirname "$SCRIPT_DIR")"
+
+UVICORN="$PYTHON_APP/.venv/bin/uvicorn"
+if [ ! -x "$UVICORN" ]; then
+    echo "error: uvicorn not found at $UVICORN" >&2
+    echo "       run: cd apps/python && uv pip sync requirements.txt" >&2
+    exit 1
+fi
+
+# .env is sourced by the repo-root wrapper (../../bin/serve.sh) before exec.
+# PORT overridable so a second instance can dodge a collision without forking.
+PORT="${PORT:-8000}"
+
+TOKEN_FILE="$HOME/.ai-agent/session-token"
+if [ -f "$TOKEN_FILE" ]; then
+    TOKEN_HINT="cat $TOKEN_FILE"
+else
+    TOKEN_HINT="will be created at $TOKEN_FILE on the first authed request"
+fi
+
+echo "Starting ai-agent Web API at http://127.0.0.1:$PORT"
+echo "Bearer token: $TOKEN_HINT"
+
+cd "$PYTHON_APP"
+# --reload-dir scoped to app code so saving a test file doesn't bounce the server.
+exec "$UVICORN" web.app:app \
+    --host 127.0.0.1 \
+    --port "$PORT" \
+    --reload \
+    --reload-dir web \
+    --reload-dir src

--- a/bin/serve.sh
+++ b/bin/serve.sh
@@ -1,18 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
-PYTHON_APP="$PROJECT_ROOT/apps/python"
 
-UVICORN="$PYTHON_APP/.venv/bin/uvicorn"
-if [ ! -x "$UVICORN" ]; then
-    echo "error: uvicorn not found at $UVICORN" >&2
-    echo "       run: cd apps/python && uv pip sync requirements.txt" >&2
-    exit 1
-fi
-
-# .env loads the same way root bin/run.sh does — so launch parity is preserved.
 ENV_FILE="$PROJECT_ROOT/.env"
 if [ -f "$ENV_FILE" ]; then
     set -a
@@ -21,14 +11,4 @@ if [ -f "$ENV_FILE" ]; then
     set +a
 fi
 
-TOKEN_FILE="$HOME/.ai-agent/session-token"
-TOKEN_DISPLAY="(generated on first request)"
-if [ -f "$TOKEN_FILE" ]; then
-    TOKEN_DISPLAY="$(cat "$TOKEN_FILE")"
-fi
-
-echo "Starting ai-agent Web API at http://127.0.0.1:8000"
-echo "Bearer token: $TOKEN_DISPLAY"
-
-cd "$PYTHON_APP"
-exec "$UVICORN" web.app:app --host 127.0.0.1 --port 8000 --reload
+exec "$PROJECT_ROOT/apps/python/bin/serve.sh" "$@"

--- a/bin/serve.sh
+++ b/bin/serve.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+PYTHON_APP="$PROJECT_ROOT/apps/python"
+
+UVICORN="$PYTHON_APP/.venv/bin/uvicorn"
+if [ ! -x "$UVICORN" ]; then
+    echo "error: uvicorn not found at $UVICORN" >&2
+    echo "       run: cd apps/python && uv pip sync requirements.txt" >&2
+    exit 1
+fi
+
+# .env loads the same way root bin/run.sh does — so launch parity is preserved.
+ENV_FILE="$PROJECT_ROOT/.env"
+if [ -f "$ENV_FILE" ]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "$ENV_FILE"
+    set +a
+fi
+
+TOKEN_FILE="$HOME/.ai-agent/session-token"
+TOKEN_DISPLAY="(generated on first request)"
+if [ -f "$TOKEN_FILE" ]; then
+    TOKEN_DISPLAY="$(cat "$TOKEN_FILE")"
+fi
+
+echo "Starting ai-agent Web API at http://127.0.0.1:8000"
+echo "Bearer token: $TOKEN_DISPLAY"
+
+cd "$PYTHON_APP"
+exec "$UVICORN" web.app:app --host 127.0.0.1 --port 8000 --reload


### PR DESCRIPTION
## Summary

Phase 1 Plan A Task 13 — the final task in the backend foundation epic. One-shot launcher script:

- Discovers project root from the script location (so it works regardless of cwd).
- Loads `.env` via `set -a; source; set +a` — same pattern as `bin/run.sh`, so launch parity is preserved.
- Prints the session token (or `(generated on first request)` if `~/.ai-agent/session-token` doesn't exist yet — `auth.py` lazy-creates it on the first authed request).
- `exec`s `uvicorn web.app:app --host 127.0.0.1 --port 8000 --reload`. Localhost-only binding keeps the API off the network.
- Pre-flight check: if `.venv/bin/uvicorn` is missing, fail loudly with the fix command (`uv pip sync requirements.txt`) instead of a confusing exec error.

## Test plan

Smoke test against the locally running server:

- [x] `bin/serve.sh` boots Uvicorn on `127.0.0.1:8000` and prints the bearer token.
- [x] `curl http://127.0.0.1:8000/api/health` → `{"status":"ok"}` (no auth).
- [x] `curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8000/api/credentials` → `{"DISCORD_TOKEN": false, "CHANNEL_ID": false, ...}` set-status map.
- [x] `curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8000/api/auth/mode` → `{"auth_mode":"cli"}` (default).
- [x] `curl http://127.0.0.1:8000/api/config` (no bearer) → `401`.
- [x] `bash -n bin/serve.sh` passes syntax check.

Closes #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added startup scripts to simplify local development and testing of the web API service with automatic environment configuration, dependency verification, and hot-reload capabilities for faster iteration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KazusaNakagawa/ai-agent-cli/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->