### PR TITLE
fix: lazy-load CONFIG so web server boots without briefing.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ bin/chat.sh                    # Launch chat session
 
   If you add new subprocess calls to claude, route them through `_build_env(state.read_state().auth_mode)` so they honor the same toggle. Never set `ANTHROPIC_API_KEY` directly in the subprocess env outside this helper.
 - **`apps/python/requirements.txt` is auto-generated** — only edit `requirements.in`, then recompile.
-- **`CONFIG = load_config()`** runs at import time in `apps/python/src/config.py`. Tests that call `load_config()` directly must patch `src.config.CONFIG_PATH`.
+- **`src.config.CONFIG` is lazy.** A module-level `__getattr__` calls `load_config()` on the first attribute access — importing `src.config` itself does **not** read `briefing.json`. This is what lets the FastAPI web server boot before `briefing.json` exists (the operator creates it via `PUT /api/config`). Batch jobs that dereference `CONFIG.portfolio` etc. still get a clear `FileNotFoundError` at first use if the file is missing. Tests that call `load_config()` directly must patch `src.config.CONFIG_PATH`.
 
 ## Config File Rules
 

--- a/apps/python/src/config.py
+++ b/apps/python/src/config.py
@@ -110,7 +110,25 @@ def load_config() -> BriefingConfig:
         ) from e
 
 
-CONFIG = load_config()
+_CONFIG_CACHE: BriefingConfig | None = None
+
+
+def __getattr__(name: str) -> BriefingConfig:
+    """Lazy-evaluate ``CONFIG`` on first attribute access (PEP 562).
+
+    Importing ``src.config`` no longer reads ``briefing.json`` at module-load
+    time. The FastAPI web server can boot before that file exists — which is
+    the whole point of ``/api/config`` (the operator manages the file via the
+    API). Batch jobs that actually dereference ``CONFIG.portfolio`` etc. still
+    hit ``FileNotFoundError`` at first access if the file is missing, which is
+    the correct behavior for them — the briefing can't run without it.
+    """
+    if name == "CONFIG":
+        global _CONFIG_CACHE
+        if _CONFIG_CACHE is None:
+            _CONFIG_CACHE = load_config()
+        return _CONFIG_CACHE
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 # XSS configs stay as dataclasses intentionally — they have no /api/config

--- a/apps/python/tests/test_config.py
+++ b/apps/python/tests/test_config.py
@@ -1,4 +1,8 @@
 import json
+import os
+import subprocess
+import sys
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -101,3 +105,34 @@ class TestLoadConfig:
             config = load_config()
 
         assert config.watch_events == []
+
+    def test_importing_src_config_does_not_eagerly_read_file(self, tmp_path):
+        """Regression: importing src.config must not read briefing.json at
+        module-load time. The FastAPI web server (web.app → web.routers.config
+        → web.schemas → src.config) needs to boot before briefing.json exists
+        — its whole purpose is to let the operator create that file via
+        /api/config. Spawning a fresh interpreter so this test doesn't depend
+        on whatever state src.config is already in for the current process."""
+        missing = tmp_path / "definitely-missing.json"
+        assert not missing.exists()
+
+        env = {**os.environ, "BRIEFING_CONFIG_PATH": str(missing)}
+        apps_python = Path(__file__).parent.parent  # apps/python
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import src.config; from web.app import app; print('imported-ok')",
+            ],
+            env=env,
+            cwd=apps_python,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        assert result.returncode == 0, (
+            f"importing failed unexpectedly\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        assert "imported-ok" in result.stdout


### PR DESCRIPTION
## Summary

Hotfix for a regression introduced by #59.

**Repro** (`dev` branch, no `apps/python/config/briefing.json` on disk):

```
$ ./bin/serve.sh
Starting ai-agent Web API at http://127.0.0.1:8000
Bearer token: cat /Users/.../session-token
...
FileNotFoundError: [Errno 2] No such file or directory:
'/Users/.../apps/python/config/briefing.json'
```

## Root cause

After #59, `web/schemas.py` re-exports from `src.config`. Importing `web.app` (which uvicorn does on boot) walks `web.routers.config` → `web.schemas` → `src.config` and triggers `src/config.py`'s module-top `CONFIG = load_config()`, which reads `briefing.json`.

Before #59, `web/schemas.py` defined its own Pydantic models with no `src.config` import, so the web server happily booted without `briefing.json` — which is the **whole point** of `/api/config` (the operator creates that file via PUT, after first boot).

## Fix

Replace the module-level `CONFIG = load_config()` with a PEP 562 `__getattr__` that evaluates `CONFIG` lazily on first attribute access and caches it:

```python
_CONFIG_CACHE: BriefingConfig | None = None

def __getattr__(name: str) -> BriefingConfig:
    if name == "CONFIG":
        global _CONFIG_CACHE
        if _CONFIG_CACHE is None:
            _CONFIG_CACHE = load_config()
        return _CONFIG_CACHE
    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
```

Effect:
- `import src.config` (or `from src.config import BriefingConfig`) **does not** read `briefing.json`. Web server boots clean.
- `from src.config import CONFIG` in batch jobs (`handler.py`, `weekly_handler.py`) still works — `__getattr__` fires once on first lookup and caches.
- If `briefing.json` is missing when a batch job actually dereferences `CONFIG.portfolio`, it still gets a clean `FileNotFoundError` (correct behavior — the briefing can't run without the file).

## Test plan

- [x] `test_importing_src_config_does_not_eagerly_read_file` — new regression test. Spawns a fresh Python interpreter with `BRIEFING_CONFIG_PATH=<missing>` and asserts `import src.config; from web.app import app` succeeds. Catches this exact regression if it recurs.
- [x] Full suite: 215 passed (was 214; +1 regression test).
- [x] Manual smoke: removed `apps/python/config/briefing.json`, ran `./bin/serve.sh`. Server booted cleanly, `/api/health` → 200, `/api/config` → 404 (expected, file missing), `/api/credentials` → set-status map.

CLAUDE.md "Key Implementation Notes" updated to document the lazy-load semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)