### PR TITLE
feat(web): add /api/run for async briefing execution

### DIFF
--- a/apps/python/src/job_store.py
+++ b/apps/python/src/job_store.py
@@ -1,0 +1,85 @@
+"""In-memory store for briefing run jobs.
+
+Phase 1 assumes a single uvicorn process, so a plain ``dict`` guarded by a
+``threading.Lock`` is sufficient. Phase 2 (multi-worker deployment) would
+need to swap this for Redis or similar — keep the API narrow so that swap
+stays local.
+"""
+import threading
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Literal
+
+JobStatus = Literal["pending", "running", "done", "failed"]
+
+
+@dataclass
+class Job:
+    job_id: str
+    status: JobStatus
+    dry_run: bool = False
+    started_at: str | None = None
+    finished_at: str | None = None
+    error: str | None = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+_lock = threading.Lock()
+_store: dict[str, Job] = {}
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def create_job(dry_run: bool = False) -> Job:
+    job_id = str(uuid.uuid4())
+    job = Job(job_id=job_id, status="pending", dry_run=dry_run)
+    with _lock:
+        _store[job_id] = job
+    return job
+
+
+def get_job(job_id: str) -> Job | None:
+    with _lock:
+        return _store.get(job_id)
+
+
+def mark_running(job_id: str) -> Job | None:
+    with _lock:
+        job = _store.get(job_id)
+        if not job:
+            return None
+        job.status = "running"
+        job.started_at = _now_iso()
+        return job
+
+
+def mark_done(job_id: str) -> Job | None:
+    with _lock:
+        job = _store.get(job_id)
+        if not job:
+            return None
+        job.status = "done"
+        job.finished_at = _now_iso()
+        return job
+
+
+def mark_failed(job_id: str, error: str) -> Job | None:
+    with _lock:
+        job = _store.get(job_id)
+        if not job:
+            return None
+        job.status = "failed"
+        job.finished_at = _now_iso()
+        job.error = error
+        return job
+
+
+def _reset_for_tests() -> None:
+    """Test-only: clear the store so individual tests don't see each other's jobs."""
+    with _lock:
+        _store.clear()

--- a/apps/python/tests/test_api_run.py
+++ b/apps/python/tests/test_api_run.py
@@ -1,0 +1,125 @@
+"""Tests for /api/run and /api/run/{job_id}."""
+import uuid
+
+import pytest
+
+from src import job_store
+
+
+@pytest.fixture(autouse=True)
+def reset_store():
+    job_store._reset_for_tests()
+    yield
+
+
+@pytest.fixture(autouse=True)
+def mock_handler(monkeypatch):
+    """No-op handler so tests don't actually generate briefings.
+
+    Individual tests that need a different mock (e.g. raising) re-monkeypatch
+    after this autouse fixture has run."""
+    monkeypatch.setattr("src.handler.lambda_handler", lambda **kwargs: None)
+
+
+async def test_post_run_returns_202_with_job_id(authed_client):
+    response = await authed_client.post("/api/run")
+    assert response.status_code == 202
+    body = response.json()
+    assert body["status"] == "pending"
+    uuid.UUID(body["job_id"])
+
+
+async def test_post_run_dry_run_query_param_persists(authed_client):
+    response = await authed_client.post("/api/run?dry_run=true")
+    assert response.status_code == 202
+    job_id = response.json()["job_id"]
+    saved = job_store.get_job(job_id)
+    assert saved.dry_run is True
+
+
+async def test_post_run_default_dry_run_is_false(authed_client):
+    response = await authed_client.post("/api/run")
+    job_id = response.json()["job_id"]
+    saved = job_store.get_job(job_id)
+    assert saved.dry_run is False
+
+
+async def test_post_run_invokes_handler_with_dry_run_flag(authed_client, monkeypatch):
+    calls = []
+
+    def fake_handler(**kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr("src.handler.lambda_handler", fake_handler)
+
+    await authed_client.post("/api/run?dry_run=true")
+    assert calls == [{"dry_run": True}]
+
+
+async def test_post_run_success_marks_status_done(authed_client):
+    response = await authed_client.post("/api/run")
+    job_id = response.json()["job_id"]
+    saved = job_store.get_job(job_id)
+    assert saved.status == "done"
+    assert saved.started_at is not None
+    assert saved.finished_at is not None
+
+
+async def test_post_run_failure_marks_status_failed(authed_client, monkeypatch):
+    def boom(**kwargs):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr("src.handler.lambda_handler", boom)
+
+    response = await authed_client.post("/api/run")
+    job_id = response.json()["job_id"]
+
+    saved = job_store.get_job(job_id)
+    assert saved.status == "failed"
+    assert saved.error == "kaboom"
+    assert saved.finished_at is not None
+
+
+async def test_get_run_returns_404_for_unknown(authed_client):
+    response = await authed_client.get("/api/run/does-not-exist")
+    assert response.status_code == 404
+
+
+async def test_get_run_returns_status_and_fields(authed_client):
+    post_resp = await authed_client.post("/api/run")
+    job_id = post_resp.json()["job_id"]
+
+    get_resp = await authed_client.get(f"/api/run/{job_id}")
+    assert get_resp.status_code == 200
+    body = get_resp.json()
+    assert body["job_id"] == job_id
+    assert body["status"] == "done"
+    assert body["started_at"] is not None
+    assert body["finished_at"] is not None
+    assert body["dry_run"] is False
+    assert body["error"] is None
+
+
+async def test_get_run_exposes_error_on_failure(authed_client, monkeypatch):
+    def boom(**kwargs):
+        raise RuntimeError("Discord credentials missing")
+
+    monkeypatch.setattr("src.handler.lambda_handler", boom)
+
+    post_resp = await authed_client.post("/api/run")
+    job_id = post_resp.json()["job_id"]
+
+    get_resp = await authed_client.get(f"/api/run/{job_id}")
+    body = get_resp.json()
+    assert body["status"] == "failed"
+    assert body["error"] == "Discord credentials missing"
+
+
+async def test_post_run_requires_bearer(async_client):
+    response = await async_client.post("/api/run")
+    assert response.status_code == 401
+
+
+async def test_get_run_requires_bearer(async_client):
+    response = await async_client.get("/api/run/some-id")
+    assert response.status_code == 401

--- a/apps/python/tests/test_job_store.py
+++ b/apps/python/tests/test_job_store.py
@@ -1,0 +1,86 @@
+"""Tests for src/job_store.py — in-memory briefing run job store."""
+import uuid
+
+import pytest
+
+from src import job_store
+
+
+@pytest.fixture(autouse=True)
+def reset_store():
+    job_store._reset_for_tests()
+    yield
+
+
+def test_create_job_returns_pending_with_uuid():
+    job = job_store.create_job()
+    assert job.status == "pending"
+    assert job.dry_run is False
+    uuid.UUID(job.job_id)  # raises if not a valid UUID
+
+
+def test_create_job_with_dry_run_flag():
+    job = job_store.create_job(dry_run=True)
+    assert job.dry_run is True
+
+
+def test_create_job_returns_unique_ids():
+    j1 = job_store.create_job()
+    j2 = job_store.create_job()
+    assert j1.job_id != j2.job_id
+
+
+def test_get_returns_none_for_unknown():
+    assert job_store.get_job("does-not-exist") is None
+
+
+def test_get_returns_created_job():
+    j = job_store.create_job()
+    same = job_store.get_job(j.job_id)
+    assert same is j
+
+
+def test_mark_running_sets_status_and_started_at():
+    j = job_store.create_job()
+    job_store.mark_running(j.job_id)
+    refreshed = job_store.get_job(j.job_id)
+    assert refreshed.status == "running"
+    assert refreshed.started_at is not None
+
+
+def test_mark_done_sets_finished_at():
+    j = job_store.create_job()
+    job_store.mark_running(j.job_id)
+    job_store.mark_done(j.job_id)
+    refreshed = job_store.get_job(j.job_id)
+    assert refreshed.status == "done"
+    assert refreshed.finished_at is not None
+
+
+def test_mark_failed_sets_error_and_finished_at():
+    j = job_store.create_job()
+    job_store.mark_failed(j.job_id, "boom")
+    refreshed = job_store.get_job(j.job_id)
+    assert refreshed.status == "failed"
+    assert refreshed.error == "boom"
+    assert refreshed.finished_at is not None
+
+
+def test_state_transitions_for_unknown_job_return_none():
+    assert job_store.mark_running("nope") is None
+    assert job_store.mark_done("nope") is None
+    assert job_store.mark_failed("nope", "x") is None
+
+
+def test_to_dict_serializes_all_fields():
+    j = job_store.create_job(dry_run=True)
+    job_store.mark_failed(j.job_id, "err")
+    d = job_store.get_job(j.job_id).to_dict()
+    assert set(d.keys()) == {
+        "job_id",
+        "status",
+        "dry_run",
+        "started_at",
+        "finished_at",
+        "error",
+    }

--- a/apps/python/web/app.py
+++ b/apps/python/web/app.py
@@ -1,9 +1,10 @@
 from fastapi import FastAPI
 
-from web.routers import auth_mode, config, credentials, health
+from web.routers import auth_mode, config, credentials, health, run
 
 app = FastAPI(title="ai-agent Web API", version="0.1.0")
 app.include_router(health.router, prefix="/api")
 app.include_router(config.router, prefix="/api")
 app.include_router(credentials.router, prefix="/api")
 app.include_router(auth_mode.router, prefix="/api")
+app.include_router(run.router, prefix="/api")

--- a/apps/python/web/routers/run.py
+++ b/apps/python/web/routers/run.py
@@ -1,0 +1,70 @@
+"""POST /api/run + GET /api/run/{job_id} — async briefing execution.
+
+Phase 1 design: a job is created in ``src.job_store`` (in-memory dict + lock),
+``lambda_handler`` runs via ``BackgroundTasks`` so the POST returns 202
+immediately. The frontend polls GET until status transitions to ``done`` /
+``failed``.
+
+``dry_run=true`` propagates to ``lambda_handler(dry_run=True)`` which runs
+the credential preflight and returns without touching claude / Discord /
+Notion — useful as a UI "is everything wired up?" check.
+"""
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from src import job_store
+from web.auth import require_bearer
+
+# NB: ``src.handler`` is imported lazily inside ``_execute_briefing`` rather than
+# at module top. ``src.handler`` does ``from src.config import CONFIG`` which
+# triggers ``src.config.__getattr__('CONFIG')`` → ``load_config()`` →
+# ``briefing.json`` read. Eager-importing here would defeat the lazy-config fix
+# from #60 and crash ``./bin/serve.sh`` when ``briefing.json`` doesn't exist
+# yet — the very file ``/api/config`` is supposed to let the operator create.
+
+router = APIRouter(dependencies=[Depends(require_bearer)])
+
+
+class RunResponse(BaseModel):
+    job_id: str
+    status: str
+
+
+class JobDetail(BaseModel):
+    job_id: str
+    status: str
+    dry_run: bool = False
+    started_at: str | None = None
+    finished_at: str | None = None
+    error: str | None = None
+
+
+def _execute_briefing(job_id: str, dry_run: bool) -> None:
+    """BackgroundTasks entrypoint. Always advances the job through
+    running → done/failed regardless of exception path."""
+    from src.handler import lambda_handler  # lazy — see module note
+
+    job_store.mark_running(job_id)
+    try:
+        lambda_handler(dry_run=dry_run)
+        job_store.mark_done(job_id)
+    except Exception as e:
+        job_store.mark_failed(job_id, str(e))
+
+
+@router.post("/run", status_code=202, response_model=RunResponse)
+def post_run(
+    background_tasks: BackgroundTasks,
+    dry_run: bool = Query(default=False),
+) -> RunResponse:
+    job = job_store.create_job(dry_run=dry_run)
+    background_tasks.add_task(_execute_briefing, job.job_id, dry_run)
+    return RunResponse(job_id=job.job_id, status=job.status)
+
+
+@router.get("/run/{job_id}", response_model=JobDetail)
+def get_run(job_id: str) -> JobDetail:
+    job = job_store.get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail=f"job not found: {job_id}")
+    return JobDetail(**job.to_dict())


### PR DESCRIPTION
## Summary

Phase 1 Plan B first sub-issue: HTTP trigger for the briefing pipeline.

- **`apps/python/src/job_store.py`** — in-memory `dict[str, Job]` guarded by a `threading.Lock`. Public API: `create_job`, `get_job`, `mark_running`, `mark_done`, `mark_failed`. Single-process Phase 1 design; the surface stays narrow so Phase 2 can swap in Redis with zero caller changes.
- **`apps/python/web/routers/run.py`** —
  - `POST /api/run?dry_run=<bool>` → 202 with `{job_id, status: "pending"}`. Schedules `src.handler.lambda_handler(dry_run=...)` via `fastapi.BackgroundTasks` and returns immediately.
  - `GET /api/run/{job_id}` → 200 with full job detail (`status`, `dry_run`, `started_at`, `finished_at`, `error`), 404 if unknown.
  - Both routes require Bearer auth via router-level dep.
  - `dry_run=true` propagates to `lambda_handler` which already supports it (preflight only — no claude / Discord / Notion calls). Useful as a UI "is everything wired up?" probe.

## Subtle bit (kept for the future contributor)

The `from src.handler import lambda_handler` import inside `_execute_briefing` is **deliberately function-local**. Importing it at module top would walk `web.app → web.routers.run → src.handler → src.config` and trigger `src.config.__getattr__("CONFIG")` via `from src.config import CONFIG`, which re-runs `load_config()` at server boot — defeating the lazy-load fix from #60 and crashing `./bin/serve.sh` when `briefing.json` doesn't exist yet. A module-level comment guards this so a future "let's hoist the imports" refactor doesn't undo it.

## Test plan

- [x] `tests/test_job_store.py` — 10 tests: create / get / state transitions / unknown-id / dry_run flag / to_dict serialization.
- [x] `tests/test_api_run.py` — 11 tests: POST 202 path, dry_run propagation, success / failure status updates, GET 404, GET fields, error exposure, Bearer enforcement on both routes.
- [x] Existing lazy-config regression test (`test_importing_src_config_does_not_eagerly_read_file`) still passes — verifies importing `web.app` does NOT trigger briefing.json read.
- [x] Full suite: **236 passed** (was 215 on `dev`; +21).
- [x] Manual smoke against `./bin/serve.sh` with no `briefing.json` present:
  - `POST /api/run?dry_run=true` → 202 + job_id
  - `GET /api/run/<id>` → `status: done` with ISO timestamps (handler's preflight just logs warnings on missing credentials, then returns due to dry_run)
  - `GET /api/run/unknown-id` → 404
  - `POST /api/run` (no bearer) → 401

Closes #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added asynchronous briefing execution via new `/api/run` POST endpoint that returns immediately (HTTP 202) with a job ID
  * Added `/api/run/{job_id}` GET endpoint to check job status, execution timestamps, and error details
  * Implemented job status lifecycle tracking (pending → running → done/failed)
  * Added optional `dry_run` query parameter to test execution paths
  * Enabled authentication protection for all new endpoints

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KazusaNakagawa/ai-agent-cli/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->