### PR TITLE
fix(web): integrate HTTPBearer so Swagger UI can authorize

### DIFF
--- a/apps/python/tests/test_api_auth.py
+++ b/apps/python/tests/test_api_auth.py
@@ -1,6 +1,12 @@
 import pytest
+from fastapi.security import HTTPAuthorizationCredentials
 
 from web import auth
+
+
+def _bearer(token: str) -> HTTPAuthorizationCredentials:
+    """Build the credentials object FastAPI's HTTPBearer dep would produce."""
+    return HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
 
 
 async def test_health_does_not_require_auth(async_client):
@@ -30,7 +36,7 @@ def test_require_bearer_rejects_missing_header(fixed_token):
     from fastapi import HTTPException
 
     with pytest.raises(HTTPException) as exc_info:
-        auth.require_bearer(authorization="")
+        auth.require_bearer(credentials=None)
     assert exc_info.value.status_code == 401
 
 
@@ -38,9 +44,9 @@ def test_require_bearer_rejects_wrong_token(fixed_token):
     from fastapi import HTTPException
 
     with pytest.raises(HTTPException) as exc_info:
-        auth.require_bearer(authorization="Bearer wrong-token")
+        auth.require_bearer(credentials=_bearer("wrong-token"))
     assert exc_info.value.status_code == 401
 
 
 def test_require_bearer_accepts_correct_token(fixed_token):
-    auth.require_bearer(authorization="Bearer test-token-123")
+    auth.require_bearer(credentials=_bearer("test-token-123"))

--- a/apps/python/web/auth.py
+++ b/apps/python/web/auth.py
@@ -1,11 +1,21 @@
-"""Bearer トークン生成と検証 dependency。"""
+"""Bearer トークン生成と検証 dependency。
+
+``HTTPBearer`` security scheme を使うことで OpenAPI 仕様に認証要件が乗り、
+Swagger UI (``/docs``) の右上に "Authorize" ボタンが出る。トークンを 1 回
+ペーストすれば protected な全エンドポイントで自動付与される。
+"""
 import secrets
 from pathlib import Path
 
-from fastapi import Header, HTTPException, status
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 TOKEN_FILE = Path.home() / ".ai-agent" / "session-token"
 _token_cache: str | None = None
+
+# ``auto_error=False`` so we return our own 401 message instead of FastAPI's
+# generic 403 "Not authenticated" when the header is missing.
+_bearer_scheme = HTTPBearer(auto_error=False)
 
 
 def _ensure_token() -> str:
@@ -23,15 +33,16 @@ def _ensure_token() -> str:
     return _token_cache
 
 
-def require_bearer(authorization: str = Header(default="")) -> None:
+def require_bearer(
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+) -> None:
     expected = _ensure_token()
-    if not authorization.startswith("Bearer "):
+    if credentials is None or credentials.scheme != "Bearer":
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Missing Bearer token",
         )
-    token = authorization[len("Bearer "):].strip()
-    if not secrets.compare_digest(token, expected):
+    if not secrets.compare_digest(credentials.credentials, expected):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid Bearer token",


### PR DESCRIPTION
## Summary

Tiny DX fix discovered during manual testing — Swagger UI at `http://127.0.0.1:8000/docs` had no way to attach the bearer token, so every "Try it out" against a protected endpoint returned 401.

Swap `require_bearer` from a hand-rolled `Header(default="")` check to `fastapi.security.HTTPBearer(auto_error=False)`. The behavioral surface is unchanged (same 401 paths, same 200 path), but FastAPI now declares the security scheme in OpenAPI:

```json
"components": {
  "securitySchemes": {
    "HTTPBearer": { "type": "http", "scheme": "bearer" }
  }
}
```

…and each protected endpoint references it. Swagger UI picks this up and renders the lock icon + "Authorize" button so the token can be pasted **once** instead of per-request.

`auto_error=False` is the small subtlety: it lets us keep returning 401 with our own `detail` strings ("Missing Bearer token" / "Invalid Bearer token") instead of FastAPI's default 403 "Not authenticated".

## Test plan

- [x] `tests/test_api_auth.py` — the three direct `require_bearer()` unit tests updated to pass `HTTPAuthorizationCredentials` objects instead of raw `"Bearer ..."` strings. All other auth tests (HTTP-level, via `authed_client` / `async_client` fixtures) unchanged.
- [x] Full suite: **256 passed** (no test count change — it's a same-shape refactor).
- [x] Manual: `./bin/serve.sh` + `curl /openapi.json | jq '.components.securitySchemes'` shows the new scheme; `/api/config` without bearer → 401, `/api/auth/mode` with bearer → 200.
- [x] Swagger UI: open `http://127.0.0.1:8000/docs`, click "Authorize", paste the token from `~/.ai-agent/session-token`, "Try it out" on any protected endpoint succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated authentication tests to validate bearer token handling

* **Bug Fixes**
  * Improved bearer token validation with consistent 401 error responses for missing or invalid credentials
  * Enhanced API documentation support for authorization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KazusaNakagawa/ai-agent-cli/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->