### PR TITLE
docs(web): add web-ui-setup.md for Phase 1 backend

### DIFF
--- a/docs/web-ui-setup.md
+++ b/docs/web-ui-setup.md
@@ -1,0 +1,131 @@
+# Web UI (Phase 1) — Setup and Operation
+
+ローカル localhost-only な FastAPI バックエンドの使い方。Plan A + Plan B 完了時点で利用可能。
+
+## 起動
+
+```bash
+./bin/serve.sh                   # http://127.0.0.1:8000 (default)
+PORT=8001 ./bin/serve.sh         # ポート衝突回避
+```
+
+`bin/serve.sh` がやること:
+
+1. `.env` を `set -a; source; set +a` で読み込み
+2. `~/.ai-agent/session-token` の場所を表示 (中身は出さない)
+3. `uvicorn web.app:app --host 127.0.0.1 --port $PORT --reload --reload-dir web --reload-dir src` を exec
+
+`--host 127.0.0.1` で localhost-only — LAN からは到達不能。
+
+## Bearer トークン
+
+トークンは `~/.ai-agent/session-token` に **初回認証リクエスト時に自動生成** される (`secrets.token_urlsafe(32)`、ファイルパーミッション `0600`)。手動発行は不要。
+
+```bash
+cat ~/.ai-agent/session-token    # 確認
+```
+
+### ローテート
+
+```bash
+rm ~/.ai-agent/session-token     # ファイル削除
+# サーバー再起動 (Ctrl-C → ./bin/serve.sh) — 古いキャッシュを捨てる
+# 次の認証付きリクエストで新しいトークンが自動生成される
+```
+
+## Swagger UI で動作確認
+
+開発・デバッグ時の最短経路:
+
+1. `./bin/serve.sh` をターミナル A で起動したまま
+2. ブラウザで <http://127.0.0.1:8000/docs>
+3. 右上の 🔒 **Authorize** をクリック → `cat ~/.ai-agent/session-token` の値を貼り付け → **Authorize**
+4. これ以降、各 endpoint の **Try it out** ボタンから直接実行可能 (トークンは自動付与)
+
+curl でやりたい場合:
+
+```bash
+TOKEN=$(cat ~/.ai-agent/session-token)
+curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8000/api/config
+```
+
+## エンドポイント一覧
+
+すべて `Authorization: Bearer <token>` 必須 (`/api/health` のみ例外)。
+
+| Method/Path | 用途 |
+|---|---|
+| `GET /api/health` | Bearer 不要。起動確認 |
+| `GET /api/config` | `briefing.json` を返す。ファイル不在なら 404 |
+| `PUT /api/config` | `briefing.json` を atomic に上書き保存 |
+| `GET /api/credentials` | `{name: bool}` の set 状況。値は返さない |
+| `PUT /api/credentials/{name}` | Keychain に保存 (`name` は allow-list 内のみ、ほかは 400) |
+| `DELETE /api/credentials/{name}` | Keychain から削除 |
+| `GET /api/auth/mode` | 現在のモード (`cli` または `api`) |
+| `PUT /api/auth/mode` | モード切替。`{"auth_mode":"api"}` |
+| `POST /api/run?dry_run=<bool>` | ブリーフィング非同期実行。202 + `{job_id, status}` |
+| `GET /api/run/{job_id}` | ジョブ進行状況 (`pending`/`running`/`done`/`failed`) |
+| `POST /api/chat` | SSE ストリーミング Q&A。`{date, question}` |
+
+詳細スキーマは Swagger UI (`/docs`) または OpenAPI JSON (`/openapi.json`) を参照。
+
+## 初回セットアップ手順
+
+フレッシュチェックアウト (`apps/python/config/briefing.json` 不在) から動かすまで:
+
+```bash
+# 1. サーバー起動 — briefing.json が無くても boot は通る (lazy-load 設計、PR #60)
+./bin/serve.sh
+
+# 2. ブラウザで /docs を開き、Authorize にトークンを貼る
+
+# 3. PUT /api/config で briefing.json を初期化
+#    例 (curl):
+TOKEN=$(cat ~/.ai-agent/session-token)
+curl -X PUT -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    -d @apps/python/config/briefing.json.example \
+    http://127.0.0.1:8000/api/config
+
+# 4. クレデンシャルを Keychain に保存
+curl -X PUT -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    -d '{"value":"<your-discord-token>"}' \
+    http://127.0.0.1:8000/api/credentials/DISCORD_TOKEN
+#    (CHANNEL_ID / NOTION_API_KEY / NOTION_DATABASE_ID も同様)
+
+# 5. (Optional) Claude API モードに切替
+curl -X PUT -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    -d '{"auth_mode":"api"}' \
+    http://127.0.0.1:8000/api/auth/mode
+#    api モードでは ANTHROPIC_API_KEY を別途 PUT /api/credentials/ANTHROPIC_API_KEY で保存
+#    cli モードのままなら Claude Code CLI の OAuth を使う (既存挙動)
+
+# 6. 動作確認
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+    "http://127.0.0.1:8000/api/run?dry_run=true"
+#    → 202 + job_id
+curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8000/api/run/<job_id>
+#    → "status": "done" (handler の preflight が走り credentials の有無を warn 出力)
+```
+
+## 認証モードについて (`cli` vs `api`)
+
+- **`cli`** (デフォルト) — `claude` CLI の OAuth セッションを使う。Anthropic API キー不要、Claude Pro/Max サブスク前提。
+- **`api`** — `ANTHROPIC_API_KEY` (Keychain → `.env` フォールバック) を環境変数経由で `claude` CLI に渡す。従量課金。
+
+切替は `PUT /api/auth/mode` の 1 リクエストのみ。`~/.ai-agent/state.json` に永続化され、次のバッチ実行 (cron 経由) から即反映される (`bin/run.sh` が毎回新規 Python プロセスを起こすため、再起動不要)。
+
+詳細は [`apps/python/src/claude_runner.py:build_env`](../apps/python/src/claude_runner.py) を参照。
+
+## トラブルシューティング
+
+| 症状 | 原因と対処 |
+|---|---|
+| `./bin/serve.sh` で `uvicorn not found` | venv 未同期。`cd apps/python && uv pip sync requirements.txt` |
+| `GET /api/config` が 404 | `apps/python/config/briefing.json` が無い。`PUT /api/config` で作成 |
+| `GET /api/config` が 500 (corrupt JSON) | `briefing.json` が壊れている。`apps/python/config/briefing.json.example` を参考に手で直すか `PUT` で再作成 |
+| `POST /api/run` の job が `failed` | `GET /api/run/{job_id}` の `error` フィールドを参照。多くは `briefing.json` 不整合 or クレデンシャル不足 |
+| `POST /api/chat` から `event: stale_session` が返る | 保存セッション ID が無効。同じリクエストを再送 (バックエンドが古いセッションファイルを削除済みなので新規セッションで実行される) |
+
+## バッチ実行 (cron) との関係
+
+このサーバーは UI/管理用のフロントエンドであり、定期実行とは独立しています。launchd でのスケジューリングは [`launchd-setup.md`](./launchd-setup.md) を参照。`PUT /api/config` で更新した内容は launchd 経由のバッチが次回起動時に自動的に反映します (毎回 `load_config()` が走るため)。


### PR DESCRIPTION
## Summary

Adds `docs/web-ui-setup.md` covering the Web UI Phase 1 backend (Plan A + Plan B). The operator-facing setup flow was previously scattered across PR descriptions and the gitignored spec doc — this consolidates it.

## Contents

- **起動:** `./bin/serve.sh`, `PORT` override, what the launcher does.
- **Bearer トークン:** `~/.ai-agent/session-token` 自動生成、ローテート手順。
- **Swagger UI:** `/docs` の Authorize ボタンに貼る最短経路 + curl 代替。
- **エンドポイント一覧:** 全 11 endpoint を 1 つの表に。詳細は `/docs` / `/openapi.json` を見るよう誘導。
- **初回セットアップ:** フレッシュチェックアウト → `briefing.json` 作成 → クレデンシャル保存 → `/api/run` で動作確認まで curl 例付き。
- **`cli` vs `api` 認証モード:** 切替方法と意味、`claude_runner.build_env` への参照。
- **トラブルシューティング:** 5 つの失敗モードと回復手順 (404 config, corrupt JSON, failed job, stale chat session, missing uvicorn)。
- **cron との関係:** `launchd-setup.md` への相互参照。

## Note on `/docs` Authorize button

The Swagger Authorize UI is the post-#66 state (HTTPBearer). The docs section that references "Authorize button" presumes #66 lands first. If #66 doesn't merge, that section should be replaced with "send `Authorization: Bearer ...` manually via curl" — the rest of the doc is independent.

## Test plan

- [x] Markdown renders correctly on GitHub.
- [x] All commands tested manually against a local `./bin/serve.sh`.
- [x] All file paths in the doc resolve (`apps/python/src/claude_runner.py`, `apps/python/config/briefing.json.example`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)