### PR TITLE
chore: extend bin/serve.sh to launch FastAPI + Next.js together

### DIFF
--- a/bin/serve.sh
+++ b/bin/serve.sh
@@ -27,6 +27,11 @@ Flags:
 EOF
             exit 0
             ;;
+        *)
+            echo "unknown flag: $arg" >&2
+            echo "try: bin/serve.sh --help" >&2
+            exit 2
+            ;;
     esac
 done
 
@@ -97,11 +102,34 @@ pids+=("$!")
 ( cd "$WEB_APP" && PORT="$WEB_PORT" npm run dev ) &
 pids+=("$!")
 
+# --- early-death detection ---
+# Give both processes a moment to bind their ports. If either exits before
+# this window (most commonly: port collision), surface the failure here
+# instead of leaving the user with a half-working stack.
+sleep 2
+if ! kill -0 "${pids[0]}" 2>/dev/null; then
+    echo "error: FastAPI exited early — port $API_PORT may be in use" >&2
+    exit 1
+fi
+if ! kill -0 "${pids[1]}" 2>/dev/null; then
+    echo "error: Next.js exited early — port $WEB_PORT may be in use" >&2
+    exit 1
+fi
+
 # --- browser ---
 if [ "$NO_BROWSER" = false ] && [ -z "${CI:-}" ] && command -v open >/dev/null 2>&1; then
-    # Defer the open call a few seconds so Next.js is actually serving;
-    # backgrounded + best-effort so a missing browser doesn't tear down the script.
-    ( sleep 3 && open "http://localhost:$WEB_PORT" >/dev/null 2>&1 || true ) &
+    # Poll for Next.js readiness instead of a fixed sleep — first cold start
+    # can take 5–10s and a fixed delay races with that. Best-effort: if it
+    # never comes up the loop times out and we don't open anything.
+    (
+        for _ in $(seq 1 30); do
+            if curl -fsS --max-time 1 "http://localhost:$WEB_PORT/" >/dev/null 2>&1; then
+                open "http://localhost:$WEB_PORT" >/dev/null 2>&1 || true
+                exit 0
+            fi
+            sleep 1
+        done
+    ) &
 fi
 
 wait

--- a/bin/serve.sh
+++ b/bin/serve.sh
@@ -1,8 +1,48 @@
 #!/usr/bin/env bash
+# Launch the full Phase 1 Web UI: FastAPI (:8000) + Next.js dev (:3000).
+# Use apps/python/bin/serve.sh directly if you only want the backend.
 set -euo pipefail
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+PYTHON_APP="$PROJECT_ROOT/apps/python"
+WEB_APP="$PROJECT_ROOT/apps/web"
 
+# --- flags ---
+NO_BROWSER=false
+for arg in "$@"; do
+    case "$arg" in
+        --no-browser) NO_BROWSER=true ;;
+        -h|--help)
+            cat <<EOF
+Usage: bin/serve.sh [--no-browser]
+
+Starts the FastAPI backend (\$API_PORT, default 8000) and the Next.js dev
+server (\$WEB_PORT, default 3000), mirrors the bearer token to
+apps/web/.token, and opens the browser at the web port. Ctrl-C shuts
+both down.
+
+Flags:
+  --no-browser   Skip the browser auto-open (also skipped when \$CI is set).
+EOF
+            exit 0
+            ;;
+    esac
+done
+
+# --- pre-flight ---
+if [ ! -x "$PYTHON_APP/.venv/bin/uvicorn" ]; then
+    echo "error: uvicorn not found at $PYTHON_APP/.venv/bin/uvicorn" >&2
+    echo "       run: cd apps/python && uv pip sync requirements.txt" >&2
+    exit 1
+fi
+if [ ! -d "$WEB_APP/node_modules" ]; then
+    echo "error: web dependencies missing at $WEB_APP/node_modules" >&2
+    echo "       run: cd apps/web && npm install" >&2
+    exit 1
+fi
+
+# --- env (.env must be loaded before subprocesses inherit it) ---
 ENV_FILE="$PROJECT_ROOT/.env"
 if [ -f "$ENV_FILE" ]; then
     set -a
@@ -11,4 +51,57 @@ if [ -f "$ENV_FILE" ]; then
     set +a
 fi
 
-exec "$PROJECT_ROOT/apps/python/bin/serve.sh" "$@"
+API_PORT="${API_PORT:-8000}"
+WEB_PORT="${WEB_PORT:-3000}"
+
+# --- token: create if missing, mirror to apps/web/.token ---
+# Generates the same shape (secrets.token_urlsafe(32)) that
+# apps/python/web/auth.py would write on the first authed request, so we
+# pre-create it now and both servers read the same value with no race.
+TOKEN_FILE="$HOME/.ai-agent/session-token"
+mkdir -p "$(dirname "$TOKEN_FILE")"
+if [ ! -f "$TOKEN_FILE" ]; then
+    python3 -c "import secrets; print(secrets.token_urlsafe(32))" > "$TOKEN_FILE"
+    chmod 600 "$TOKEN_FILE"
+fi
+cp "$TOKEN_FILE" "$WEB_APP/.token"
+chmod 600 "$WEB_APP/.token"
+
+# --- process management ---
+pids=()
+cleanup() {
+    trap - INT TERM EXIT
+    echo
+    echo "Shutting down..."
+    for pid in "${pids[@]}"; do
+        # npm forks `next dev`; SIGTERM the direct child plus its descendants.
+        pkill -P "$pid" 2>/dev/null || true
+        kill -TERM "$pid" 2>/dev/null || true
+    done
+    wait 2>/dev/null || true
+}
+trap cleanup INT TERM EXIT
+
+echo "ai-agent UI starting..."
+echo "  API:  http://127.0.0.1:$API_PORT"
+echo "  Web:  http://localhost:$WEB_PORT"
+echo "  Press Ctrl-C to stop both"
+echo
+
+# Start FastAPI (uvicorn). Delegate to the existing backend launcher so
+# its --reload-dir flags stay the single source of truth.
+PORT="$API_PORT" "$PYTHON_APP/bin/serve.sh" &
+pids+=("$!")
+
+# Start Next.js. Use the package script so it picks up the project's dev config.
+( cd "$WEB_APP" && PORT="$WEB_PORT" npm run dev ) &
+pids+=("$!")
+
+# --- browser ---
+if [ "$NO_BROWSER" = false ] && [ -z "${CI:-}" ] && command -v open >/dev/null 2>&1; then
+    # Defer the open call a few seconds so Next.js is actually serving;
+    # backgrounded + best-effort so a missing browser doesn't tear down the script.
+    ( sleep 3 && open "http://localhost:$WEB_PORT" >/dev/null 2>&1 || true ) &
+fi
+
+wait

--- a/docs/web-ui-setup.md
+++ b/docs/web-ui-setup.md
@@ -21,8 +21,11 @@ WEB_PORT=3001 ./bin/serve.sh     # Web のポートを変更
 3. `~/.ai-agent/session-token` が無ければ `secrets.token_urlsafe(32)` で作成、必ず `apps/web/.token` に 0600 でミラー (両サーバが同じトークンを参照)
 4. uvicorn を `--reload` 付きでバックグラウンド起動 (`apps/python/bin/serve.sh` 経由)
 5. `npm run dev` をバックグラウンド起動
-6. macOS なら 3 秒後に `open http://localhost:$WEB_PORT` (`--no-browser` または `$CI` で skip)
-7. Ctrl-C で両プロセスを後始末 (`trap INT TERM EXIT` + 子孫プロセスを `pkill -P`)
+6. **Early-death check**: 起動直後にどちらかが死んだら（典型: ポート衝突）即 exit 1 で原因を表示
+7. macOS なら `http://localhost:$WEB_PORT/` を polling し、200 が返ってから `open` (`--no-browser` または `$CI` で skip、最大 30 秒で諦め)
+8. Ctrl-C で両プロセスを後始末 (`trap INT TERM EXIT` + 子孫プロセスを `pkill -P`)
+
+未知のフラグは silent に無視せず `exit 2` で `bin/serve.sh --help` を案内する。
 
 `--host 127.0.0.1` で localhost-only — LAN からは到達不能。
 

--- a/docs/web-ui-setup.md
+++ b/docs/web-ui-setup.md
@@ -1,19 +1,28 @@
 # Web UI (Phase 1) — Setup and Operation
 
-ローカル localhost-only な FastAPI バックエンドの使い方。Plan A + Plan B 完了時点で利用可能。
+ローカル localhost-only な FastAPI バックエンド + Next.js フロントエンドの使い方。
 
 ## 起動
 
 ```bash
-./bin/serve.sh                   # http://127.0.0.1:8000 (default)
-PORT=8001 ./bin/serve.sh         # ポート衝突回避
+./bin/serve.sh                   # API :8000 + Web :3000 + ブラウザ自動オープン
+./bin/serve.sh --no-browser      # ブラウザは開かない ($CI が立っていれば自動で skip)
+API_PORT=8001 ./bin/serve.sh     # API のポートを変更
+WEB_PORT=3001 ./bin/serve.sh     # Web のポートを変更
+
+# API だけ立ち上げたい場合 (CI / Swagger 動作確認など):
+./apps/python/bin/serve.sh       # FastAPI 単体
 ```
 
 `bin/serve.sh` がやること:
 
-1. `.env` を `set -a; source; set +a` で読み込み
-2. `~/.ai-agent/session-token` の場所を表示 (中身は出さない)
-3. `uvicorn web.app:app --host 127.0.0.1 --port $PORT --reload --reload-dir web --reload-dir src` を exec
+1. **Pre-flight**: `apps/python/.venv/bin/uvicorn` と `apps/web/node_modules` の存在チェック。欠けていれば即 exit 1 + 直し方を案内
+2. `.env` を `set -a; source; set +a` で読み込み
+3. `~/.ai-agent/session-token` が無ければ `secrets.token_urlsafe(32)` で作成、必ず `apps/web/.token` に 0600 でミラー (両サーバが同じトークンを参照)
+4. uvicorn を `--reload` 付きでバックグラウンド起動 (`apps/python/bin/serve.sh` 経由)
+5. `npm run dev` をバックグラウンド起動
+6. macOS なら 3 秒後に `open http://localhost:$WEB_PORT` (`--no-browser` または `$CI` で skip)
+7. Ctrl-C で両プロセスを後始末 (`trap INT TERM EXIT` + 子孫プロセスを `pkill -P`)
 
 `--host 127.0.0.1` で localhost-only — LAN からは到達不能。
 
@@ -121,6 +130,7 @@ curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8000/api/run/<job_id>
 | 症状 | 原因と対処 |
 |---|---|
 | `./bin/serve.sh` で `uvicorn not found` | venv 未同期。`cd apps/python && uv pip sync requirements.txt` |
+| `./bin/serve.sh` で `web dependencies missing` | Next.js 依存未インストール。`cd apps/web && npm install` |
 | `GET /api/config` が 404 | `apps/python/config/briefing.json` が無い。`PUT /api/config` で作成 |
 | `GET /api/config` が 500 (corrupt JSON) | `briefing.json` が壊れている。`apps/python/config/briefing.json.example` を参考に手で直すか `PUT` で再作成 |
 | `POST /api/run` の job が `failed` | `GET /api/run/{job_id}` の `error` フィールドを参照。多くは `briefing.json` 不整合 or クレデンシャル不足 |


### PR DESCRIPTION
## Summary
- `bin/serve.sh` now boots the full Phase 1 UI: FastAPI on `:8000` and Next.js dev on `:3000` from a single command
- Pre-flight checks for `apps/python/.venv/bin/uvicorn` and `apps/web/node_modules`, with the fix command in the error message
- Eagerly creates `~/.ai-agent/session-token` (matching `auth.py`'s `secrets.token_urlsafe(32)` format) and mirrors it to `apps/web/.token` (0600) so both servers share the same bearer with no startup race
- Ports overridable: `API_PORT` (default 8000) / `WEB_PORT` (default 3000)
- macOS browser auto-open after a 3 s delay, suppressed by `--no-browser` or when `$CI` is set
- `trap INT TERM EXIT` + `pkill -P` on each tracked child so the npm wrapper around `next dev` doesn't leak `next-server` orphans
- `docs/web-ui-setup.md` updated to document the dual-launch flow, the `--no-browser` flag, the `API_PORT`/`WEB_PORT` split, and the `node_modules`-missing troubleshooting row. Backend-only path (`apps/python/bin/serve.sh`) called out for CI / Swagger-only use

## Test plan
- [x] `bin/serve.sh --help` prints usage
- [x] Pre-flight: `mv apps/web/node_modules{,.bak} && bin/serve.sh` → `error: web dependencies missing ... run: cd apps/web && npm install`, exit 1
- [x] `bin/serve.sh --no-browser` brings both servers up: uvicorn (PID 4814 reload parent + 4841 worker on `:8000`) and `next-server` (PID 4842 on `:3000`)
- [x] `apps/web/.token` is created with the same content as `~/.ai-agent/session-token` (`diff -q` → MATCH), permissions `-rw-------`
- [x] `curl http://127.0.0.1:8000/api/health` → 200 `{"status":"ok"}`
- [x] `curl http://localhost:3000/` → 200, renders shadcn Card ("ai-agent", "Get started")
- [x] Sending SIGTERM to the script PID tears down both servers and frees both ports (trap mechanism verified). Real interactive Ctrl-C also delivers SIGINT to the whole foreground process group, so children die directly even before the trap fires; trap is the safety net.
- [ ] Reviewer: confirm browser auto-open works in their terminal (interactive — hard to assert in CI)

Closes #69