### PR TITLE
feat(web): 4-step onboarding wizard

### DIFF
--- a/apps/python/tests/test_api_state.py
+++ b/apps/python/tests/test_api_state.py
@@ -1,0 +1,68 @@
+"""Tests for /api/state — full state read + partial update."""
+import pytest
+
+from src import state as state_mod
+
+
+@pytest.fixture(autouse=True)
+def isolated_state(monkeypatch, tmp_path):
+    monkeypatch.setattr(state_mod, "STATE_FILE", tmp_path / "state.json")
+
+
+async def test_get_state_returns_defaults_when_file_missing(authed_client):
+    response = await authed_client.get("/api/state")
+    assert response.status_code == 200
+    assert response.json() == {
+        "onboarded": False,
+        "auth_mode": "cli",
+        "migrated_from_env": False,
+        "version": 1,
+    }
+
+
+async def test_get_state_requires_bearer(async_client):
+    response = await async_client.get("/api/state")
+    assert response.status_code == 401
+
+
+async def test_put_state_flips_onboarded_and_preserves_other_fields(authed_client):
+    state_mod.write_state(state_mod.State(auth_mode="api"))
+    response = await authed_client.put("/api/state", json={"onboarded": True})
+    assert response.status_code == 200
+    assert response.json() == {
+        "onboarded": True,
+        "auth_mode": "api",
+        "migrated_from_env": False,
+        "version": 1,
+    }
+    persisted = state_mod.read_state()
+    assert persisted.onboarded is True
+    assert persisted.auth_mode == "api"
+
+
+async def test_put_state_partial_update_leaves_unspecified_fields_alone(authed_client):
+    state_mod.write_state(
+        state_mod.State(onboarded=True, auth_mode="api", migrated_from_env=True)
+    )
+    response = await authed_client.put("/api/state", json={"auth_mode": "cli"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["onboarded"] is True
+    assert body["auth_mode"] == "cli"
+    assert body["migrated_from_env"] is True
+
+
+async def test_put_invalid_auth_mode_returns_422(authed_client):
+    response = await authed_client.put("/api/state", json={"auth_mode": "oauth"})
+    assert response.status_code == 422
+
+
+async def test_put_state_ignores_unknown_fields(authed_client):
+    # Pydantic defaults: unknown fields are silently dropped (not extra=forbid).
+    # The endpoint should still succeed and not crash.
+    response = await authed_client.put(
+        "/api/state", json={"onboarded": True, "version": 99}
+    )
+    assert response.status_code == 200
+    assert response.json()["version"] == 1  # version unchanged
+    assert response.json()["onboarded"] is True

--- a/apps/python/web/app.py
+++ b/apps/python/web/app.py
@@ -1,11 +1,12 @@
 from fastapi import FastAPI
 
-from web.routers import auth_mode, chat, config, credentials, health, run
+from web.routers import auth_mode, chat, config, credentials, health, run, state
 
 app = FastAPI(title="ai-agent Web API", version="0.1.0")
 app.include_router(health.router, prefix="/api")
 app.include_router(config.router, prefix="/api")
 app.include_router(credentials.router, prefix="/api")
 app.include_router(auth_mode.router, prefix="/api")
+app.include_router(state.router, prefix="/api")
 app.include_router(run.router, prefix="/api")
 app.include_router(chat.router, prefix="/api")

--- a/apps/python/web/routers/state.py
+++ b/apps/python/web/routers/state.py
@@ -1,7 +1,7 @@
 """GET / PUT /api/state — ``~/.ai-agent/state.json`` の読み書き。
 
 ``auth_mode`` 専用の ``/api/auth/mode`` と違い、こちらは state.json 全体を返す
-／部分更新できる汎用エンドポイント。オンボーディングウィザードが
+/ 部分更新できる汎用エンドポイント。オンボーディングウィザードが
 ``onboarded: true`` を立てるために使う。
 
 部分更新ポリシー: 渡されたフィールドだけを read-modify-write で書き戻す。

--- a/apps/python/web/routers/state.py
+++ b/apps/python/web/routers/state.py
@@ -1,0 +1,63 @@
+"""GET / PUT /api/state — ``~/.ai-agent/state.json`` の読み書き。
+
+``auth_mode`` 専用の ``/api/auth/mode`` と違い、こちらは state.json 全体を返す
+／部分更新できる汎用エンドポイント。オンボーディングウィザードが
+``onboarded: true`` を立てるために使う。
+
+部分更新ポリシー: 渡されたフィールドだけを read-modify-write で書き戻す。
+``version`` は read-only (バージョン番号は state schema が変わったときだけ
+バックエンド側で bump する)。
+"""
+from typing import Literal
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from src import state as state_mod
+from web.auth import require_bearer
+
+router = APIRouter(dependencies=[Depends(require_bearer)])
+
+
+class StateResponse(BaseModel):
+    onboarded: bool
+    auth_mode: Literal["cli", "api"]
+    migrated_from_env: bool
+    version: int
+
+
+class StatePatchBody(BaseModel):
+    """全フィールド optional。指定されたものだけを書き戻す。
+
+    ``version`` は受け付けない (クライアントが書き換える理由がない)。"""
+
+    onboarded: bool | None = None
+    auth_mode: Literal["cli", "api"] | None = None
+    migrated_from_env: bool | None = None
+
+
+def _to_response(s: state_mod.State) -> StateResponse:
+    return StateResponse(
+        onboarded=s.onboarded,
+        auth_mode=s.auth_mode,
+        migrated_from_env=s.migrated_from_env,
+        version=s.version,
+    )
+
+
+@router.get("/state", response_model=StateResponse)
+def get_state() -> StateResponse:
+    return _to_response(state_mod.read_state())
+
+
+@router.put("/state", response_model=StateResponse)
+def put_state(body: StatePatchBody) -> StateResponse:
+    current = state_mod.read_state()
+    if body.onboarded is not None:
+        current.onboarded = body.onboarded
+    if body.auth_mode is not None:
+        current.auth_mode = body.auth_mode
+    if body.migrated_from_env is not None:
+        current.migrated_from_env = body.migrated_from_env
+    state_mod.write_state(current)
+    return _to_response(current)

--- a/apps/web/app/api/[...path]/route.ts
+++ b/apps/web/app/api/[...path]/route.ts
@@ -34,6 +34,11 @@ async function handle(
   upstream.headers.forEach((value, key) => {
     if (!HOP_BY_HOP.has(key.toLowerCase())) headers.set(key, value)
   })
+  // Stop the browser's HTTP cache from serving stale `/api/run/{id}` polls
+  // and similarly stop Next.js from caching the GET route handler itself.
+  // Override whatever upstream sent (FastAPI sets no cache headers).
+  headers.set("Cache-Control", "no-store, no-cache, must-revalidate")
+  headers.set("Pragma", "no-cache")
 
   return new Response(upstream.body, {
     status: upstream.status,
@@ -41,6 +46,9 @@ async function handle(
     headers,
   })
 }
+
+// Force the proxy out of Next.js's static cache so every request hits FastAPI.
+export const dynamic = "force-dynamic"
 
 export {
   handle as GET,

--- a/apps/web/app/api/[...path]/route.ts
+++ b/apps/web/app/api/[...path]/route.ts
@@ -1,0 +1,51 @@
+import { apiFetch } from "@/lib/api"
+
+const HOP_BY_HOP = new Set([
+  "connection",
+  "keep-alive",
+  "transfer-encoding",
+  "upgrade",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailers",
+  "host",
+  "content-length",
+])
+
+async function handle(
+  req: Request,
+  { params }: { params: { path: string[] } },
+) {
+  const upstreamPath = "/api/" + params.path.join("/")
+  const url = new URL(req.url)
+  const target = upstreamPath + url.search
+
+  const init: RequestInit = { method: req.method }
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    init.body = await req.arrayBuffer()
+    const ct = req.headers.get("content-type")
+    if (ct) init.headers = { "content-type": ct }
+  }
+
+  const upstream = await apiFetch(target, init)
+
+  const headers = new Headers()
+  upstream.headers.forEach((value, key) => {
+    if (!HOP_BY_HOP.has(key.toLowerCase())) headers.set(key, value)
+  })
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers,
+  })
+}
+
+export {
+  handle as GET,
+  handle as POST,
+  handle as PUT,
+  handle as DELETE,
+  handle as PATCH,
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,26 +1,25 @@
-import { Button } from "@/components/ui/button"
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card"
+import { apiFetch } from "@/lib/api"
+import { OnboardedHome } from "@/components/OnboardedHome"
+import { Wizard } from "@/components/onboarding/Wizard"
 
-export default function Home() {
+async function isOnboarded(): Promise<boolean> {
+  try {
+    const res = await apiFetch("/api/state")
+    if (!res.ok) return false
+    const data = (await res.json()) as { onboarded?: boolean }
+    return Boolean(data.onboarded)
+  } catch {
+    return false
+  }
+}
+
+export const dynamic = "force-dynamic"
+
+export default async function Home() {
+  const onboarded = await isOnboarded()
   return (
     <main className="flex min-h-screen items-center justify-center p-8">
-      <Card className="w-full max-w-md">
-        <CardHeader>
-          <CardTitle>ai-agent</CardTitle>
-          <CardDescription>
-            Daily briefing &amp; Q&amp;A — Phase 1 scaffold
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <Button>Get started</Button>
-        </CardContent>
-      </Card>
+      {onboarded ? <OnboardedHome /> : <Wizard />}
     </main>
   )
 }

--- a/apps/web/components/OnboardedHome.tsx
+++ b/apps/web/components/OnboardedHome.tsx
@@ -1,0 +1,21 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+
+export function OnboardedHome() {
+  return (
+    <Card className="w-full max-w-md">
+      <CardHeader>
+        <CardTitle>ai-agent</CardTitle>
+        <CardDescription>Setup complete</CardDescription>
+      </CardHeader>
+      <CardContent className="text-sm text-muted-foreground">
+        Main sidebar UI is coming in #71.
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/components/onboarding/Step1AuthMode.tsx
+++ b/apps/web/components/onboarding/Step1AuthMode.tsx
@@ -1,0 +1,94 @@
+"use client"
+import { useState } from "react"
+
+import { AuthMode, WizardData } from "./Wizard"
+import { WizardShell } from "./wizard-shell"
+
+type Props = {
+  data: WizardData
+  setData: (updater: (prev: WizardData) => WizardData) => void
+  onNext: () => void
+  step: 1 | 2 | 3 | 4
+}
+
+const OPTIONS: { value: AuthMode; label: string; hint: string }[] = [
+  {
+    value: "cli",
+    label: "Claude Pro / Max subscription (CLI)",
+    hint: "Uses the OAuth session from `claude login`. No API key billing.",
+  },
+  {
+    value: "api",
+    label: "Anthropic API key",
+    hint: "Pay-per-use via ANTHROPIC_API_KEY. Set the key in Step 3.",
+  },
+]
+
+export function Step1AuthMode({ data, setData, onNext, step }: Props) {
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const submit = async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      const res = await fetch("/api/auth/mode", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ auth_mode: data.authMode }),
+      })
+      if (!res.ok) {
+        setError(`Failed to set auth mode (HTTP ${res.status})`)
+        return
+      }
+      onNext()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Network error")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <WizardShell
+      step={step}
+      title="Choose how to call Claude"
+      description="You can switch later from the sidebar."
+      busy={busy}
+      error={error}
+      primaryLabel="Next"
+      onPrimary={submit}
+    >
+      <fieldset className="space-y-3">
+        <legend className="sr-only">Authentication mode</legend>
+        {OPTIONS.map((opt) => (
+          <label
+            key={opt.value}
+            className="flex cursor-pointer items-start gap-3 rounded-md border p-3 hover:bg-accent"
+          >
+            <input
+              type="radio"
+              name="auth-mode"
+              value={opt.value}
+              checked={data.authMode === opt.value}
+              onChange={() =>
+                setData((prev) => ({ ...prev, authMode: opt.value }))
+              }
+              className="mt-1"
+            />
+            <span className="flex flex-col">
+              <span className="font-medium">{opt.label}</span>
+              <span className="text-xs text-muted-foreground">{opt.hint}</span>
+            </span>
+          </label>
+        ))}
+      </fieldset>
+      {data.authMode === "cli" && (
+        <p className="text-xs text-muted-foreground">
+          Run <code className="font-mono">claude login</code> in a terminal
+          first if you have not authenticated yet.
+        </p>
+      )}
+    </WizardShell>
+  )
+}

--- a/apps/web/components/onboarding/Step2Portfolio.tsx
+++ b/apps/web/components/onboarding/Step2Portfolio.tsx
@@ -1,0 +1,101 @@
+"use client"
+import { useState } from "react"
+
+import { Input } from "@/components/ui/input"
+import { WizardData } from "./Wizard"
+import { WizardShell } from "./wizard-shell"
+
+type Props = {
+  data: WizardData
+  setData: (updater: (prev: WizardData) => WizardData) => void
+  onNext: () => void
+  onBack: () => void
+  step: 1 | 2 | 3 | 4
+}
+
+const splitCsv = (raw: string): string[] =>
+  raw
+    .split(",")
+    .map((t) => t.trim())
+    .filter(Boolean)
+
+export function Step2Portfolio({ data, setData, onNext, onBack, step }: Props) {
+  const [tickersRaw, setTickersRaw] = useState<string>(data.tickers.join(", "))
+  const [themesRaw, setThemesRaw] = useState<string>(data.themes.join(", "))
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const tickers = splitCsv(tickersRaw)
+  const themes = splitCsv(themesRaw)
+  const canSubmit = tickers.length > 0
+
+  const submit = async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      // The backend schema requires >=1 watch_sector. We synthesise a default
+      // sector wrapping the same tickers so the wizard succeeds; the user
+      // refines real sector mapping later from the sidebar.
+      const payload = {
+        portfolio: { tickers, themes },
+        watch_sectors: [
+          { sector: "Default", tickers, notes: null },
+        ],
+        geopolitical: { conflicts: [] },
+        watch_events: [],
+      }
+      const res = await fetch("/api/config", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      })
+      if (!res.ok) {
+        const text = await res.text()
+        setError(`PUT /api/config failed (HTTP ${res.status}): ${text}`)
+        return
+      }
+      setData((prev) => ({ ...prev, tickers, themes }))
+      onNext()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Network error")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <WizardShell
+      step={step}
+      title="Portfolio basics"
+      description="Comma-separated. You can edit watch sectors later."
+      busy={busy}
+      error={error}
+      primaryLabel="Next"
+      primaryDisabled={!canSubmit}
+      onPrimary={submit}
+      onBack={onBack}
+    >
+      <label className="block space-y-1">
+        <span className="text-sm font-medium">Tickers</span>
+        <Input
+          value={tickersRaw}
+          onChange={(e) => setTickersRaw(e.target.value)}
+          placeholder="PLTR, NVDA, GOOGL"
+          data-testid="tickers-input"
+        />
+        <span className="text-xs text-muted-foreground">
+          At least one ticker is required.
+        </span>
+      </label>
+      <label className="block space-y-1">
+        <span className="text-sm font-medium">Themes</span>
+        <Input
+          value={themesRaw}
+          onChange={(e) => setThemesRaw(e.target.value)}
+          placeholder="AI規制, 半導体, 関税"
+          data-testid="themes-input"
+        />
+      </label>
+    </WizardShell>
+  )
+}

--- a/apps/web/components/onboarding/Step2Portfolio.tsx
+++ b/apps/web/components/onboarding/Step2Portfolio.tsx
@@ -19,13 +19,19 @@ const splitCsv = (raw: string): string[] =>
     .map((t) => t.trim())
     .filter(Boolean)
 
+// Backend writes tickers verbatim and downstream metrics sum over the array,
+// so dedupe + uppercase here to avoid double-counting (PLTR vs pltr) and
+// repeat fetches.
+const normalizeTickers = (raw: string): string[] =>
+  Array.from(new Set(splitCsv(raw).map((t) => t.toUpperCase())))
+
 export function Step2Portfolio({ data, setData, onNext, onBack, step }: Props) {
   const [tickersRaw, setTickersRaw] = useState<string>(data.tickers.join(", "))
   const [themesRaw, setThemesRaw] = useState<string>(data.themes.join(", "))
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const tickers = splitCsv(tickersRaw)
+  const tickers = normalizeTickers(tickersRaw)
   const themes = splitCsv(themesRaw)
   const canSubmit = tickers.length > 0
 

--- a/apps/web/components/onboarding/Step3Notifications.tsx
+++ b/apps/web/components/onboarding/Step3Notifications.tsx
@@ -17,12 +17,13 @@ type Field = {
   name: string
   label: string
   hint?: string
+  secret?: boolean
 }
 
 const FIELDS: Field[] = [
-  { name: "DISCORD_TOKEN", label: "Discord bot token" },
+  { name: "DISCORD_TOKEN", label: "Discord bot token", secret: true },
   { name: "CHANNEL_ID", label: "Discord channel id" },
-  { name: "NOTION_API_KEY", label: "Notion integration API key" },
+  { name: "NOTION_API_KEY", label: "Notion integration API key", secret: true },
   { name: "NOTION_DATABASE_ID", label: "Notion database id" },
 ]
 
@@ -44,6 +45,7 @@ export function Step3Notifications({
           name: "ANTHROPIC_API_KEY",
           label: "Anthropic API key",
           hint: "Required because you picked API mode in Step 1.",
+          secret: true,
         },
       ]
     : FIELDS
@@ -96,7 +98,7 @@ export function Step3Notifications({
         <label key={f.name} className="block space-y-1">
           <span className="text-sm font-medium">{f.label}</span>
           <Input
-            type="password"
+            type={f.secret ? "password" : "text"}
             value={values[f.name] ?? ""}
             onChange={(e) =>
               setValues((prev) => ({ ...prev, [f.name]: e.target.value }))

--- a/apps/web/components/onboarding/Step3Notifications.tsx
+++ b/apps/web/components/onboarding/Step3Notifications.tsx
@@ -1,0 +1,113 @@
+"use client"
+import { useState } from "react"
+
+import { Input } from "@/components/ui/input"
+import { WizardData } from "./Wizard"
+import { WizardShell } from "./wizard-shell"
+
+type Props = {
+  data: WizardData
+  setData: (updater: (prev: WizardData) => WizardData) => void
+  onNext: () => void
+  onBack: () => void
+  step: 1 | 2 | 3 | 4
+}
+
+type Field = {
+  name: string
+  label: string
+  hint?: string
+}
+
+const FIELDS: Field[] = [
+  { name: "DISCORD_TOKEN", label: "Discord bot token" },
+  { name: "CHANNEL_ID", label: "Discord channel id" },
+  { name: "NOTION_API_KEY", label: "Notion integration API key" },
+  { name: "NOTION_DATABASE_ID", label: "Notion database id" },
+]
+
+export function Step3Notifications({
+  data,
+  onNext,
+  onBack,
+  step,
+}: Props) {
+  const [values, setValues] = useState<Record<string, string>>(() =>
+    Object.fromEntries(FIELDS.map((f) => [f.name, ""])),
+  )
+  // ANTHROPIC_API_KEY only shown when API auth mode is selected in Step 1.
+  const showAnthropicKey = data.authMode === "api"
+  const allFields: Field[] = showAnthropicKey
+    ? [
+        ...FIELDS,
+        {
+          name: "ANTHROPIC_API_KEY",
+          label: "Anthropic API key",
+          hint: "Required because you picked API mode in Step 1.",
+        },
+      ]
+    : FIELDS
+
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const submit = async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      const writes = allFields
+        .map((f) => [f.name, (values[f.name] ?? "").trim()] as const)
+        .filter(([, v]) => v.length > 0)
+      for (const [name, value] of writes) {
+        const res = await fetch(
+          `/api/credentials/${encodeURIComponent(name)}`,
+          {
+            method: "PUT",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ value }),
+          },
+        )
+        if (!res.ok) {
+          const text = await res.text()
+          setError(`PUT /api/credentials/${name} failed (HTTP ${res.status}): ${text}`)
+          return
+        }
+      }
+      onNext()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Network error")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <WizardShell
+      step={step}
+      title="Notifications and credentials"
+      description="Leave any field blank to skip. You can add them later from the sidebar."
+      busy={busy}
+      error={error}
+      primaryLabel="Next"
+      onPrimary={submit}
+      onBack={onBack}
+    >
+      {allFields.map((f) => (
+        <label key={f.name} className="block space-y-1">
+          <span className="text-sm font-medium">{f.label}</span>
+          <Input
+            type="password"
+            value={values[f.name] ?? ""}
+            onChange={(e) =>
+              setValues((prev) => ({ ...prev, [f.name]: e.target.value }))
+            }
+            data-testid={`cred-${f.name}`}
+          />
+          {f.hint && (
+            <span className="text-xs text-muted-foreground">{f.hint}</span>
+          )}
+        </label>
+      ))}
+    </WizardShell>
+  )
+}

--- a/apps/web/components/onboarding/Step4TestRun.tsx
+++ b/apps/web/components/onboarding/Step4TestRun.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useState } from "react"
 
 import { WizardData } from "./Wizard"
 import { WizardShell } from "./wizard-shell"
@@ -21,9 +21,6 @@ export function Step4TestRun({ onBack, step }: Props) {
   const [jobId, setJobId] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [completing, setCompleting] = useState(false)
-  const cancelledRef = useRef(false)
-
-  useEffect(() => () => { cancelledRef.current = true }, [])
 
   const finishOnboarding = useCallback(async () => {
     setCompleting(true)
@@ -64,9 +61,13 @@ export function Step4TestRun({ onBack, step }: Props) {
       }
       const body = (await res.json()) as { job_id: string; status: JobStatus }
       setJobId(body.job_id)
-      // poll
+      // Poll until the job leaves pending/running. The 30s ceiling is the
+      // only stop condition; we don't track a cancelled flag because the
+      // button is disabled while busy so the user can't navigate away
+      // mid-poll, and StrictMode double-invoke of an effect-based flag was
+      // the source of an earlier "loop never starts" bug.
       const startedAt = Date.now()
-      while (!cancelledRef.current) {
+      while (true) {
         await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS))
         if (Date.now() - startedAt > POLL_TIMEOUT_MS) {
           setError("Timed out waiting for the job to finish")

--- a/apps/web/components/onboarding/Step4TestRun.tsx
+++ b/apps/web/components/onboarding/Step4TestRun.tsx
@@ -52,7 +52,10 @@ export function Step4TestRun({ onBack, step }: Props) {
     setStatus("pending")
     setJobId(null)
     try {
-      const res = await fetch("/api/run?dry_run=true", { method: "POST" })
+      const res = await fetch("/api/run?dry_run=true", {
+        method: "POST",
+        cache: "no-store",
+      })
       if (!res.ok) {
         const text = await res.text()
         setError(`POST /api/run failed (HTTP ${res.status}): ${text}`)
@@ -70,7 +73,9 @@ export function Step4TestRun({ onBack, step }: Props) {
           setStatus("failed")
           return
         }
-        const pollRes = await fetch(`/api/run/${body.job_id}`)
+        const pollRes = await fetch(`/api/run/${body.job_id}`, {
+          cache: "no-store",
+        })
         if (!pollRes.ok) {
           setError(`GET /api/run/${body.job_id} failed (HTTP ${pollRes.status})`)
           setStatus("failed")

--- a/apps/web/components/onboarding/Step4TestRun.tsx
+++ b/apps/web/components/onboarding/Step4TestRun.tsx
@@ -1,0 +1,145 @@
+"use client"
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import { WizardData } from "./Wizard"
+import { WizardShell } from "./wizard-shell"
+
+type Props = {
+  data: WizardData
+  setData: (updater: (prev: WizardData) => WizardData) => void
+  onBack: () => void
+  step: 1 | 2 | 3 | 4
+}
+
+type JobStatus = "idle" | "pending" | "running" | "done" | "failed"
+
+const POLL_INTERVAL_MS = 1000
+const POLL_TIMEOUT_MS = 30_000
+
+export function Step4TestRun({ onBack, step }: Props) {
+  const [status, setStatus] = useState<JobStatus>("idle")
+  const [jobId, setJobId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [completing, setCompleting] = useState(false)
+  const cancelledRef = useRef(false)
+
+  useEffect(() => () => { cancelledRef.current = true }, [])
+
+  const finishOnboarding = useCallback(async () => {
+    setCompleting(true)
+    try {
+      const res = await fetch("/api/state", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ onboarded: true }),
+      })
+      if (!res.ok) {
+        setError(`PUT /api/state failed (HTTP ${res.status})`)
+        setCompleting(false)
+        return
+      }
+      // Reload so the Server Component re-evaluates and renders the
+      // post-onboarding placeholder.
+      window.location.reload()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Network error")
+      setCompleting(false)
+    }
+  }, [])
+
+  const runTest = useCallback(async () => {
+    setError(null)
+    setStatus("pending")
+    setJobId(null)
+    try {
+      const res = await fetch("/api/run?dry_run=true", { method: "POST" })
+      if (!res.ok) {
+        const text = await res.text()
+        setError(`POST /api/run failed (HTTP ${res.status}): ${text}`)
+        setStatus("failed")
+        return
+      }
+      const body = (await res.json()) as { job_id: string; status: JobStatus }
+      setJobId(body.job_id)
+      // poll
+      const startedAt = Date.now()
+      while (!cancelledRef.current) {
+        await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS))
+        if (Date.now() - startedAt > POLL_TIMEOUT_MS) {
+          setError("Timed out waiting for the job to finish")
+          setStatus("failed")
+          return
+        }
+        const pollRes = await fetch(`/api/run/${body.job_id}`)
+        if (!pollRes.ok) {
+          setError(`GET /api/run/${body.job_id} failed (HTTP ${pollRes.status})`)
+          setStatus("failed")
+          return
+        }
+        const detail = (await pollRes.json()) as {
+          status: JobStatus
+          error?: string | null
+        }
+        setStatus(detail.status)
+        if (detail.status === "done") return
+        if (detail.status === "failed") {
+          setError(detail.error ?? "Job failed without an error message")
+          return
+        }
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Network error")
+      setStatus("failed")
+    }
+  }, [])
+
+  const isDone = status === "done"
+  const isFailed = status === "failed"
+  const busy = status === "pending" || status === "running" || completing
+
+  let primaryLabel: string
+  let primaryHandler: () => void
+  if (isDone) {
+    primaryLabel = "Finish"
+    primaryHandler = finishOnboarding
+  } else if (busy) {
+    primaryLabel = "..."
+    primaryHandler = () => undefined
+  } else if (isFailed) {
+    primaryLabel = "Retry"
+    primaryHandler = () => void runTest()
+  } else {
+    primaryLabel = "Run test"
+    primaryHandler = () => void runTest()
+  }
+
+  return (
+    <WizardShell
+      step={step}
+      title="Verify the pipeline"
+      description="Runs /api/run?dry_run=true — credential preflight only, no Claude calls."
+      busy={busy}
+      error={error}
+      primaryLabel={primaryLabel}
+      onPrimary={primaryHandler}
+      onBack={isDone || completing ? undefined : onBack}
+    >
+      <div className="space-y-2 text-sm">
+        <p>
+          <span className="font-medium">Status:</span>{" "}
+          <span data-testid="job-status">{status}</span>
+        </p>
+        {jobId && (
+          <p className="text-xs text-muted-foreground">
+            Job id: <code className="font-mono">{jobId}</code>
+          </p>
+        )}
+        {isDone && (
+          <p className="text-sm">
+            All good. Press <strong>Finish</strong> to complete onboarding.
+          </p>
+        )}
+      </div>
+    </WizardShell>
+  )
+}

--- a/apps/web/components/onboarding/Wizard.tsx
+++ b/apps/web/components/onboarding/Wizard.tsx
@@ -1,0 +1,40 @@
+"use client"
+import { useState } from "react"
+
+import { Step1AuthMode } from "./Step1AuthMode"
+import { Step2Portfolio } from "./Step2Portfolio"
+import { Step3Notifications } from "./Step3Notifications"
+import { Step4TestRun } from "./Step4TestRun"
+
+export type AuthMode = "cli" | "api"
+
+export type WizardData = {
+  authMode: AuthMode
+  tickers: string[]
+  themes: string[]
+}
+
+const INITIAL: WizardData = {
+  authMode: "cli",
+  tickers: [],
+  themes: [],
+}
+
+export function Wizard() {
+  const [step, setStep] = useState<1 | 2 | 3 | 4>(1)
+  const [data, setData] = useState<WizardData>(INITIAL)
+
+  const goNext = () => setStep((s) => (s === 4 ? s : ((s + 1) as 1 | 2 | 3 | 4)))
+  const goBack = () => setStep((s) => (s === 1 ? s : ((s - 1) as 1 | 2 | 3 | 4)))
+
+  const props = { data, setData, onNext: goNext, onBack: goBack, step }
+
+  return (
+    <div className="w-full max-w-xl" data-testid="wizard">
+      {step === 1 && <Step1AuthMode {...props} />}
+      {step === 2 && <Step2Portfolio {...props} />}
+      {step === 3 && <Step3Notifications {...props} />}
+      {step === 4 && <Step4TestRun {...props} />}
+    </div>
+  )
+}

--- a/apps/web/components/onboarding/wizard-shell.tsx
+++ b/apps/web/components/onboarding/wizard-shell.tsx
@@ -1,0 +1,77 @@
+"use client"
+import { ReactNode } from "react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+
+export type ShellProps = {
+  step: 1 | 2 | 3 | 4
+  title: string
+  description?: string
+  error?: string | null
+  busy?: boolean
+  primaryLabel: string
+  onPrimary: () => void | Promise<void>
+  primaryDisabled?: boolean
+  onBack?: () => void
+  children: ReactNode
+}
+
+export function WizardShell({
+  step,
+  title,
+  description,
+  error,
+  busy,
+  primaryLabel,
+  onPrimary,
+  primaryDisabled,
+  onBack,
+  children,
+}: ShellProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <p className="text-xs text-muted-foreground">Step {step} / 4</p>
+        <CardTitle>{title}</CardTitle>
+        {description && <CardDescription>{description}</CardDescription>}
+      </CardHeader>
+      <CardContent className="space-y-4">{children}</CardContent>
+      <CardFooter className="flex flex-col items-stretch gap-2">
+        {error && (
+          <p
+            role="alert"
+            className="text-sm text-destructive"
+            data-testid="wizard-error"
+          >
+            {error}
+          </p>
+        )}
+        <div className="flex justify-between gap-2">
+          <Button
+            variant="ghost"
+            onClick={onBack}
+            disabled={!onBack || busy}
+            data-testid="wizard-back"
+          >
+            Back
+          </Button>
+          <Button
+            onClick={() => void onPrimary()}
+            disabled={busy || primaryDisabled}
+            data-testid="wizard-primary"
+          >
+            {busy ? "..." : primaryLabel}
+          </Button>
+        </div>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -14,5 +14,9 @@ export async function apiFetch(
 ): Promise<Response> {
   const headers = new Headers(init.headers)
   headers.set("Authorization", `Bearer ${readToken()}`)
-  return fetch(`${API_BASE}${path}`, { ...init, headers })
+  // `cache: 'no-store'` opts out of Next.js's Server Component fetch cache.
+  // Without it, RSC reads (e.g. /api/state) are memoised for the lifetime
+  // of the render and stale after the user mutates state, so the wizard
+  // would not advance to OnboardedHome on reload.
+  return fetch(`${API_BASE}${path}`, { cache: "no-store", ...init, headers })
 }

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -17,6 +17,7 @@ export async function apiFetch(
   // `cache: 'no-store'` opts out of Next.js's Server Component fetch cache.
   // Without it, RSC reads (e.g. /api/state) are memoised for the lifetime
   // of the render and stale after the user mutates state, so the wizard
-  // would not advance to OnboardedHome on reload.
-  return fetch(`${API_BASE}${path}`, { cache: "no-store", ...init, headers })
+  // would not advance to OnboardedHome on reload. Set AFTER `...init` so
+  // callers can't accidentally re-enable caching.
+  return fetch(`${API_BASE}${path}`, { ...init, cache: "no-store", headers })
 }

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -23,6 +23,7 @@
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -1427,6 +1428,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -1504,6 +1506,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,6 +26,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/apps/web/tests/smoke.test.tsx
+++ b/apps/web/tests/smoke.test.tsx
@@ -1,14 +1,13 @@
 import { render, screen } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
 
-import Home from "@/app/page"
+import { OnboardedHome } from "@/components/OnboardedHome"
 
-describe("Home", () => {
-  it("renders the shadcn Card title and Button", () => {
-    render(<Home />)
+describe("OnboardedHome", () => {
+  it("renders the shadcn Card title and post-onboarding hint", () => {
+    render(<OnboardedHome />)
     expect(screen.getByText("ai-agent")).toBeInTheDocument()
-    expect(
-      screen.getByRole("button", { name: /get started/i }),
-    ).toBeInTheDocument()
+    expect(screen.getByText(/Setup complete/i)).toBeInTheDocument()
+    expect(screen.getByText(/Main sidebar UI is coming in #71/)).toBeInTheDocument()
   })
 })

--- a/apps/web/tests/wizard.test.tsx
+++ b/apps/web/tests/wizard.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { Wizard } from "@/components/onboarding/Wizard"
+
+describe("Wizard", () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    vi.stubGlobal("fetch", fetchMock)
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("renders Step 1 by default", () => {
+    render(<Wizard />)
+    expect(screen.getByText(/Step 1 \/ 4/)).toBeInTheDocument()
+    expect(screen.getByText(/Choose how to call Claude/)).toBeInTheDocument()
+  })
+
+  it("advances from Step 1 to Step 2 after PUT /api/auth/mode succeeds", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ auth_mode: "cli" }), { status: 200 }),
+    )
+    const user = userEvent.setup()
+    render(<Wizard />)
+
+    await user.click(screen.getByTestId("wizard-primary"))
+
+    await waitFor(() => {
+      expect(screen.getByText(/Step 2 \/ 4/)).toBeInTheDocument()
+    })
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/auth/mode",
+      expect.objectContaining({ method: "PUT" }),
+    )
+    expect(screen.getByTestId("tickers-input")).toBeInTheDocument()
+  })
+
+  it("surfaces a Step 1 error when PUT /api/auth/mode fails", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response("boom", { status: 500 }),
+    )
+    const user = userEvent.setup()
+    render(<Wizard />)
+
+    await user.click(screen.getByTestId("wizard-primary"))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("wizard-error")).toHaveTextContent(/500/)
+    })
+    expect(screen.getByText(/Step 1 \/ 4/)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
Implements the first-run wizard from Issue #70 + the small backend it needs.

**Backend (`apps/python`):**
- `web/routers/state.py` — generic `GET /api/state` (returns the full state) and `PUT /api/state` (partial read-modify-write). Used by the wizard to flip `onboarded → true` on completion.
- `web/app.py` — register the new router under `/api`.
- `tests/test_api_state.py` — 6 cases: defaults when file missing, bearer requirement, partial update preserves untouched fields, invalid `auth_mode` → 422, unknown fields silently dropped (`version` stays read-only).

**Frontend (`apps/web`):**
- `app/api/[...path]/route.ts` — catch-all Route Handler that proxies any `/api/*` call to FastAPI server-side via `lib/api.ts`. Browser never sees the bearer token; client components just `fetch("/api/...")`.
- `app/page.tsx` — Server Component reads `/api/state`, renders `<Wizard />` when not onboarded, `<OnboardedHome />` (placeholder Card for #71) otherwise. `dynamic = "force-dynamic"` so the page isn't statically pre-rendered.
- `lib/api.ts` — default `cache: "no-store"` on the outbound fetch. Without it Next.js memoises RSC reads for the render lifetime, so the `/api/state` check kept returning the pre-mutation snapshot after the wizard finished.
- `components/onboarding/Wizard.tsx` — client-side step state machine (1–4 + accumulated data).
- `components/onboarding/wizard-shell.tsx` — shared Card/header/footer so each step file is just its own fields.
- `Step1AuthMode` — CLI / API radio, persists via `PUT /api/auth/mode`.
- `Step2Portfolio` — tickers (≥1) + themes CSV, `PUT /api/config`. Synthesises a single `"Default"` `watch_sector` wrapping the same tickers because `BriefingFileConfig.watch_sectors` requires `min_length=1`; the user refines real sectors in #71.
- `Step3Notifications` — per-field `PUT /api/credentials/{name}` (DISCORD_TOKEN / CHANNEL_ID / NOTION_API_KEY / NOTION_DATABASE_ID), skipping empties. `ANTHROPIC_API_KEY` field only appears when API mode was picked.
- `Step4TestRun` — `POST /api/run?dry_run=true`, polls `/api/run/{id}` at 1 Hz with a 30 s ceiling, surfaces `failed.error`, then flips `onboarded` via `PUT /api/state` and reloads.
- `components/OnboardedHome.tsx` — post-onboarding placeholder Card.
- `tests/wizard.test.tsx` — renders Step 1, asserts the advance-to-Step-2 path on a 200 PUT, and the error path on a 500.
- `tests/smoke.test.tsx` — pivoted from `Home` (now an async Server Component RTL can't render directly) to `OnboardedHome`.
- `package.json` — `@testing-library/user-event` dev dep.

## Test plan
- [x] `cd apps/python && .venv/bin/pytest tests/test_api_state.py -v` → 6/6 passed (coverage: state.py 97%).
- [x] `cd apps/web && npm run test` → 4/4 passed (OnboardedHome smoke + Wizard step nav + error).
- [x] `cd apps/web && npm run build` → Compiled successfully; `/` is `ƒ (Dynamic)`, `/api/[...path]` is `ƒ`.
- [x] `bin/serve.sh --no-browser` + `curl /api/state` (direct and via proxy) both 200.
- [x] `GET /` with `onboarded=false` returns the wizard ("Step 1 / 4", "Choose how to call Claude").
- [x] `PUT /api/state {"onboarded": true}` via proxy → `GET /` switches to OnboardedHome ("Setup complete", "Main sidebar UI is coming in #71"). `PUT … {"onboarded": false}` switches back.
- [x] Reviewer: walk all four wizard steps in a browser with real credentials handy; confirm Step 4's dry_run job completes and `Finish` reloads into OnboardedHome.

Closes #70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-step onboarding wizard guiding users through authentication setup, portfolio configuration, and credential management
  * Introduced state persistence to track onboarding completion
  * Home page now dynamically displays appropriate content based on onboarding status

* **Tests**
  * Added comprehensive test coverage for onboarding wizard flow
  * Added test coverage for state API endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->