### PR TITLE
feat(web): sidebar settings UI for credentials + auth mode

### DIFF
--- a/apps/web/app/(main)/auth/page.tsx
+++ b/apps/web/app/(main)/auth/page.tsx
@@ -1,0 +1,46 @@
+import { apiFetch } from "@/lib/api"
+import { AuthModeForm } from "@/components/screens/AuthModeForm"
+
+type Initial = {
+  authMode: "cli" | "api"
+  anthropicKeySet: boolean
+}
+
+async function loadInitial(): Promise<Initial> {
+  const [modeRes, credsRes] = await Promise.all([
+    apiFetch("/api/auth/mode"),
+    apiFetch("/api/credentials"),
+  ])
+  if (!modeRes.ok) {
+    throw new Error(`GET /api/auth/mode returned HTTP ${modeRes.status}`)
+  }
+  if (!credsRes.ok) {
+    throw new Error(`GET /api/credentials returned HTTP ${credsRes.status}`)
+  }
+  const mode = (await modeRes.json()) as { auth_mode: "cli" | "api" }
+  const creds = (await credsRes.json()) as Record<string, boolean>
+  return {
+    authMode: mode.auth_mode,
+    anthropicKeySet: Boolean(creds.ANTHROPIC_API_KEY),
+  }
+}
+
+export const dynamic = "force-dynamic"
+
+export default async function AuthPage() {
+  const initial = await loadInitial()
+  return (
+    <div className="space-y-4">
+      <header>
+        <h2 className="text-xl font-semibold">Auth</h2>
+        <p className="text-sm text-muted-foreground">
+          How ai-agent talks to Claude. Switch any time.
+        </p>
+      </header>
+      <AuthModeForm
+        initialAuthMode={initial.authMode}
+        anthropicKeySet={initial.anthropicKeySet}
+      />
+    </div>
+  )
+}

--- a/apps/web/app/(main)/credentials/page.tsx
+++ b/apps/web/app/(main)/credentials/page.tsx
@@ -1,0 +1,28 @@
+import { apiFetch } from "@/lib/api"
+import { CredentialsForm } from "@/components/screens/CredentialsForm"
+
+async function loadStatus(): Promise<Record<string, boolean>> {
+  const res = await apiFetch("/api/credentials")
+  if (!res.ok) {
+    throw new Error(`GET /api/credentials returned HTTP ${res.status}`)
+  }
+  return (await res.json()) as Record<string, boolean>
+}
+
+export const dynamic = "force-dynamic"
+
+export default async function CredentialsPage() {
+  const status = await loadStatus()
+  return (
+    <div className="space-y-4">
+      <header>
+        <h2 className="text-xl font-semibold">Credentials</h2>
+        <p className="text-sm text-muted-foreground">
+          Stored in the OS keychain. Existing values are never shown — only
+          whether each key is set.
+        </p>
+      </header>
+      <CredentialsForm initial={status} />
+    </div>
+  )
+}

--- a/apps/web/components/Sidebar.tsx
+++ b/apps/web/components/Sidebar.tsx
@@ -10,6 +10,8 @@ const ITEMS: Item[] = [
   { href: "/portfolio", label: "Portfolio", icon: "📊" },
   { href: "/watch-sectors", label: "Watch Sectors", icon: "🌐" },
   { href: "/geopolitical", label: "Geopolitical Risks", icon: "🗺️" },
+  { href: "/credentials", label: "Credentials", icon: "📨" },
+  { href: "/auth", label: "Auth", icon: "🔑" },
 ]
 
 export function Sidebar() {

--- a/apps/web/components/screens/AuthModeForm.tsx
+++ b/apps/web/components/screens/AuthModeForm.tsx
@@ -1,0 +1,129 @@
+"use client"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { SaveStatus, SaveStatusValue } from "@/components/SaveStatus"
+
+type AuthMode = "cli" | "api"
+
+type Props = {
+  initialAuthMode: AuthMode
+  anthropicKeySet: boolean
+}
+
+const OPTIONS: { value: AuthMode; label: string; hint: string }[] = [
+  {
+    value: "cli",
+    label: "Claude Pro / Max subscription (CLI)",
+    hint: "Uses the OAuth session from `claude login`. No API key billing.",
+  },
+  {
+    value: "api",
+    label: "Anthropic API key",
+    hint: "Pay-per-use via ANTHROPIC_API_KEY (stored in the keychain).",
+  },
+]
+
+export function AuthModeForm({ initialAuthMode, anthropicKeySet }: Props) {
+  const router = useRouter()
+  const [selected, setSelected] = useState<AuthMode>(initialAuthMode)
+  const [status, setStatus] = useState<SaveStatusValue>("idle")
+  const [error, setError] = useState<string | null>(null)
+
+  // Guard: API mode requires ANTHROPIC_API_KEY in the keychain. We let the
+  // user select the radio but prevent submission with an inline message,
+  // so they can read the rationale + the link before committing.
+  const apiBlocked = selected === "api" && !anthropicKeySet
+
+  const save = async () => {
+    if (apiBlocked) {
+      setError(
+        "Set ANTHROPIC_API_KEY in Credentials before switching to API mode.",
+      )
+      setStatus("error")
+      return
+    }
+    setStatus("saving")
+    setError(null)
+    const res = await fetch("/api/auth/mode", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ auth_mode: selected }),
+    })
+    if (!res.ok) {
+      setError(`PUT /api/auth/mode failed (HTTP ${res.status})`)
+      setStatus("error")
+      return
+    }
+    setStatus("saved")
+    router.refresh()
+  }
+
+  return (
+    <div className="space-y-4">
+      <fieldset className="space-y-3" data-testid="auth-options">
+        <legend className="sr-only">Authentication mode</legend>
+        {OPTIONS.map((opt) => (
+          <Card key={opt.value}>
+            <CardContent className="pt-6">
+              <label className="flex cursor-pointer items-start gap-3">
+                <input
+                  type="radio"
+                  name="auth-mode"
+                  value={opt.value}
+                  checked={selected === opt.value}
+                  onChange={() => setSelected(opt.value)}
+                  className="mt-1"
+                  data-testid={`auth-radio-${opt.value}`}
+                />
+                <span className="flex flex-col">
+                  <span className="font-medium">{opt.label}</span>
+                  <span className="text-xs text-muted-foreground">
+                    {opt.hint}
+                  </span>
+                </span>
+              </label>
+            </CardContent>
+          </Card>
+        ))}
+      </fieldset>
+
+      {apiBlocked && (
+        <p
+          className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive"
+          data-testid="api-blocked"
+        >
+          API mode requires <code className="font-mono">ANTHROPIC_API_KEY</code>
+          {" "}in the keychain. Open{" "}
+          <Link
+            href="/credentials"
+            className="underline underline-offset-2"
+          >
+            Credentials
+          </Link>{" "}
+          to set it, then come back.
+        </p>
+      )}
+
+      <div className="flex items-center gap-3">
+        <Button
+          onClick={() => void save()}
+          disabled={status === "saving" || selected === initialAuthMode}
+          data-testid="auth-save"
+        >
+          Save
+        </Button>
+        <SaveStatus status={status} />
+      </div>
+
+      {error && (
+        <p className="text-sm text-destructive" data-testid="generic-error">
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/apps/web/components/screens/CredentialsForm.tsx
+++ b/apps/web/components/screens/CredentialsForm.tsx
@@ -1,0 +1,202 @@
+"use client"
+import { useRouter } from "next/navigation"
+import { useState } from "react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+
+type Props = { initial: Record<string, boolean> }
+
+type Field = { name: string; label: string; secret: boolean }
+
+// Mirrors apps/python/src/credentials.ALLOWED_KEYS so the UI lists exactly
+// what the backend will accept.
+const FIELDS: Field[] = [
+  { name: "DISCORD_TOKEN", label: "Discord bot token", secret: true },
+  { name: "CHANNEL_ID", label: "Discord channel id", secret: false },
+  { name: "NOTION_API_KEY", label: "Notion integration key", secret: true },
+  { name: "NOTION_DATABASE_ID", label: "Notion database id", secret: false },
+  { name: "ANTHROPIC_API_KEY", label: "Anthropic API key", secret: true },
+]
+
+export function CredentialsForm({ initial }: Props) {
+  const router = useRouter()
+  const [status, setStatus] = useState<Record<string, boolean>>(initial)
+  const [editing, setEditing] = useState<Field | null>(null)
+  const [draft, setDraft] = useState("")
+  const [busy, setBusy] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const openEdit = (f: Field) => {
+    setEditing(f)
+    setDraft("")
+    setError(null)
+  }
+  const closeEdit = () => {
+    setEditing(null)
+    setDraft("")
+  }
+
+  const save = async () => {
+    if (!editing) return
+    const value = draft.trim()
+    if (value === "") {
+      setError("Value is required")
+      return
+    }
+    setBusy(editing.name)
+    setError(null)
+    const res = await fetch(
+      `/api/credentials/${encodeURIComponent(editing.name)}`,
+      {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ value }),
+      },
+    )
+    setBusy(null)
+    if (!res.ok) {
+      setError(`PUT failed (HTTP ${res.status})`)
+      return
+    }
+    setStatus((prev) => ({ ...prev, [editing.name]: true }))
+    closeEdit()
+    router.refresh()
+  }
+
+  const remove = async (name: string) => {
+    setBusy(name)
+    setError(null)
+    const res = await fetch(`/api/credentials/${encodeURIComponent(name)}`, {
+      method: "DELETE",
+    })
+    setBusy(null)
+    if (!res.ok) {
+      setError(`DELETE failed (HTTP ${res.status})`)
+      return
+    }
+    setStatus((prev) => ({ ...prev, [name]: false }))
+    router.refresh()
+  }
+
+  return (
+    <div className="space-y-3">
+      {FIELDS.map((f) => {
+        const set = Boolean(status[f.name])
+        return (
+          <Card key={f.name}>
+            <CardContent className="flex items-center justify-between gap-4 pt-6">
+              <div className="space-y-1">
+                <p className="font-medium">{f.label}</p>
+                <p className="text-xs font-mono text-muted-foreground">
+                  {f.name}
+                </p>
+              </div>
+              <div className="flex items-center gap-3">
+                <Badge
+                  variant={set ? "default" : "secondary"}
+                  data-testid={`status-${f.name}`}
+                >
+                  {set ? "Set" : "Not set"}
+                </Badge>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => openEdit(f)}
+                  disabled={busy === f.name}
+                  data-testid={`update-${f.name}`}
+                >
+                  {set ? "Update" : "Set"}
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => void remove(f.name)}
+                  disabled={!set || busy === f.name}
+                  data-testid={`delete-${f.name}`}
+                >
+                  Delete
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        )
+      })}
+
+      <Dialog
+        open={editing !== null}
+        onOpenChange={(open) => {
+          if (!open) closeEdit()
+        }}
+      >
+        <DialogContent>
+          {editing && (
+            <>
+              <DialogHeader>
+                <DialogTitle>
+                  {status[editing.name] ? "Update" : "Set"} {editing.label}
+                </DialogTitle>
+                <DialogDescription>
+                  Stored in the OS keychain under
+                  <code className="ml-1 font-mono">{editing.name}</code>.
+                </DialogDescription>
+              </DialogHeader>
+              <Input
+                autoFocus
+                type={editing.secret ? "password" : "text"}
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                placeholder={
+                  editing.secret ? "••••••••••" : "Paste the value"
+                }
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault()
+                    void save()
+                  }
+                }}
+                data-testid="credential-draft"
+              />
+              {error && (
+                <p
+                  className="text-sm text-destructive"
+                  data-testid="credential-error"
+                >
+                  {error}
+                </p>
+              )}
+              <DialogFooter>
+                <Button variant="ghost" onClick={closeEdit}>
+                  Cancel
+                </Button>
+                <Button
+                  onClick={() => void save()}
+                  disabled={busy === editing.name}
+                  data-testid="credential-save"
+                >
+                  Save
+                </Button>
+              </DialogFooter>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {error && !editing && (
+        <p className="text-sm text-destructive" data-testid="generic-error">
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/apps/web/tests/auth-mode-form.test.tsx
+++ b/apps/web/tests/auth-mode-form.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { AuthModeForm } from "@/components/screens/AuthModeForm"
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}))
+
+describe("AuthModeForm", () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    vi.stubGlobal("fetch", fetchMock)
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("blocks API mode selection when ANTHROPIC_API_KEY is not set", async () => {
+    const user = userEvent.setup()
+    render(<AuthModeForm initialAuthMode="cli" anthropicKeySet={false} />)
+    await user.click(screen.getByTestId("auth-radio-api"))
+    expect(screen.getByTestId("api-blocked")).toBeInTheDocument()
+
+    await user.click(screen.getByTestId("auth-save"))
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("allows API mode selection when ANTHROPIC_API_KEY is set", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ auth_mode: "api" }), { status: 200 }),
+    )
+    const user = userEvent.setup()
+    render(<AuthModeForm initialAuthMode="cli" anthropicKeySet={true} />)
+    await user.click(screen.getByTestId("auth-radio-api"))
+    expect(screen.queryByTestId("api-blocked")).toBeNull()
+
+    await user.click(screen.getByTestId("auth-save"))
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/auth/mode",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ auth_mode: "api" }),
+      }),
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId("save-status")).toHaveTextContent("Saved")
+    })
+  })
+
+  it("disables Save when the current selection matches the initial mode", () => {
+    render(<AuthModeForm initialAuthMode="cli" anthropicKeySet={true} />)
+    const btn = screen.getByTestId("auth-save") as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+  })
+})

--- a/apps/web/tests/credentials-form.test.tsx
+++ b/apps/web/tests/credentials-form.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { CredentialsForm } from "@/components/screens/CredentialsForm"
+
+// next/navigation is opaque under jsdom; stub the bits the component touches.
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}))
+
+describe("CredentialsForm", () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    vi.stubGlobal("fetch", fetchMock)
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  const initial = {
+    DISCORD_TOKEN: true,
+    CHANNEL_ID: false,
+    NOTION_API_KEY: false,
+    NOTION_DATABASE_ID: true,
+    ANTHROPIC_API_KEY: false,
+  }
+
+  it("renders Set / Not set badges from status", () => {
+    render(<CredentialsForm initial={initial} />)
+    expect(screen.getByTestId("status-DISCORD_TOKEN")).toHaveTextContent("Set")
+    expect(screen.getByTestId("status-CHANNEL_ID")).toHaveTextContent("Not set")
+    expect(screen.getByTestId("status-NOTION_DATABASE_ID")).toHaveTextContent(
+      "Set",
+    )
+  })
+
+  it("PUTs masked value when the dialog Save is clicked", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }))
+    const user = userEvent.setup()
+    render(<CredentialsForm initial={initial} />)
+
+    await user.click(screen.getByTestId("update-ANTHROPIC_API_KEY"))
+    const input = (await screen.findByTestId(
+      "credential-draft",
+    )) as HTMLInputElement
+    expect(input.type).toBe("password") // secret field is masked
+
+    await user.type(input, "sk-test-key")
+    await user.click(screen.getByTestId("credential-save"))
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/credentials/ANTHROPIC_API_KEY",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ value: "sk-test-key" }),
+      }),
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId("status-ANTHROPIC_API_KEY")).toHaveTextContent(
+        "Set",
+      )
+    })
+  })
+
+  it("renders the Channel ID input as text (not a password)", async () => {
+    const user = userEvent.setup()
+    render(<CredentialsForm initial={initial} />)
+    await user.click(screen.getByTestId("update-CHANNEL_ID"))
+    const input = (await screen.findByTestId(
+      "credential-draft",
+    )) as HTMLInputElement
+    expect(input.type).toBe("text")
+  })
+
+  it("DELETEs the credential and flips the badge to Not set", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }))
+    const user = userEvent.setup()
+    render(<CredentialsForm initial={initial} />)
+
+    await user.click(screen.getByTestId("delete-DISCORD_TOKEN"))
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/credentials/DISCORD_TOKEN",
+      expect.objectContaining({ method: "DELETE" }),
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId("status-DISCORD_TOKEN")).toHaveTextContent(
+        "Not set",
+      )
+    })
+  })
+
+  it("disables Delete when the credential is not set", () => {
+    render(<CredentialsForm initial={initial} />)
+    const btn = screen.getByTestId("delete-CHANNEL_ID") as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+  })
+
+  it("does not PUT when the draft is empty", async () => {
+    const user = userEvent.setup()
+    render(<CredentialsForm initial={initial} />)
+    await user.click(screen.getByTestId("update-ANTHROPIC_API_KEY"))
+    await user.click(screen.getByTestId("credential-save"))
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(screen.getByTestId("credential-error")).toHaveTextContent(
+      /required/i,
+    )
+  })
+})


### PR DESCRIPTION
## Summary
Two new sidebar screens that round-trip `/api/credentials` and `/api/auth/mode` end-to-end.

- **Sidebar**: adds 📨 Credentials and 🔑 Auth (5 nav items total now).
- **`/credentials`** — Server fetches `GET /api/credentials` (the `{name: bool}` set-status map; the API never returns values by design). Renders all 5 allow-listed keys as Cards with:
  - **Set / Not set Badge** driven by status
  - **Update / Set** button opens a shadcn Dialog with a single Input. `DISCORD_TOKEN` / `NOTION_API_KEY` / `ANTHROPIC_API_KEY` use `type="password"`; `CHANNEL_ID` / `NOTION_DATABASE_ID` use `type="text"` so the non-secret IDs are readable.
  - **Delete** button issues `DELETE /api/credentials/{name}` and is disabled when the key is not set.
  - Empty draft is rejected client-side (`Value is required`) so Pydantic's `min_length=1` 422 is never reached from happy paths.
  - `router.refresh()` after every mutation re-renders with the new server status.
- **`/auth`** — Server fetches `GET /api/auth/mode` and `GET /api/credentials` in parallel, renders two radio cards (`cli` / `api`). Switching to `api` when `ANTHROPIC_API_KEY` is not set shows an inline block notice with a link to `/credentials` and prevents the PUT. Save is also disabled while the selection matches the initial mode (no-op writes blocked).

## Test plan
- [x] `cd apps/web && npm run test` → **23/23 passed** (+9 new: 6 CredentialsForm + 3 AuthModeForm)
- [x] `npm run build` → Compiled successfully; both new routes present (`/auth` 3.28 kB, `/credentials` 15.5 kB)
- [x] `bin/serve.sh --no-browser`:
  - `GET /credentials` → 200 renders all 5 names with status badges
  - `GET /auth` → 200, both radios + label rendered
  - `PUT /api/credentials/CHANNEL_ID` via the Next.js proxy → **204**, `GET /api/credentials` confirms `CHANNEL_ID: true` on disk (keychain)
  - `DELETE /api/credentials/CHANNEL_ID` → 204, status back to `false`
- [ ] Reviewer: walk both screens in a browser:
  - Set/update at least one credential via the dialog (mask shown for secret fields, text for IDs); confirm badge flips immediately
  - Delete a set credential; confirm badge flips to "Not set"
  - With `ANTHROPIC_API_KEY` not set, pick API radio → see the inline notice + link; click Save → no PUT fires
  - Set `ANTHROPIC_API_KEY`, return to `/auth`, switch to API → Save succeeds, refresh sticks

Closes #72