### PR TITLE
test(web): add Playwright E2E onboarding-and-run smoke gate

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -36,3 +36,9 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# Playwright E2E
+/e2e/.tmp-home
+/e2e/test-results
+/playwright-report
+/test-results

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -69,9 +69,18 @@ Isolation is per-run, no manual cleanup required:
 Failures drop a screenshot + trace under `e2e/test-results/`; view a
 trace with `npx playwright show-trace e2e/test-results/<test>/trace.zip`.
 
-Prerequisites: `cd apps/python && uv pip sync requirements.txt` (the
-config invokes `apps/python/.venv/bin/uvicorn`) and one-time
-`npx playwright install chromium`.
+Prerequisites (one-time per machine):
+
+```bash
+cd apps/python
+uv venv .venv                  # create the venv the config invokes
+uv pip sync requirements.txt   # install backend deps
+cd ../web
+npx playwright install chromium
+```
+
+The config invokes `apps/python/.venv/bin/uvicorn` directly, so the venv
+must exist before `npm run test:e2e` is run.
 
 ## References
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -13,6 +13,7 @@ npm run start    # serve the production build
 npm run lint     # next lint
 npm run test     # vitest run (one-off)
 npm run test:watch
+npm run test:e2e # playwright — onboarding-and-run smoke gate
 ```
 
 ## API client
@@ -41,6 +42,36 @@ component will fail at build time.
 
 Vitest + jsdom + Testing Library. Tests live in `tests/` and run with
 `npm run test`. See `tests/smoke.test.tsx` for the baseline pattern.
+
+### E2E smoke gate
+
+`npm run test:e2e` runs the single Playwright scenario in `e2e/` that walks
+the first-time user flow end-to-end: launch → 4-step onboarding wizard →
+`POST /api/run?dry_run=true` → sidebar reachable. This is intentionally
+the *only* E2E test — everything else is covered by Vitest. Treat it as
+the manual smoke gate before cutting a release; it is **not** wired into
+the `web` GitHub Actions workflow because Playwright's browser download
+(~150 MB) inflates CI time disproportionately for a single scenario.
+
+Isolation is per-run, no manual cleanup required:
+
+- `playwright.config.ts` wipes `e2e/.tmp-home/` and pre-seeds a session
+  token there before either server boots.
+- FastAPI is started with `HOME=<tmp-home>` and
+  `BRIEFING_CONFIG_PATH=<tmp-home>/.ai-agent/briefing.json`, so
+  `state.json`, the session token, and `briefing.json` all live under the
+  tmp tree — your real `~/.ai-agent/` is untouched.
+- Step 3 is submitted blank, so no `PUT /api/credentials/*` calls reach
+  the macOS Keychain.
+- The job runs with `dry_run=true`, so no claude / Discord / Notion calls
+  happen.
+
+Failures drop a screenshot + trace under `e2e/test-results/`; view a
+trace with `npx playwright show-trace e2e/test-results/<test>/trace.zip`.
+
+Prerequisites: `cd apps/python && uv pip sync requirements.txt` (the
+config invokes `apps/python/.venv/bin/uvicorn`) and one-time
+`npx playwright install chromium`.
 
 ## References
 

--- a/apps/web/e2e/onboarding-and-run.spec.ts
+++ b/apps/web/e2e/onboarding-and-run.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "@playwright/test"
+
+test("first-time user can complete onboarding and reach the sidebar", async ({ page }) => {
+  await page.goto("/")
+
+  // Step 1 — Auth mode. "cli" is preselected; just advance.
+  await expect(page.getByText("Choose how to call Claude")).toBeVisible()
+  await page.getByRole("button", { name: "Next" }).click()
+
+  // Step 2 — Portfolio. Tickers field is the only required input.
+  await expect(page.getByText("Portfolio basics")).toBeVisible()
+  await page.getByTestId("tickers-input").fill("PLTR, NVDA")
+  await page.getByRole("button", { name: "Next" }).click()
+
+  // Step 3 — Notifications. All blank so the wizard sends zero PUT
+  // /api/credentials/* writes (the form filters empty values), keeping the
+  // real Keychain untouched.
+  await expect(page.getByText("Notifications and credentials")).toBeVisible()
+  await page.getByRole("button", { name: "Next" }).click()
+
+  // Step 4 — Dry-run pipeline check. Backend returns 202 immediately, then
+  // job_store flips the status to "done" once lambda_handler(dry_run=True)
+  // returns — typically sub-second.
+  await expect(page.getByText("Verify the pipeline")).toBeVisible()
+  await page.getByRole("button", { name: "Run test" }).click()
+  await expect(page.getByTestId("job-status")).toHaveText("done", { timeout: 30_000 })
+
+  // Finish triggers PUT /api/state {onboarded: true} then window.location.reload.
+  // After reload, the Server Component sees onboarded=true and redirects "/"
+  // to "/portfolio", which mounts the sidebar.
+  await page.getByRole("button", { name: "Finish" }).click()
+  await expect(page.getByTestId("nav-portfolio")).toBeVisible({ timeout: 15_000 })
+})

--- a/apps/web/e2e/paths.ts
+++ b/apps/web/e2e/paths.ts
@@ -6,7 +6,10 @@ const TMP_HOME = join(WEB_DIR, "e2e", ".tmp-home")
 const TMP_AGENT_DIR = join(TMP_HOME, ".ai-agent")
 const TMP_TOKEN_FILE = join(TMP_AGENT_DIR, "session-token")
 const TMP_CONFIG_FILE = join(TMP_AGENT_DIR, "briefing.json")
-const NEXT_TOKEN_FILE = join(WEB_DIR, ".token")
+// Inside TMP_HOME (not apps/web/.token) so an E2E run never clobbers the
+// real `.token` that bin/serve.sh writes for the developer's local Next.js
+// session. The Next dev server reaches this path via AI_AGENT_TOKEN_PATH.
+const NEXT_TOKEN_FILE = join(TMP_HOME, ".token")
 
 export const PATHS = {
   WEB_DIR,

--- a/apps/web/e2e/paths.ts
+++ b/apps/web/e2e/paths.ts
@@ -1,0 +1,19 @@
+import { join, resolve } from "node:path"
+
+const WEB_DIR = resolve(__dirname, "..")
+const PYTHON_DIR = resolve(WEB_DIR, "..", "python")
+const TMP_HOME = join(WEB_DIR, "e2e", ".tmp-home")
+const TMP_AGENT_DIR = join(TMP_HOME, ".ai-agent")
+const TMP_TOKEN_FILE = join(TMP_AGENT_DIR, "session-token")
+const TMP_CONFIG_FILE = join(TMP_AGENT_DIR, "briefing.json")
+const NEXT_TOKEN_FILE = join(WEB_DIR, ".token")
+
+export const PATHS = {
+  WEB_DIR,
+  PYTHON_DIR,
+  TMP_HOME,
+  TMP_AGENT_DIR,
+  TMP_TOKEN_FILE,
+  TMP_CONFIG_FILE,
+  NEXT_TOKEN_FILE,
+}

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -22,6 +22,7 @@
         "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -775,6 +776,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -7320,6 +7337,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
@@ -25,6 +26,7 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process"
+import { randomBytes } from "node:crypto"
 import { mkdirSync, rmSync, writeFileSync } from "node:fs"
 
 import { defineConfig, devices } from "@playwright/test"
@@ -23,11 +23,7 @@ import { PATHS } from "./e2e/paths"
 if (!process.env.TEST_WORKER_INDEX) {
   rmSync(PATHS.TMP_HOME, { recursive: true, force: true })
   mkdirSync(PATHS.TMP_AGENT_DIR, { recursive: true })
-  const token = execSync(
-    "node -e \"process.stdout.write(require('crypto').randomBytes(32).toString('base64url'))\"",
-  )
-    .toString()
-    .trim()
+  const token = randomBytes(32).toString("base64url")
   writeFileSync(PATHS.TMP_TOKEN_FILE, token, { mode: 0o600 })
   writeFileSync(PATHS.NEXT_TOKEN_FILE, token, { mode: 0o600 })
 }

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,74 @@
+import { execSync } from "node:child_process"
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+
+import { defineConfig, devices } from "@playwright/test"
+
+import { PATHS } from "./e2e/paths"
+
+// Per-run isolation strategy: FastAPI stores state.json + session-token under
+// `Path.home() / ".ai-agent"`, so launching it with HOME pointed at a
+// throwaway tmp dir keeps `~/.ai-agent` untouched. `BRIEFING_CONFIG_PATH`
+// does the same for briefing.json.
+//
+// The seed (wipe tmp HOME + generate matching tokens for FastAPI and the
+// Next.js proxy) lives HERE rather than in `globalSetup` for two reasons:
+//   1. Playwright launches `webServer` BEFORE running `globalSetup`. If we
+//      seeded in globalSetup, FastAPI would boot first, read whatever stale
+//      token a previous run left on disk, and cache it — every later
+//      request that uses the freshly-seeded token would then 401.
+//   2. Playwright re-imports this config in every worker, which would
+//      otherwise re-run the seed mid-test and trigger the same race. The
+//      `TEST_WORKER_INDEX` env var is set only inside workers, so we use it
+//      to skip the seed there.
+if (!process.env.TEST_WORKER_INDEX) {
+  rmSync(PATHS.TMP_HOME, { recursive: true, force: true })
+  mkdirSync(PATHS.TMP_AGENT_DIR, { recursive: true })
+  const token = execSync(
+    "node -e \"process.stdout.write(require('crypto').randomBytes(32).toString('base64url'))\"",
+  )
+    .toString()
+    .trim()
+  writeFileSync(PATHS.TMP_TOKEN_FILE, token, { mode: 0o600 })
+  writeFileSync(PATHS.NEXT_TOKEN_FILE, token, { mode: 0o600 })
+}
+
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: /.*\.spec\.ts$/,
+  outputDir: "./e2e/test-results",
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  reporter: [["list"], ["html", { outputFolder: "playwright-report", open: "never" }]],
+  use: {
+    baseURL: "http://127.0.0.1:3000",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: [
+    {
+      command: ".venv/bin/uvicorn web.app:app --host 127.0.0.1 --port 8000",
+      cwd: PATHS.PYTHON_DIR,
+      url: "http://127.0.0.1:8000/api/health",
+      reuseExistingServer: false,
+      timeout: 60_000,
+      env: {
+        HOME: PATHS.TMP_HOME,
+        BRIEFING_CONFIG_PATH: PATHS.TMP_CONFIG_FILE,
+        PYTHONUNBUFFERED: "1",
+      },
+    },
+    {
+      command: "npm run dev",
+      cwd: PATHS.WEB_DIR,
+      url: "http://127.0.0.1:3000",
+      reuseExistingServer: false,
+      timeout: 120_000,
+      env: {
+        AI_AGENT_TOKEN_PATH: PATHS.NEXT_TOKEN_FILE,
+        API_BASE: "http://127.0.0.1:8000",
+      },
+    },
+  ],
+})


### PR DESCRIPTION
## Summary
- Adds the single Playwright E2E scenario specified in #75: launch → 4-step onboarding wizard → `POST /api/run?dry_run=true` → sidebar reachable. The rest of the web UI stays under Vitest.
- Positioned as the manual pre-release smoke gate; intentionally **not** wired into the `web` GitHub Actions workflow because Playwright's chromium download (~150 MB) inflates CI for a single scenario.
- Per-run isolation without touching the developer's real `~/.ai-agent`: FastAPI is launched with `HOME` pointed at `apps/web/e2e/.tmp-home` and `BRIEFING_CONFIG_PATH` at a sibling `briefing.json`. Step 3 is submitted blank, so the macOS Keychain is never written. Job runs with `dry_run=true`, so no Claude / Discord / Notion calls happen.
- Implementation note: the wipe-tmp-HOME + token seed lives at the top of `playwright.config.ts` (guarded by `TEST_WORKER_INDEX`) rather than in `globalSetup`. Playwright runs `webServer` **before** `globalSetup`, so seeding later races FastAPI's first-request token cache and produces silent 401s — comment in the config explains the trade-off.

## Test plan
- [x] `cd apps/web && npm run test:e2e` passes locally (chromium, ~3 s after warm-up).
- [x] Forced failure produces a screenshot + `trace.zip` under `apps/web/e2e/test-results/<test>/` (verified by injecting a deliberately-failing assertion).
- [x] `~/.ai-agent/{state.json,session-token}` and the macOS Keychain are untouched after the run (verified by hash + `security find-generic-password` no-op).
- [x] `npm run lint` clean, `npm run test` 42/42 still green.
- [ ] Reviewer: run `cd apps/python && uv pip sync requirements.txt` and `cd apps/web && npx playwright install chromium` once before running `npm run test:e2e`.

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added Playwright-based end-to-end testing infrastructure
  * New test suite for user onboarding flow
  * Added `test:e2e` and `test:watch` npm scripts
  * Updated documentation with testing setup instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->