### PR TITLE
refactor(web): extract SessionExpiredCard + useConfigSave / useAbortableMount hooks

### DIFF
--- a/apps/web/components/SessionExpiredCard.tsx
+++ b/apps/web/components/SessionExpiredCard.tsx
@@ -1,0 +1,21 @@
+import { Card, CardContent } from "@/components/ui/card"
+
+export function SessionExpiredCard() {
+  return (
+    <Card>
+      <CardContent
+        className="space-y-2 pt-6 text-sm"
+        data-testid="session-expired"
+      >
+        <p className="font-medium text-destructive">Session expired</p>
+        <p className="text-muted-foreground">
+          The bearer token in <code className="font-mono">apps/web/.token</code>
+          {" "}no longer matches{" "}
+          <code className="font-mono">~/.ai-agent/session-token</code>.
+          Restart the dev server (<code className="font-mono">bin/serve.sh</code>)
+          to mirror a fresh token and refresh this page.
+        </p>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/components/screens/ChatForm.tsx
+++ b/apps/web/components/screens/ChatForm.tsx
@@ -7,6 +7,7 @@ import { SessionExpiredCard } from "@/components/SessionExpiredCard"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { LoadingDots } from "@/components/ui/loading-dots"
+import { useAbortableMount } from "@/lib/hooks/useAbortableMount"
 import { cn } from "@/lib/utils"
 
 type Message = {
@@ -75,16 +76,12 @@ export function ChatForm() {
   const [supportsMic, setSupportsMic] = useState(false)
 
   // Suppress setState and cancel in-flight work after unmount.
-  const mountedRef = useRef(true)
-  const abortRef = useRef<AbortController | null>(null)
+  const { mountedRef, abortRef } = useAbortableMount()
   const recRef = useRef<Recognition | null>(null)
 
   useEffect(() => {
-    mountedRef.current = true
     setSupportsMic(getRecognitionCtor() !== null)
     return () => {
-      mountedRef.current = false
-      abortRef.current?.abort()
       recRef.current?.stop()
     }
   }, [])
@@ -151,7 +148,7 @@ export function ChatForm() {
       }
       return stale ? "stale" : "ok"
     },
-    [],
+    [mountedRef],
   )
 
   const send = useCallback(async () => {
@@ -216,7 +213,7 @@ export function ChatForm() {
         setRetrying(false)
       }
     }
-  }, [busy, input, stream])
+  }, [abortRef, busy, input, mountedRef, stream])
 
   const toggleMic = useCallback(() => {
     if (listening) {
@@ -245,7 +242,7 @@ export function ChatForm() {
     rec.start()
     recRef.current = rec
     setListening(true)
-  }, [listening])
+  }, [listening, mountedRef])
 
   if (sessionExpired) {
     return <SessionExpiredCard />

--- a/apps/web/components/screens/ChatForm.tsx
+++ b/apps/web/components/screens/ChatForm.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 
+import { SessionExpiredCard } from "@/components/SessionExpiredCard"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { LoadingDots } from "@/components/ui/loading-dots"
@@ -247,23 +248,7 @@ export function ChatForm() {
   }, [listening])
 
   if (sessionExpired) {
-    return (
-      <Card>
-        <CardContent
-          className="space-y-2 pt-6 text-sm"
-          data-testid="session-expired"
-        >
-          <p className="font-medium text-destructive">Session expired</p>
-          <p className="text-muted-foreground">
-            The bearer token in <code className="font-mono">apps/web/.token</code>
-            {" "}no longer matches{" "}
-            <code className="font-mono">~/.ai-agent/session-token</code>.
-            Restart the dev server (<code className="font-mono">bin/serve.sh</code>)
-            to mirror a fresh token and refresh this page.
-          </p>
-        </CardContent>
-      </Card>
-    )
+    return <SessionExpiredCard />
   }
 
   return (

--- a/apps/web/components/screens/GeopoliticalForm.tsx
+++ b/apps/web/components/screens/GeopoliticalForm.tsx
@@ -1,17 +1,13 @@
 "use client"
-import { useRouter } from "next/navigation"
 import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { ChipInput } from "@/components/ChipInput"
-import { SaveStatus, SaveStatusValue } from "@/components/SaveStatus"
+import { SaveStatus } from "@/components/SaveStatus"
 import { BriefingConfig, Conflict } from "@/lib/config-types"
-import {
-  ValidationErrorMap,
-  parseValidationErrors,
-} from "@/lib/validation-errors"
+import { useConfigSave } from "@/lib/hooks/useConfigSave"
 
 type Props = { initial: BriefingConfig }
 
@@ -24,11 +20,8 @@ const blankConflict = (): Conflict => ({
 const upper = (s: string) => s.toUpperCase()
 
 export function GeopoliticalForm({ initial }: Props) {
-  const router = useRouter()
   const [rows, setRows] = useState<Conflict[]>(initial.geopolitical.conflicts)
-  const [status, setStatus] = useState<SaveStatusValue>("idle")
-  const [errors, setErrors] = useState<ValidationErrorMap>(new Map())
-  const [genericError, setGenericError] = useState<string | null>(null)
+  const { status, errors, genericError, save } = useConfigSave()
 
   const updateRow = (idx: number, patch: Partial<Conflict>) =>
     setRows((prev) => prev.map((r, i) => (i === idx ? { ...r, ...patch } : r)))
@@ -36,11 +29,8 @@ export function GeopoliticalForm({ initial }: Props) {
     setRows((prev) => prev.filter((_, i) => i !== idx))
   const addRow = () => setRows((prev) => [...prev, blankConflict()])
 
-  const save = async () => {
-    setStatus("saving")
-    setErrors(new Map())
-    setGenericError(null)
-    const payload: BriefingConfig = {
+  const onSave = () =>
+    save({
       ...initial,
       geopolitical: {
         conflicts: rows.map((r) => ({
@@ -48,24 +38,7 @@ export function GeopoliticalForm({ initial }: Props) {
           notes: r.notes && r.notes.trim() !== "" ? r.notes : null,
         })),
       },
-    }
-    const res = await fetch("/api/config", {
-      method: "PUT",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(payload),
     })
-    if (res.ok) {
-      setStatus("saved")
-      router.refresh()
-      return
-    }
-    if (res.status === 422) {
-      setErrors(await parseValidationErrors(res))
-    } else {
-      setGenericError(`PUT /api/config failed (HTTP ${res.status})`)
-    }
-    setStatus("error")
-  }
 
   return (
     <div className="space-y-4">
@@ -149,7 +122,7 @@ export function GeopoliticalForm({ initial }: Props) {
         <Button variant="outline" onClick={addRow} data-testid="conflict-add">
           + Add conflict
         </Button>
-        <Button onClick={() => void save()} disabled={status === "saving"}>
+        <Button onClick={() => void onSave()} disabled={status === "saving"}>
           Save
         </Button>
         <SaveStatus status={status} />

--- a/apps/web/components/screens/PortfolioForm.tsx
+++ b/apps/web/components/screens/PortfolioForm.tsx
@@ -1,56 +1,26 @@
 "use client"
-import { useRouter } from "next/navigation"
 import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { ChipInput } from "@/components/ChipInput"
-import { SaveStatus, SaveStatusValue } from "@/components/SaveStatus"
+import { SaveStatus } from "@/components/SaveStatus"
 import { BriefingConfig } from "@/lib/config-types"
-import {
-  ValidationErrorMap,
-  parseValidationErrors,
-} from "@/lib/validation-errors"
+import { useConfigSave } from "@/lib/hooks/useConfigSave"
 
 type Props = { initial: BriefingConfig }
 
 const upper = (s: string) => s.toUpperCase()
 
 export function PortfolioForm({ initial }: Props) {
-  const router = useRouter()
   const [tickers, setTickers] = useState<string[]>(initial.portfolio.tickers)
   const [themes, setThemes] = useState<string[]>(initial.portfolio.themes)
-  const [status, setStatus] = useState<SaveStatusValue>("idle")
-  const [errors, setErrors] = useState<ValidationErrorMap>(new Map())
-  const [genericError, setGenericError] = useState<string | null>(null)
+  const { status, errors, genericError, save } = useConfigSave()
 
   const tickersError = errors.get("portfolio/tickers")
   const themesError = errors.get("portfolio/themes")
 
-  const save = async () => {
-    setStatus("saving")
-    setErrors(new Map())
-    setGenericError(null)
-    const payload: BriefingConfig = {
-      ...initial,
-      portfolio: { tickers, themes },
-    }
-    const res = await fetch("/api/config", {
-      method: "PUT",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(payload),
-    })
-    if (res.ok) {
-      setStatus("saved")
-      router.refresh()
-      return
-    }
-    if (res.status === 422) {
-      setErrors(await parseValidationErrors(res))
-    } else {
-      setGenericError(`PUT /api/config failed (HTTP ${res.status})`)
-    }
-    setStatus("error")
-  }
+  const onSave = () =>
+    save({ ...initial, portfolio: { tickers, themes } })
 
   return (
     <div className="space-y-4">
@@ -90,7 +60,7 @@ export function PortfolioForm({ initial }: Props) {
         )}
       </div>
       <div className="flex items-center gap-3">
-        <Button onClick={() => void save()} disabled={status === "saving"}>
+        <Button onClick={() => void onSave()} disabled={status === "saving"}>
           Save
         </Button>
         <SaveStatus status={status} />

--- a/apps/web/components/screens/RunForm.tsx
+++ b/apps/web/components/screens/RunForm.tsx
@@ -1,6 +1,7 @@
 "use client"
 import { useCallback, useEffect, useRef, useState } from "react"
 
+import { SessionExpiredCard } from "@/components/SessionExpiredCard"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { LoadingDots } from "@/components/ui/loading-dots"
@@ -127,23 +128,7 @@ export function RunForm() {
   }, [dryRun])
 
   if (sessionExpired) {
-    return (
-      <Card>
-        <CardContent
-          className="space-y-2 pt-6 text-sm"
-          data-testid="session-expired"
-        >
-          <p className="font-medium text-destructive">Session expired</p>
-          <p className="text-muted-foreground">
-            The bearer token in <code className="font-mono">apps/web/.token</code>
-            {" "}no longer matches{" "}
-            <code className="font-mono">~/.ai-agent/session-token</code>.
-            Restart the dev server (<code className="font-mono">bin/serve.sh</code>)
-            to mirror a fresh token and refresh this page.
-          </p>
-        </CardContent>
-      </Card>
-    )
+    return <SessionExpiredCard />
   }
 
   const started = fmtTs(job?.started_at)

--- a/apps/web/components/screens/RunForm.tsx
+++ b/apps/web/components/screens/RunForm.tsx
@@ -1,10 +1,11 @@
 "use client"
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useState } from "react"
 
 import { SessionExpiredCard } from "@/components/SessionExpiredCard"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { LoadingDots } from "@/components/ui/loading-dots"
+import { useAbortableMount } from "@/lib/hooks/useAbortableMount"
 
 type JobStatus = "idle" | "pending" | "running" | "done" | "failed"
 
@@ -38,15 +39,7 @@ export function RunForm() {
 
   // Cancel in-flight fetches and suppress setState if the component unmounts
   // mid-poll (e.g. user navigates away via the sidebar during a ~5-min run).
-  const mountedRef = useRef(true)
-  const abortRef = useRef<AbortController | null>(null)
-  useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-      abortRef.current?.abort()
-    }
-  }, [])
+  const { mountedRef, abortRef } = useAbortableMount()
 
   const busy = status === "pending" || status === "running"
 
@@ -125,7 +118,7 @@ export function RunForm() {
       setError(e instanceof Error ? e.message : "Network error")
       setStatus("failed")
     }
-  }, [dryRun])
+  }, [abortRef, dryRun, mountedRef])
 
   if (sessionExpired) {
     return <SessionExpiredCard />

--- a/apps/web/components/screens/WatchSectorsForm.tsx
+++ b/apps/web/components/screens/WatchSectorsForm.tsx
@@ -1,17 +1,13 @@
 "use client"
-import { useRouter } from "next/navigation"
 import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { ChipInput } from "@/components/ChipInput"
-import { SaveStatus, SaveStatusValue } from "@/components/SaveStatus"
+import { SaveStatus } from "@/components/SaveStatus"
 import { BriefingConfig, WatchSector } from "@/lib/config-types"
-import {
-  ValidationErrorMap,
-  parseValidationErrors,
-} from "@/lib/validation-errors"
+import { useConfigSave } from "@/lib/hooks/useConfigSave"
 
 type Props = { initial: BriefingConfig }
 
@@ -19,11 +15,8 @@ const blankSector = (): WatchSector => ({ sector: "", tickers: [], notes: "" })
 const upper = (s: string) => s.toUpperCase()
 
 export function WatchSectorsForm({ initial }: Props) {
-  const router = useRouter()
   const [rows, setRows] = useState<WatchSector[]>(initial.watch_sectors)
-  const [status, setStatus] = useState<SaveStatusValue>("idle")
-  const [errors, setErrors] = useState<ValidationErrorMap>(new Map())
-  const [genericError, setGenericError] = useState<string | null>(null)
+  const { status, errors, genericError, save } = useConfigSave()
 
   const collectionError = errors.get("watch_sectors")
 
@@ -37,35 +30,15 @@ export function WatchSectorsForm({ initial }: Props) {
   }
   const addRow = () => setRows((prev) => [...prev, blankSector()])
 
-  const save = async () => {
-    setStatus("saving")
-    setErrors(new Map())
-    setGenericError(null)
-    const payload: BriefingConfig = {
+  const onSave = () =>
+    save({
       ...initial,
       // Trim empty notes to null since the backend types `notes: str | None`.
       watch_sectors: rows.map((r) => ({
         ...r,
         notes: r.notes && r.notes.trim() !== "" ? r.notes : null,
       })),
-    }
-    const res = await fetch("/api/config", {
-      method: "PUT",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(payload),
     })
-    if (res.ok) {
-      setStatus("saved")
-      router.refresh()
-      return
-    }
-    if (res.status === 422) {
-      setErrors(await parseValidationErrors(res))
-    } else {
-      setGenericError(`PUT /api/config failed (HTTP ${res.status})`)
-    }
-    setStatus("error")
-  }
 
   return (
     <div className="space-y-4">
@@ -135,7 +108,7 @@ export function WatchSectorsForm({ initial }: Props) {
         <Button variant="outline" onClick={addRow} data-testid="sector-add">
           + Add sector
         </Button>
-        <Button onClick={() => void save()} disabled={status === "saving"}>
+        <Button onClick={() => void onSave()} disabled={status === "saving"}>
           Save
         </Button>
         <SaveStatus status={status} />

--- a/apps/web/lib/hooks/useAbortableMount.ts
+++ b/apps/web/lib/hooks/useAbortableMount.ts
@@ -1,0 +1,26 @@
+"use client"
+import { useEffect, useRef, type MutableRefObject } from "react"
+
+export type UseAbortableMount = {
+  mountedRef: MutableRefObject<boolean>
+  abortRef: MutableRefObject<AbortController | null>
+}
+
+// Pairs an `unmounted` flag with an in-flight AbortController so callers can
+// cancel pending fetches and suppress setState after the component unmounts.
+export function useAbortableMount(): UseAbortableMount {
+  const mountedRef = useRef(true)
+  const abortRef = useRef<AbortController | null>(null)
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      // Intentionally read the current value at unmount — the controller may
+      // have been replaced after this effect ran, and we want to abort
+      // whichever request is in flight right now.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      abortRef.current?.abort()
+    }
+  }, [])
+  return { mountedRef, abortRef }
+}

--- a/apps/web/lib/hooks/useConfigSave.ts
+++ b/apps/web/lib/hooks/useConfigSave.ts
@@ -26,11 +26,18 @@ export function useConfigSave(): UseConfigSave {
     setStatus("saving")
     setErrors(new Map())
     setGenericError(null)
-    const res = await fetch("/api/config", {
-      method: "PUT",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(payload),
-    })
+    let res: Response
+    try {
+      res = await fetch("/api/config", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      })
+    } catch (e) {
+      setGenericError(e instanceof Error ? e.message : "Network error")
+      setStatus("error")
+      return
+    }
     if (res.ok) {
       setStatus("saved")
       router.refresh()

--- a/apps/web/lib/hooks/useConfigSave.ts
+++ b/apps/web/lib/hooks/useConfigSave.ts
@@ -1,0 +1,48 @@
+"use client"
+import { useRouter } from "next/navigation"
+import { useState } from "react"
+
+import { SaveStatusValue } from "@/components/SaveStatus"
+import { BriefingConfig } from "@/lib/config-types"
+import {
+  ValidationErrorMap,
+  parseValidationErrors,
+} from "@/lib/validation-errors"
+
+export type UseConfigSave = {
+  status: SaveStatusValue
+  errors: ValidationErrorMap
+  genericError: string | null
+  save: (payload: BriefingConfig) => Promise<void>
+}
+
+export function useConfigSave(): UseConfigSave {
+  const router = useRouter()
+  const [status, setStatus] = useState<SaveStatusValue>("idle")
+  const [errors, setErrors] = useState<ValidationErrorMap>(new Map())
+  const [genericError, setGenericError] = useState<string | null>(null)
+
+  const save = async (payload: BriefingConfig) => {
+    setStatus("saving")
+    setErrors(new Map())
+    setGenericError(null)
+    const res = await fetch("/api/config", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    })
+    if (res.ok) {
+      setStatus("saved")
+      router.refresh()
+      return
+    }
+    if (res.status === 422) {
+      setErrors(await parseValidationErrors(res))
+    } else {
+      setGenericError(`PUT /api/config failed (HTTP ${res.status})`)
+    }
+    setStatus("error")
+  }
+
+  return { status, errors, genericError, save }
+}


### PR DESCRIPTION
## Summary
- Extract duplicated 401 Session-expired card from `ChatForm` / `RunForm` into `components/SessionExpiredCard.tsx`.
- Consolidate `PUT /api/config` + 422 validation + `SaveStatus` across `Portfolio` / `Geopolitical` / `WatchSectors` forms into `lib/hooks/useConfigSave.ts`.
- Consolidate `mountedRef` + `abortRef` + cleanup pattern shared by `ChatForm` / `RunForm` into `lib/hooks/useAbortableMount.ts`.
- Net diff: **+126 / -155** (8 files).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 42/42 passed
- [x] `npm run lint` — no warnings or errors
- [ ] Manual smoke: navigate Portfolio / Geopolitical / WatchSectors → Save (success, 422, generic error)
- [ ] Manual smoke: trigger Run / Chat 401 path → Session-expired card renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated session expiration card to provide clearer notification when sessions expire

* **Refactor**
  * Consolidated form save and validation-error handling across multiple configuration forms for consistent behavior
  * Enhanced component lifecycle management to properly cancel in-flight HTTP requests when navigating away from pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->