### PR TITLE
feat(web): theme system — dark / light + background variants

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -56,4 +56,25 @@
   body {
     @apply bg-background text-foreground;
   }
+
+  /* Background presets. The "default" preset is just the theme background.
+     Additional presets paint the body via gradients that adapt to dark mode. */
+  html[data-bg="soft"] body {
+    background:
+      radial-gradient(
+        circle at top left,
+        hsl(210 40% 98%) 0%,
+        hsl(220 35% 92%) 40%,
+        hsl(225 30% 88%) 100%
+      );
+  }
+  html.dark[data-bg="soft"] body {
+    background:
+      radial-gradient(
+        circle at top left,
+        hsl(222.2 84% 6%) 0%,
+        hsl(220 50% 8%) 40%,
+        hsl(217.2 35% 12%) 100%
+      );
+  }
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -24,6 +24,12 @@
     --input: 214.3 31.8% 91.4%;
     --ring: 222.2 84% 4.9%;
     --radius: 0.5rem;
+
+    /* Soft preset stops — kept as tokens so the gradient palette is
+       editable in one place, not buried in the selector below. */
+    --bg-soft-start: 210 40% 98%;
+    --bg-soft-mid: 220 35% 92%;
+    --bg-soft-end: 225 30% 88%;
   }
 
   .dark {
@@ -46,6 +52,10 @@
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;
     --ring: 212.7 26.8% 83.9%;
+
+    --bg-soft-start: 222.2 84% 6%;
+    --bg-soft-mid: 220 50% 8%;
+    --bg-soft-end: 217.2 35% 12%;
   }
 }
 
@@ -58,23 +68,15 @@
   }
 
   /* Background presets. The "default" preset is just the theme background.
-     Additional presets paint the body via gradients that adapt to dark mode. */
+     "soft" paints a radial gradient using --bg-soft-* tokens that swap
+     automatically with the theme via the .dark override above. */
   html[data-bg="soft"] body {
     background:
       radial-gradient(
         circle at top left,
-        hsl(210 40% 98%) 0%,
-        hsl(220 35% 92%) 40%,
-        hsl(225 30% 88%) 100%
-      );
-  }
-  html.dark[data-bg="soft"] body {
-    background:
-      radial-gradient(
-        circle at top left,
-        hsl(222.2 84% 6%) 0%,
-        hsl(220 50% 8%) 40%,
-        hsl(217.2 35% 12%) 100%
+        hsl(var(--bg-soft-start)) 0%,
+        hsl(var(--bg-soft-mid)) 40%,
+        hsl(var(--bg-soft-end)) 100%
       );
   }
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
+
+import { ThemeProvider, themeBootScript } from "@/components/ThemeProvider";
 import "./globals.css";
 
 const geistSans = localFont({
@@ -24,11 +26,16 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    // suppressHydrationWarning: themeBootScript mutates <html> before React
+    // hydrates, so the server-rendered markup intentionally diverges.
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeBootScript }} />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <ThemeProvider>{children}</ThemeProvider>
       </body>
     </html>
   );

--- a/apps/web/components/AppearancePanel.tsx
+++ b/apps/web/components/AppearancePanel.tsx
@@ -1,0 +1,73 @@
+"use client"
+import { useTheme } from "@/components/ThemeProvider"
+import { cn } from "@/lib/utils"
+import {
+  Background,
+  BACKGROUNDS,
+  Theme,
+  THEMES,
+} from "@/lib/theme"
+
+const THEME_LABEL: Record<Theme, string> = {
+  light: "Light",
+  dark: "Dark",
+}
+const BG_LABEL: Record<Background, string> = {
+  default: "Default",
+  soft: "Soft",
+}
+
+export function AppearancePanel() {
+  const { theme, background, setTheme, setBackground } = useTheme()
+  return (
+    <div className="space-y-2 border-t pt-3" data-testid="appearance-panel">
+      <p className="px-2 text-[10px] font-medium uppercase text-muted-foreground">
+        Appearance
+      </p>
+      <div className="space-y-1">
+        <p className="px-2 text-xs text-muted-foreground">Theme</p>
+        <div className="flex gap-1 px-2">
+          {THEMES.map((t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => setTheme(t)}
+              aria-pressed={theme === t}
+              data-testid={`theme-${t}`}
+              className={cn(
+                "flex-1 rounded-md border px-2 py-1 text-xs transition-colors",
+                theme === t
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "border-input hover:bg-accent",
+              )}
+            >
+              {THEME_LABEL[t]}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-1">
+        <p className="px-2 text-xs text-muted-foreground">Background</p>
+        <div className="flex gap-1 px-2">
+          {BACKGROUNDS.map((b) => (
+            <button
+              key={b}
+              type="button"
+              onClick={() => setBackground(b)}
+              aria-pressed={background === b}
+              data-testid={`bg-${b}`}
+              className={cn(
+                "flex-1 rounded-md border px-2 py-1 text-xs transition-colors",
+                background === b
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "border-input hover:bg-accent",
+              )}
+            >
+              {BG_LABEL[b]}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/AppearancePanel.tsx
+++ b/apps/web/components/AppearancePanel.tsx
@@ -17,16 +17,16 @@ const BG_LABEL: Record<Background, string> = {
   soft: "Soft",
 }
 
+// Renders only the Theme + Background controls. The "Appearance" label and
+// any surrounding disclosure live in the Sidebar so this panel can be reused
+// from a future /appearance route without duplicating the heading.
 export function AppearancePanel() {
   const { theme, background, setTheme, setBackground } = useTheme()
   return (
-    <div className="space-y-2 border-t pt-3" data-testid="appearance-panel">
-      <p className="px-2 text-[10px] font-medium uppercase text-muted-foreground">
-        Appearance
-      </p>
+    <div className="space-y-2" data-testid="appearance-panel">
       <div className="space-y-1">
-        <p className="px-2 text-xs text-muted-foreground">Theme</p>
-        <div className="flex gap-1 px-2">
+        <p className="text-[10px] uppercase text-muted-foreground">Theme</p>
+        <div className="flex gap-1">
           {THEMES.map((t) => (
             <button
               key={t}
@@ -47,8 +47,10 @@ export function AppearancePanel() {
         </div>
       </div>
       <div className="space-y-1">
-        <p className="px-2 text-xs text-muted-foreground">Background</p>
-        <div className="flex gap-1 px-2">
+        <p className="text-[10px] uppercase text-muted-foreground">
+          Background
+        </p>
+        <div className="flex gap-1">
           {BACKGROUNDS.map((b) => (
             <button
               key={b}

--- a/apps/web/components/SaveStatus.tsx
+++ b/apps/web/components/SaveStatus.tsx
@@ -11,7 +11,10 @@ export function SaveStatus({ status }: { status: Status }) {
     )
   if (status === "saved")
     return (
-      <span className="text-sm text-green-600" data-testid="save-status">
+      <span
+        className="text-sm text-green-600 dark:text-green-400"
+        data-testid="save-status"
+      >
         Saved
       </span>
     )

--- a/apps/web/components/Sidebar.tsx
+++ b/apps/web/components/Sidebar.tsx
@@ -2,6 +2,7 @@
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 
+import { AppearancePanel } from "@/components/AppearancePanel"
 import { cn } from "@/lib/utils"
 
 type Item = { href: string; label: string; icon: string }
@@ -42,6 +43,9 @@ export function Sidebar() {
           )
         })}
       </nav>
+      <div className="mt-auto">
+        <AppearancePanel />
+      </div>
     </aside>
   )
 }

--- a/apps/web/components/Sidebar.tsx
+++ b/apps/web/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 "use client"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
+import { useState } from "react"
 
 import { AppearancePanel } from "@/components/AppearancePanel"
 import { cn } from "@/lib/utils"
@@ -19,33 +20,61 @@ const ITEMS: Item[] = [
 
 export function Sidebar() {
   const pathname = usePathname()
+  const [appearanceOpen, setAppearanceOpen] = useState(false)
   return (
-    <aside className="flex w-60 flex-col gap-1 border-r bg-card p-4">
-      <h1 className="px-2 pb-4 text-base font-semibold">ai-agent</h1>
-      <nav className="flex flex-col gap-1">
-        {ITEMS.map((item) => {
-          const active = pathname === item.href
-          return (
-            <Link
-              key={item.href}
-              href={item.href}
-              className={cn(
-                "flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors",
-                active
-                  ? "bg-accent font-medium text-accent-foreground"
-                  : "hover:bg-accent/50",
-              )}
-              data-testid={`nav-${item.href.slice(1)}`}
-            >
-              <span aria-hidden>{item.icon}</span>
-              <span>{item.label}</span>
-            </Link>
-          )
-        })}
-      </nav>
-      <div className="mt-auto">
-        <AppearancePanel />
-      </div>
+    <aside className="flex w-60 flex-col gap-4 border-r bg-card p-4">
+      <section className="flex flex-col gap-1">
+        <h1 className="px-2 pb-2 text-base font-semibold">ai-agent</h1>
+        <nav className="flex flex-col gap-1">
+          {ITEMS.map((item) => {
+            const active = pathname === item.href
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={cn(
+                  "flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors",
+                  active
+                    ? "bg-accent font-medium text-accent-foreground"
+                    : "hover:bg-accent/50",
+                )}
+                data-testid={`nav-${item.href.slice(1)}`}
+              >
+                <span aria-hidden>{item.icon}</span>
+                <span>{item.label}</span>
+              </Link>
+            )
+          })}
+        </nav>
+      </section>
+
+      <section className="flex flex-col gap-1">
+        <h2 className="flex items-center gap-2 px-2 pb-2 text-base font-semibold">
+          <span aria-hidden>⚙️</span>
+          <span>Config</span>
+        </h2>
+        <button
+          type="button"
+          onClick={() => setAppearanceOpen((v) => !v)}
+          aria-expanded={appearanceOpen}
+          aria-controls="appearance-panel-body"
+          data-testid="appearance-toggle"
+          className="flex items-center justify-between rounded-md px-3 py-2 text-sm transition-colors hover:bg-accent/50"
+        >
+          <span className="flex items-center gap-2">
+            <span aria-hidden>🎨</span>
+            <span>Appearance</span>
+          </span>
+          <span aria-hidden className="text-xs text-muted-foreground">
+            {appearanceOpen ? "▾" : "▸"}
+          </span>
+        </button>
+        {appearanceOpen && (
+          <div id="appearance-panel-body" className="px-3 pb-1 pt-1">
+            <AppearancePanel />
+          </div>
+        )}
+      </section>
     </aside>
   )
 }

--- a/apps/web/components/ThemeProvider.tsx
+++ b/apps/web/components/ThemeProvider.tsx
@@ -1,0 +1,110 @@
+"use client"
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react"
+
+import {
+  Background,
+  BACKGROUND_STORAGE_KEY,
+  isBackground,
+  isTheme,
+  Theme,
+  THEME_STORAGE_KEY,
+} from "@/lib/theme"
+
+type Ctx = {
+  theme: Theme
+  background: Background
+  setTheme: (t: Theme) => void
+  setBackground: (b: Background) => void
+}
+
+const ThemeContext = createContext<Ctx | null>(null)
+
+// Reads the current state already painted onto <html> by the pre-hydration
+// script (see app/layout.tsx). Defaults are conservative for SSR — the
+// pre-hydration script has already corrected the DOM before this mounts.
+function readInitialTheme(): Theme {
+  if (typeof document === "undefined") return "light"
+  return document.documentElement.classList.contains("dark") ? "dark" : "light"
+}
+function readInitialBackground(): Background {
+  if (typeof document === "undefined") return "default"
+  const v = document.documentElement.getAttribute("data-bg")
+  return isBackground(v) ? v : "default"
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(readInitialTheme)
+  const [background, setBackgroundState] =
+    useState<Background>(readInitialBackground)
+
+  // Keep <html> in sync if state changes after mount (e.g. via the panel).
+  useEffect(() => {
+    const root = document.documentElement
+    root.classList.toggle("dark", theme === "dark")
+  }, [theme])
+
+  useEffect(() => {
+    document.documentElement.setAttribute("data-bg", background)
+  }, [background])
+
+  const setTheme = useCallback((t: Theme) => {
+    setThemeState(t)
+    try {
+      localStorage.setItem(THEME_STORAGE_KEY, t)
+    } catch {
+      // localStorage may be unavailable (private mode, quota); the class
+      // toggle still works for the session.
+    }
+  }, [])
+
+  const setBackground = useCallback((b: Background) => {
+    setBackgroundState(b)
+    try {
+      localStorage.setItem(BACKGROUND_STORAGE_KEY, b)
+    } catch {
+      // see above
+    }
+  }, [])
+
+  const value = useMemo<Ctx>(
+    () => ({ theme, background, setTheme, setBackground }),
+    [theme, background, setTheme, setBackground],
+  )
+  return (
+    <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+  )
+}
+
+export function useTheme(): Ctx {
+  const ctx = useContext(ThemeContext)
+  if (!ctx) throw new Error("useTheme must be used within ThemeProvider")
+  return ctx
+}
+
+// Inline script that runs before React hydration, applied via dangerouslySet-
+// InnerHTML in app/layout.tsx. It must be self-contained, defensive against
+// missing storage, and idempotent.
+export const themeBootScript = `
+(function(){try{
+  var t = localStorage.getItem(${JSON.stringify(THEME_STORAGE_KEY)});
+  if (t !== "light" && t !== "dark") {
+    t = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark" : "light";
+  }
+  if (t === "dark") document.documentElement.classList.add("dark");
+  var b = localStorage.getItem(${JSON.stringify(BACKGROUND_STORAGE_KEY)});
+  if (b !== "default" && b !== "soft") b = "default";
+  document.documentElement.setAttribute("data-bg", b);
+}catch(e){}})();
+`
+
+// Re-export helpers so tests / consumers can avoid importing two modules.
+export { isBackground, isTheme }
+export type { Background, Theme }

--- a/apps/web/components/ThemeProvider.tsx
+++ b/apps/web/components/ThemeProvider.tsx
@@ -11,10 +11,12 @@ import {
 import {
   Background,
   BACKGROUND_STORAGE_KEY,
+  BACKGROUNDS,
   isBackground,
   isTheme,
   Theme,
   THEME_STORAGE_KEY,
+  THEMES,
 } from "@/lib/theme"
 
 type Ctx = {
@@ -91,16 +93,28 @@ export function useTheme(): Ctx {
 // Inline script that runs before React hydration, applied via dangerouslySet-
 // InnerHTML in app/layout.tsx. It must be self-contained, defensive against
 // missing storage, and idempotent.
+//
+// String literals (themes, backgrounds, defaults) are interpolated from
+// lib/theme so this script can never drift from the typed constants — adding
+// a new theme/background propagates here automatically.
+const THEMES_JSON = JSON.stringify(THEMES)
+const BGS_JSON = JSON.stringify(BACKGROUNDS)
+const DEFAULT_BG: Background = "default"
+const DARK: Theme = "dark"
+const LIGHT: Theme = "light"
+
 export const themeBootScript = `
 (function(){try{
+  var THEMES = ${THEMES_JSON};
+  var BGS = ${BGS_JSON};
   var t = localStorage.getItem(${JSON.stringify(THEME_STORAGE_KEY)});
-  if (t !== "light" && t !== "dark") {
+  if (THEMES.indexOf(t) === -1) {
     t = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches
-      ? "dark" : "light";
+      ? ${JSON.stringify(DARK)} : ${JSON.stringify(LIGHT)};
   }
-  if (t === "dark") document.documentElement.classList.add("dark");
+  if (t === ${JSON.stringify(DARK)}) document.documentElement.classList.add(${JSON.stringify(DARK)});
   var b = localStorage.getItem(${JSON.stringify(BACKGROUND_STORAGE_KEY)});
-  if (b !== "default" && b !== "soft") b = "default";
+  if (BGS.indexOf(b) === -1) b = ${JSON.stringify(DEFAULT_BG)};
   document.documentElement.setAttribute("data-bg", b);
 }catch(e){}})();
 `

--- a/apps/web/lib/theme.ts
+++ b/apps/web/lib/theme.ts
@@ -1,0 +1,15 @@
+export type Theme = "light" | "dark"
+export type Background = "default" | "soft"
+
+export const THEMES: Theme[] = ["light", "dark"]
+export const BACKGROUNDS: Background[] = ["default", "soft"]
+
+export const THEME_STORAGE_KEY = "ai-agent:theme"
+export const BACKGROUND_STORAGE_KEY = "ai-agent:background"
+
+export function isTheme(v: unknown): v is Theme {
+  return v === "light" || v === "dark"
+}
+export function isBackground(v: unknown): v is Background {
+  return v === "default" || v === "soft"
+}

--- a/apps/web/tests/theme-provider.test.tsx
+++ b/apps/web/tests/theme-provider.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import { AppearancePanel } from "@/components/AppearancePanel"
+import { ThemeProvider } from "@/components/ThemeProvider"
+import {
+  BACKGROUND_STORAGE_KEY,
+  THEME_STORAGE_KEY,
+} from "@/lib/theme"
+
+describe("ThemeProvider + AppearancePanel", () => {
+  beforeEach(() => {
+    document.documentElement.className = ""
+    document.documentElement.removeAttribute("data-bg")
+    localStorage.clear()
+  })
+  afterEach(() => {
+    document.documentElement.className = ""
+    document.documentElement.removeAttribute("data-bg")
+    localStorage.clear()
+  })
+
+  it("applies the 'dark' class on documentElement when Dark is selected", async () => {
+    const user = userEvent.setup()
+    render(
+      <ThemeProvider>
+        <AppearancePanel />
+      </ThemeProvider>,
+    )
+    expect(document.documentElement.classList.contains("dark")).toBe(false)
+    await user.click(screen.getByTestId("theme-dark"))
+    expect(document.documentElement.classList.contains("dark")).toBe(true)
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark")
+  })
+
+  it("sets data-bg attribute and persists the background choice", async () => {
+    const user = userEvent.setup()
+    render(
+      <ThemeProvider>
+        <AppearancePanel />
+      </ThemeProvider>,
+    )
+    await user.click(screen.getByTestId("bg-soft"))
+    expect(document.documentElement.getAttribute("data-bg")).toBe("soft")
+    expect(localStorage.getItem(BACKGROUND_STORAGE_KEY)).toBe("soft")
+  })
+})


### PR DESCRIPTION
## Summary
- Pre-hydration inline script sets `dark` class + `data-bg` attribute on `<html>` from `localStorage`, with `prefers-color-scheme` fallback. Avoids flash-of-wrong-theme.
- `ThemeProvider` context exposes `useTheme()` and persists choices to `ai-agent:theme` / `ai-agent:background` keys.
- `AppearancePanel` in the sidebar footer offers Light/Dark + Default/Soft background presets.
- "Soft" preset paints a subtle radial gradient that adapts to dark mode via existing shadcn HSL tokens.
- Adds `dark:text-green-400` to `SaveStatus` success text (only hardcoded color found in audit).

Closes #89

## Test plan
- [x] `npm test` — 44/44 passed (2 new theme-provider tests)
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds
- [ ] Manual browser smoke (please verify):
  - [ ] Toggle Light ↔ Dark in sidebar — UI flips without reload
  - [ ] Toggle Default ↔ Soft background — gradient applies in both themes
  - [ ] Refresh page — choices persist
  - [ ] Clear `localStorage` and reload — theme matches OS `prefers-color-scheme`
  - [ ] Hard reload — no flash-of-wrong-theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)