### PR TITLE
feat(web): briefing.json import / export from the UI

### DIFF
--- a/apps/web/components/ConfigFilePanel.tsx
+++ b/apps/web/components/ConfigFilePanel.tsx
@@ -1,0 +1,142 @@
+"use client"
+import { useRouter } from "next/navigation"
+import { useRef, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+
+type Status = "idle" | "busy" | "success" | "error"
+
+const DOWNLOAD_NAME = "briefing.json"
+
+export function ConfigFilePanel() {
+  const router = useRouter()
+  const fileRef = useRef<HTMLInputElement>(null)
+  const [status, setStatus] = useState<Status>("idle")
+  const [error, setError] = useState<string | null>(null)
+  const [successMsg, setSuccessMsg] = useState<string | null>(null)
+
+  const busy = status === "busy"
+
+  const onExport = async () => {
+    setStatus("busy")
+    setError(null)
+    setSuccessMsg(null)
+    let res: Response
+    try {
+      res = await fetch("/api/config", { cache: "no-store" })
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Network error")
+      setStatus("error")
+      return
+    }
+    if (!res.ok) {
+      setError(`GET /api/config failed (HTTP ${res.status})`)
+      setStatus("error")
+      return
+    }
+    const data = await res.json()
+    const blob = new Blob([JSON.stringify(data, null, 2)], {
+      type: "application/json",
+    })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement("a")
+    a.href = url
+    a.download = DOWNLOAD_NAME
+    a.click()
+    URL.revokeObjectURL(url)
+    setSuccessMsg("Exported")
+    setStatus("success")
+  }
+
+  const onImportClick = () => fileRef.current?.click()
+
+  const onFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    e.target.value = "" // allow re-selecting the same file later
+    if (!file) return
+    setStatus("busy")
+    setError(null)
+    setSuccessMsg(null)
+
+    let parsed: unknown
+    try {
+      const text = await file.text()
+      parsed = JSON.parse(text)
+    } catch {
+      setError("Invalid JSON — file is not parseable")
+      setStatus("error")
+      return
+    }
+
+    let res: Response
+    try {
+      res = await fetch("/api/config", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(parsed),
+      })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Network error")
+      setStatus("error")
+      return
+    }
+    if (res.ok) {
+      setSuccessMsg("Imported")
+      setStatus("success")
+      router.refresh()
+      return
+    }
+    if (res.status === 422) {
+      setError("Schema validation failed — file does not match briefing.json")
+    } else {
+      setError(`PUT /api/config failed (HTTP ${res.status})`)
+    }
+    setStatus("error")
+  }
+
+  return (
+    <div className="space-y-2" data-testid="config-file-panel">
+      <div className="flex flex-col gap-1">
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => void onExport()}
+          disabled={busy}
+          data-testid="config-export"
+        >
+          Export
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={onImportClick}
+          disabled={busy}
+          data-testid="config-import"
+        >
+          Import
+        </Button>
+        <input
+          ref={fileRef}
+          type="file"
+          accept="application/json,.json"
+          className="hidden"
+          onChange={(e) => void onFileChange(e)}
+          data-testid="config-import-input"
+        />
+      </div>
+      {successMsg && (
+        <p
+          className="text-xs text-green-600 dark:text-green-400"
+          data-testid="config-success"
+        >
+          {successMsg}
+        </p>
+      )}
+      {error && (
+        <p className="text-xs text-destructive" data-testid="config-error">
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/apps/web/components/Sidebar.tsx
+++ b/apps/web/components/Sidebar.tsx
@@ -1,10 +1,10 @@
 "use client"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { useState } from "react"
 
 import { AppearancePanel } from "@/components/AppearancePanel"
 import { ConfigFilePanel } from "@/components/ConfigFilePanel"
+import { SidebarDisclosure } from "@/components/SidebarDisclosure"
 import { cn } from "@/lib/utils"
 
 type Item = { href: string; label: string; icon: string }
@@ -21,8 +21,6 @@ const ITEMS: Item[] = [
 
 export function Sidebar() {
   const pathname = usePathname()
-  const [appearanceOpen, setAppearanceOpen] = useState(false)
-  const [configFileOpen, setConfigFileOpen] = useState(false)
   return (
     <aside className="flex w-60 flex-col gap-4 border-r bg-card p-4">
       <section className="flex flex-col gap-1">
@@ -55,48 +53,20 @@ export function Sidebar() {
           <span aria-hidden>⚙️</span>
           <span>Config</span>
         </h2>
-        <button
-          type="button"
-          onClick={() => setAppearanceOpen((v) => !v)}
-          aria-expanded={appearanceOpen}
-          aria-controls="appearance-panel-body"
-          data-testid="appearance-toggle"
-          className="flex items-center justify-between rounded-md px-3 py-2 text-sm transition-colors hover:bg-accent/50"
+        <SidebarDisclosure
+          label="Appearance"
+          icon="🎨"
+          testid="appearance-toggle"
         >
-          <span className="flex items-center gap-2">
-            <span aria-hidden>🎨</span>
-            <span>Appearance</span>
-          </span>
-          <span aria-hidden className="text-xs text-muted-foreground">
-            {appearanceOpen ? "▾" : "▸"}
-          </span>
-        </button>
-        {appearanceOpen && (
-          <div id="appearance-panel-body" className="px-3 pb-1 pt-1">
-            <AppearancePanel />
-          </div>
-        )}
-        <button
-          type="button"
-          onClick={() => setConfigFileOpen((v) => !v)}
-          aria-expanded={configFileOpen}
-          aria-controls="config-file-panel-body"
-          data-testid="config-file-toggle"
-          className="flex items-center justify-between rounded-md px-3 py-2 text-sm transition-colors hover:bg-accent/50"
+          <AppearancePanel />
+        </SidebarDisclosure>
+        <SidebarDisclosure
+          label="Config file"
+          icon="📁"
+          testid="config-file-toggle"
         >
-          <span className="flex items-center gap-2">
-            <span aria-hidden>📁</span>
-            <span>Config file</span>
-          </span>
-          <span aria-hidden className="text-xs text-muted-foreground">
-            {configFileOpen ? "▾" : "▸"}
-          </span>
-        </button>
-        {configFileOpen && (
-          <div id="config-file-panel-body" className="px-3 pb-1 pt-1">
-            <ConfigFilePanel />
-          </div>
-        )}
+          <ConfigFilePanel />
+        </SidebarDisclosure>
       </section>
     </aside>
   )

--- a/apps/web/components/Sidebar.tsx
+++ b/apps/web/components/Sidebar.tsx
@@ -4,6 +4,7 @@ import { usePathname } from "next/navigation"
 import { useState } from "react"
 
 import { AppearancePanel } from "@/components/AppearancePanel"
+import { ConfigFilePanel } from "@/components/ConfigFilePanel"
 import { cn } from "@/lib/utils"
 
 type Item = { href: string; label: string; icon: string }
@@ -21,6 +22,7 @@ const ITEMS: Item[] = [
 export function Sidebar() {
   const pathname = usePathname()
   const [appearanceOpen, setAppearanceOpen] = useState(false)
+  const [configFileOpen, setConfigFileOpen] = useState(false)
   return (
     <aside className="flex w-60 flex-col gap-4 border-r bg-card p-4">
       <section className="flex flex-col gap-1">
@@ -72,6 +74,27 @@ export function Sidebar() {
         {appearanceOpen && (
           <div id="appearance-panel-body" className="px-3 pb-1 pt-1">
             <AppearancePanel />
+          </div>
+        )}
+        <button
+          type="button"
+          onClick={() => setConfigFileOpen((v) => !v)}
+          aria-expanded={configFileOpen}
+          aria-controls="config-file-panel-body"
+          data-testid="config-file-toggle"
+          className="flex items-center justify-between rounded-md px-3 py-2 text-sm transition-colors hover:bg-accent/50"
+        >
+          <span className="flex items-center gap-2">
+            <span aria-hidden>📁</span>
+            <span>Config file</span>
+          </span>
+          <span aria-hidden className="text-xs text-muted-foreground">
+            {configFileOpen ? "▾" : "▸"}
+          </span>
+        </button>
+        {configFileOpen && (
+          <div id="config-file-panel-body" className="px-3 pb-1 pt-1">
+            <ConfigFilePanel />
           </div>
         )}
       </section>

--- a/apps/web/components/Sidebar.tsx
+++ b/apps/web/components/Sidebar.tsx
@@ -49,23 +49,28 @@ export function Sidebar() {
       </section>
 
       <section className="flex flex-col gap-1">
-        <h2 className="flex items-center gap-2 px-2 pb-2 text-base font-semibold">
-          <span aria-hidden>⚙️</span>
-          <span>Config</span>
-        </h2>
         <SidebarDisclosure
-          label="Appearance"
-          icon="🎨"
-          testid="appearance-toggle"
+          label="Config"
+          icon="⚙️"
+          testid="config-toggle"
+          variant="heading"
         >
-          <AppearancePanel />
-        </SidebarDisclosure>
-        <SidebarDisclosure
-          label="Config file"
-          icon="📁"
-          testid="config-file-toggle"
-        >
-          <ConfigFilePanel />
+          <div className="flex flex-col gap-1">
+            <SidebarDisclosure
+              label="Appearance"
+              icon="🎨"
+              testid="appearance-toggle"
+            >
+              <AppearancePanel />
+            </SidebarDisclosure>
+            <SidebarDisclosure
+              label="Config file"
+              icon="📁"
+              testid="config-file-toggle"
+            >
+              <ConfigFilePanel />
+            </SidebarDisclosure>
+          </div>
         </SidebarDisclosure>
       </section>
     </aside>

--- a/apps/web/components/SidebarDisclosure.tsx
+++ b/apps/web/components/SidebarDisclosure.tsx
@@ -1,0 +1,42 @@
+"use client"
+import { useId, useState } from "react"
+
+type Props = {
+  label: string
+  icon: string
+  testid: string
+  children: React.ReactNode
+}
+
+// Collapsible row used inside the sidebar's Config section. Keeps each
+// settings panel hidden behind a single click so the section stays compact
+// as more entries are added (Appearance, Config file, ...).
+export function SidebarDisclosure({ label, icon, testid, children }: Props) {
+  const [open, setOpen] = useState(false)
+  const bodyId = useId()
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls={bodyId}
+        data-testid={testid}
+        className="flex items-center justify-between rounded-md px-3 py-2 text-sm transition-colors hover:bg-accent/50"
+      >
+        <span className="flex items-center gap-2">
+          <span aria-hidden>{icon}</span>
+          <span>{label}</span>
+        </span>
+        <span aria-hidden className="text-xs text-muted-foreground">
+          {open ? "▾" : "▸"}
+        </span>
+      </button>
+      {open && (
+        <div id={bodyId} className="px-3 pb-1 pt-1">
+          {children}
+        </div>
+      )}
+    </>
+  )
+}

--- a/apps/web/components/SidebarDisclosure.tsx
+++ b/apps/web/components/SidebarDisclosure.tsx
@@ -1,19 +1,33 @@
 "use client"
 import { useId, useState } from "react"
 
+import { cn } from "@/lib/utils"
+
+type Variant = "default" | "heading"
+
 type Props = {
   label: string
   icon: string
   testid: string
+  variant?: Variant
+  defaultOpen?: boolean
   children: React.ReactNode
 }
 
-// Collapsible row used inside the sidebar's Config section. Keeps each
-// settings panel hidden behind a single click so the section stays compact
-// as more entries are added (Appearance, Config file, ...).
-export function SidebarDisclosure({ label, icon, testid, children }: Props) {
-  const [open, setOpen] = useState(false)
+// Collapsible row used inside the sidebar. `variant="heading"` renders the
+// trigger as a section header (larger, semibold) so a Config-style group can
+// nest other disclosures inside it without visually flattening the hierarchy.
+export function SidebarDisclosure({
+  label,
+  icon,
+  testid,
+  variant = "default",
+  defaultOpen = false,
+  children,
+}: Props) {
+  const [open, setOpen] = useState(defaultOpen)
   const bodyId = useId()
+  const isHeading = variant === "heading"
   return (
     <>
       <button
@@ -22,7 +36,12 @@ export function SidebarDisclosure({ label, icon, testid, children }: Props) {
         aria-expanded={open}
         aria-controls={bodyId}
         data-testid={testid}
-        className="flex items-center justify-between rounded-md px-3 py-2 text-sm transition-colors hover:bg-accent/50"
+        className={cn(
+          "flex items-center justify-between rounded-md transition-colors hover:bg-accent/50",
+          isHeading
+            ? "px-2 py-2 text-base font-semibold"
+            : "px-3 py-2 text-sm",
+        )}
       >
         <span className="flex items-center gap-2">
           <span aria-hidden>{icon}</span>
@@ -33,7 +52,10 @@ export function SidebarDisclosure({ label, icon, testid, children }: Props) {
         </span>
       </button>
       {open && (
-        <div id={bodyId} className="px-3 pb-1 pt-1">
+        <div
+          id={bodyId}
+          className={cn(isHeading ? "pt-1" : "px-3 pb-1 pt-1")}
+        >
           {children}
         </div>
       )}

--- a/apps/web/tests/config-file-panel.test.tsx
+++ b/apps/web/tests/config-file-panel.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { ConfigFilePanel } from "@/components/ConfigFilePanel"
+
+const refreshMock = vi.fn()
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: refreshMock }),
+}))
+
+describe("ConfigFilePanel", () => {
+  const fetchMock = vi.fn()
+  const clickSpy = vi.fn()
+  const originalCreateObjectURL = URL.createObjectURL
+  const originalRevokeObjectURL = URL.revokeObjectURL
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    clickSpy.mockReset()
+    refreshMock.mockReset()
+    vi.stubGlobal("fetch", fetchMock)
+    // Override per-element click via HTMLAnchorElement.prototype so the
+    // download trigger doesn't actually navigate jsdom.
+    HTMLAnchorElement.prototype.click = clickSpy
+    URL.createObjectURL = vi.fn(() => "blob:fake")
+    URL.revokeObjectURL = vi.fn()
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    URL.createObjectURL = originalCreateObjectURL
+    URL.revokeObjectURL = originalRevokeObjectURL
+  })
+
+  it("Export triggers a download with the GET /api/config body", async () => {
+    const config = { portfolio: { tickers: ["NVDA"], themes: [] } }
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => config,
+    })
+    const user = userEvent.setup()
+    render(<ConfigFilePanel />)
+    await user.click(screen.getByTestId("config-export"))
+    await waitFor(() => {
+      expect(screen.getByTestId("config-success")).toHaveTextContent("Exported")
+    })
+    expect(fetchMock).toHaveBeenCalledWith("/api/config", { cache: "no-store" })
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1)
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+    expect(URL.revokeObjectURL).toHaveBeenCalledTimes(1)
+  })
+
+  it("Import: invalid JSON surfaces inline error and skips PUT", async () => {
+    const user = userEvent.setup()
+    render(<ConfigFilePanel />)
+    const file = new File(["not json {{{"], "broken.json", {
+      type: "application/json",
+    })
+    await user.upload(screen.getByTestId("config-import-input"), file)
+    await waitFor(() => {
+      expect(screen.getByTestId("config-error")).toHaveTextContent(
+        /invalid json/i,
+      )
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(refreshMock).not.toHaveBeenCalled()
+  })
+
+  it("Import: schema validation failure (422) surfaces inline error", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 422,
+      json: async () => ({ detail: [] }),
+    })
+    const user = userEvent.setup()
+    render(<ConfigFilePanel />)
+    const file = new File(['{"portfolio": {}}'], "bad.json", {
+      type: "application/json",
+    })
+    await user.upload(screen.getByTestId("config-import-input"), file)
+    await waitFor(() => {
+      expect(screen.getByTestId("config-error")).toHaveTextContent(
+        /schema validation failed/i,
+      )
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(refreshMock).not.toHaveBeenCalled()
+  })
+
+  it("Import: success path PUTs the parsed body and refreshes the router", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    })
+    const user = userEvent.setup()
+    render(<ConfigFilePanel />)
+    const payload = { portfolio: { tickers: ["PLTR"], themes: [] } }
+    const file = new File([JSON.stringify(payload)], "ok.json", {
+      type: "application/json",
+    })
+    await user.upload(screen.getByTestId("config-import-input"), file)
+    await waitFor(() => {
+      expect(screen.getByTestId("config-success")).toHaveTextContent("Imported")
+    })
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe("/api/config")
+    expect(init.method).toBe("PUT")
+    expect(JSON.parse(String(init.body))).toEqual(payload)
+    expect(refreshMock).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary
- `ConfigFilePanel` adds **Export** (GET `/api/config` → JSON Blob download as `briefing.json`) and **Import** (hidden file picker → `JSON.parse` → PUT `/api/config`) controls.
- Reuses the existing GET / PUT endpoints unchanged. Invalid uploads surface inline via FastAPI's 422 — the on-disk file is left untouched.
- Exposed under a new **📁 Config file** disclosure in the sidebar's ⚙️ Config section, mirroring the Appearance pattern.

Closes #85

## Test plan
- [x] `npm test` — 48/48 passed (4 new config-file-panel tests: success / invalid JSON / 422 / round-trip body)
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds
- [ ] Manual browser smoke (please verify):
  - [ ] Sidebar → ⚙️ Config → 📁 Config file expands to show Export / Import
  - [ ] Click Export → browser downloads `briefing.json`; body matches current `GET /api/config`
  - [ ] Edit the file, Import it → forms re-render with new values
  - [ ] Import a file with garbage JSON → inline error, on-disk file unchanged
  - [ ] Import a file with schema mismatch → inline error from 422, on-disk file unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)