### PR TITLE
feat(web): persist in-flight job state across tab switches

### DIFF
--- a/apps/web/app/(main)/layout.tsx
+++ b/apps/web/app/(main)/layout.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation"
 
 import { apiFetch } from "@/lib/api"
 import { Sidebar } from "@/components/Sidebar"
+import { JobStateProvider } from "@/lib/jobStore"
 
 async function isOnboarded(): Promise<boolean> {
   try {
@@ -24,9 +25,11 @@ export default async function MainLayout({
   // Guard: kick anyone not onboarded back to / for the wizard.
   if (!(await isOnboarded())) redirect("/")
   return (
-    <div className="flex min-h-screen">
-      <Sidebar />
-      <main className="flex-1 p-8">{children}</main>
-    </div>
+    <JobStateProvider>
+      <div className="flex min-h-screen">
+        <Sidebar />
+        <main className="flex-1 p-8">{children}</main>
+      </div>
+    </JobStateProvider>
   )
 }

--- a/apps/web/components/Sidebar.tsx
+++ b/apps/web/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react"
 import { AppearancePanel } from "@/components/AppearancePanel"
 import { ConfigFilePanel } from "@/components/ConfigFilePanel"
 import { SidebarDisclosure } from "@/components/SidebarDisclosure"
+import { useJobState } from "@/lib/jobStore"
 import {
   SIDEBAR_COLLAPSED_ATTR,
   SIDEBAR_COLLAPSED_KEY,
@@ -26,6 +27,7 @@ const ITEMS: Item[] = [
 
 export function Sidebar() {
   const pathname = usePathname()
+  const { isBackgrounded: runJobActive } = useJobState()
   // Initialize to false so SSR and the first client render agree (avoiding
   // a hydration mismatch on data-collapsed / aria-expanded / title). The
   // visible width is already correct on first paint because CSS reacts to
@@ -87,6 +89,7 @@ export function Sidebar() {
         <nav className="flex flex-col gap-1">
           {ITEMS.map((item) => {
             const active = pathname === item.href
+            const showRunDot = item.href === "/run" && runJobActive
             return (
               <Link
                 key={item.href}
@@ -104,6 +107,13 @@ export function Sidebar() {
               >
                 <span aria-hidden>{item.icon}</span>
                 <span data-sidebar-label>{item.label}</span>
+                {showRunDot && (
+                  <span
+                    data-testid="sidebar-run-dot"
+                    aria-label="Background job in progress"
+                    className="ml-auto h-2 w-2 shrink-0 rounded-full bg-primary"
+                  />
+                )}
               </Link>
             )
           })}

--- a/apps/web/components/screens/RunForm.tsx
+++ b/apps/web/components/screens/RunForm.tsx
@@ -1,25 +1,11 @@
 "use client"
-import { useCallback, useState } from "react"
+import { useState } from "react"
 
 import { SessionExpiredCard } from "@/components/SessionExpiredCard"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { LoadingDots } from "@/components/ui/loading-dots"
-import { useAbortableMount } from "@/lib/hooks/useAbortableMount"
-
-type JobStatus = "idle" | "pending" | "running" | "done" | "failed"
-
-type JobDetail = {
-  job_id: string
-  status: JobStatus
-  dry_run?: boolean
-  started_at?: string | null
-  finished_at?: string | null
-  error?: string | null
-}
-
-const POLL_INTERVAL_MS = 2000
-const POLL_TIMEOUT_MS = 10 * 60 * 1000 // 10 minutes — full runs can take ~5 min
+import { useJobState } from "@/lib/jobStore"
 
 function fmtTs(ts: string | null | undefined): string | null {
   if (!ts) return null
@@ -31,101 +17,27 @@ function fmtTs(ts: string | null | undefined): string | null {
 }
 
 export function RunForm() {
-  const [dryRun, setDryRun] = useState(false)
-  const [status, setStatus] = useState<JobStatus>("idle")
-  const [job, setJob] = useState<JobDetail | null>(null)
-  const [error, setError] = useState<string | null>(null)
-  const [sessionExpired, setSessionExpired] = useState(false)
+  const [dryRunChoice, setDryRunChoice] = useState(false)
+  const {
+    jobId,
+    status,
+    dryRun,
+    startedAt,
+    finishedAt,
+    error,
+    sessionExpired,
+    isBackgrounded,
+    startJob,
+  } = useJobState()
 
-  // Cancel in-flight fetches and suppress setState if the component unmounts
-  // mid-poll (e.g. user navigates away via the sidebar during a ~5-min run).
-  const { mountedRef, abortRef } = useAbortableMount()
-
-  const busy = status === "pending" || status === "running"
-
-  const run = useCallback(async () => {
-    abortRef.current?.abort()
-    const ctl = new AbortController()
-    abortRef.current = ctl
-    const aborted = () => ctl.signal.aborted || !mountedRef.current
-
-    setError(null)
-    setSessionExpired(false)
-    setJob(null)
-    setStatus("pending")
-    try {
-      const postRes = await fetch(
-        `/api/run${dryRun ? "?dry_run=true" : ""}`,
-        { method: "POST", cache: "no-store", signal: ctl.signal },
-      )
-      if (aborted()) return
-      if (postRes.status === 401) {
-        setSessionExpired(true)
-        setStatus("idle")
-        return
-      }
-      if (!postRes.ok) {
-        const text = await postRes.text()
-        if (aborted()) return
-        setError(`POST /api/run failed (HTTP ${postRes.status}): ${text}`)
-        setStatus("failed")
-        return
-      }
-      const body = (await postRes.json()) as JobDetail
-      if (aborted()) return
-      setJob(body)
-      // Poll until terminal status or timeout. The 10-min ceiling bounds
-      // the loop; unmount/navigation triggers AbortController + mountedRef
-      // to stop polling and discard pending setState calls.
-      const startedAt = Date.now()
-      while (true) {
-        await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS))
-        if (aborted()) return
-        if (Date.now() - startedAt > POLL_TIMEOUT_MS) {
-          setError("Timed out waiting for the job to finish")
-          setStatus("failed")
-          return
-        }
-        const pollRes = await fetch(`/api/run/${body.job_id}`, {
-          cache: "no-store",
-          signal: ctl.signal,
-        })
-        if (aborted()) return
-        if (pollRes.status === 401) {
-          setSessionExpired(true)
-          setStatus("idle")
-          return
-        }
-        if (!pollRes.ok) {
-          setError(`GET /api/run/${body.job_id} failed (HTTP ${pollRes.status})`)
-          setStatus("failed")
-          return
-        }
-        const detail = (await pollRes.json()) as JobDetail
-        if (aborted()) return
-        // Merge: the GET response may omit `dry_run`, which was set on the
-        // POST response. Without merging the badge would flicker off.
-        setJob((prev) => (prev ? { ...prev, ...detail } : detail))
-        setStatus(detail.status)
-        if (detail.status === "done") return
-        if (detail.status === "failed") {
-          setError(detail.error ?? "Job failed without an error message")
-          return
-        }
-      }
-    } catch (e) {
-      if (aborted()) return
-      setError(e instanceof Error ? e.message : "Network error")
-      setStatus("failed")
-    }
-  }, [abortRef, dryRun, mountedRef])
+  const busy = isBackgrounded
 
   if (sessionExpired) {
     return <SessionExpiredCard />
   }
 
-  const started = fmtTs(job?.started_at)
-  const finished = fmtTs(job?.finished_at)
+  const started = fmtTs(startedAt)
+  const finished = fmtTs(finishedAt)
 
   return (
     <div className="space-y-4">
@@ -134,8 +46,8 @@ export function RunForm() {
           <label className="flex items-center gap-2 text-sm">
             <input
               type="checkbox"
-              checked={dryRun}
-              onChange={(e) => setDryRun(e.target.checked)}
+              checked={dryRunChoice}
+              onChange={(e) => setDryRunChoice(e.target.checked)}
               disabled={busy}
               data-testid="dry-run-checkbox"
             />
@@ -148,7 +60,7 @@ export function RunForm() {
           </label>
           <Button
             size="lg"
-            onClick={() => void run()}
+            onClick={() => void startJob({ dryRun: dryRunChoice })}
             disabled={busy}
             data-testid="run-button"
           >
@@ -157,7 +69,7 @@ export function RunForm() {
         </CardContent>
       </Card>
 
-      {job && (
+      {jobId && (
         <Card>
           <CardContent className="space-y-2 pt-6 text-sm">
             <p className="flex items-center gap-2">
@@ -174,8 +86,8 @@ export function RunForm() {
               )}
             </p>
             <p className="text-xs text-muted-foreground">
-              Job id: <code className="font-mono">{job.job_id}</code>
-              {job.dry_run && (
+              Job id: <code className="font-mono">{jobId}</code>
+              {dryRun && (
                 <span className="ml-2 rounded bg-muted px-1 py-0.5 text-[10px]">
                   dry_run
                 </span>

--- a/apps/web/components/screens/RunForm.tsx
+++ b/apps/web/components/screens/RunForm.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
 import { SessionExpiredCard } from "@/components/SessionExpiredCard"
 import { Button } from "@/components/ui/button"
@@ -29,6 +29,13 @@ export function RunForm() {
     isBackgrounded,
     startJob,
   } = useJobState()
+
+  // Mirror the persisted job's dryRun into the checkbox after hydration so the
+  // control reflects the restored job's mode. User toggles still flow through
+  // setDryRunChoice and override the restored value.
+  useEffect(() => {
+    if (jobId) setDryRunChoice(Boolean(dryRun))
+  }, [jobId, dryRun])
 
   const busy = isBackgrounded
 

--- a/apps/web/lib/jobStore.tsx
+++ b/apps/web/lib/jobStore.tsx
@@ -1,0 +1,290 @@
+"use client"
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react"
+
+export type JobStatus = "idle" | "pending" | "running" | "done" | "failed"
+
+export type JobState = {
+  jobId: string | null
+  status: JobStatus
+  dryRun: boolean
+  startedAt: string | null
+  finishedAt: string | null
+  error: string | null
+  sessionExpired: boolean
+}
+
+type StartOpts = { dryRun: boolean }
+
+export type JobStateContextValue = JobState & {
+  isBackgrounded: boolean
+  startJob: (opts: StartOpts) => Promise<void>
+  reset: () => void
+}
+
+// Bumped if the persisted shape changes incompatibly.
+const STORAGE_KEY = "ai-agent:run-job:v1"
+const POLL_INTERVAL_MS = 2000
+const POLL_TIMEOUT_MS = 10 * 60 * 1000
+
+const initialState: JobState = {
+  jobId: null,
+  status: "idle",
+  dryRun: false,
+  startedAt: null,
+  finishedAt: null,
+  error: null,
+  sessionExpired: false,
+}
+
+const isInFlight = (s: JobStatus) => s === "pending" || s === "running"
+const isTerminal = (s: JobStatus) => s === "done" || s === "failed"
+
+type ApiJobDetail = {
+  job_id?: string
+  status: JobStatus
+  dry_run?: boolean
+  started_at?: string | null
+  finished_at?: string | null
+  error?: string | null
+}
+
+function loadPersisted(): JobState {
+  if (typeof window === "undefined") return initialState
+  try {
+    const raw = window.sessionStorage.getItem(STORAGE_KEY)
+    if (!raw) return initialState
+    const parsed = JSON.parse(raw) as Partial<JobState>
+    return { ...initialState, ...parsed, sessionExpired: false }
+  } catch {
+    return initialState
+  }
+}
+
+function persist(state: JobState) {
+  if (typeof window === "undefined") return
+  try {
+    // sessionExpired is UI-only; never persist it
+    const toStore = { ...state, sessionExpired: false }
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(toStore))
+  } catch {
+    // quota / unavailable — state remains in memory for the tab
+  }
+}
+
+function clearPersisted() {
+  if (typeof window === "undefined") return
+  try {
+    window.sessionStorage.removeItem(STORAGE_KEY)
+  } catch {
+    // ignore
+  }
+}
+
+const JobStateContext = createContext<JobStateContextValue | null>(null)
+
+export function JobStateProvider({ children }: { children: ReactNode }) {
+  // Render initialState on first paint so SSR and the first client render
+  // agree (sessionStorage is unavailable on the server). The hydrate effect
+  // below promotes state to whatever was persisted in this tab.
+  const [state, setState] = useState<JobState>(initialState)
+  const [hydrated, setHydrated] = useState(false)
+
+  useEffect(() => {
+    setState(loadPersisted())
+    setHydrated(true)
+  }, [])
+
+  useEffect(() => {
+    if (!hydrated) return
+    if (!state.jobId && state.status === "idle" && !state.error) {
+      clearPersisted()
+    } else {
+      persist(state)
+    }
+  }, [state, hydrated])
+
+  const inFlight = isInFlight(state.status)
+
+  // Polling loop. Runs while an in-flight job is present; aborted/cleaned up
+  // on jobId change, status leaving in-flight, or unmount. Mount with a
+  // persisted in-flight job resumes polling per the acceptance criteria.
+  useEffect(() => {
+    if (!hydrated) return
+    if (!state.jobId) return
+    if (!inFlight) return
+
+    const jobId = state.jobId
+    const ctl = new AbortController()
+    const pollStartedAt = Date.now()
+    let stopped = false
+
+    const stop = () => {
+      stopped = true
+      ctl.abort()
+    }
+
+    ;(async () => {
+      while (!stopped) {
+        await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS))
+        if (stopped) return
+        if (Date.now() - pollStartedAt > POLL_TIMEOUT_MS) {
+          setState((prev) =>
+            prev.jobId === jobId
+              ? {
+                  ...prev,
+                  status: "failed",
+                  error: "Timed out waiting for the job to finish",
+                }
+              : prev,
+          )
+          return
+        }
+        try {
+          const res = await fetch(`/api/run/${jobId}`, {
+            cache: "no-store",
+            signal: ctl.signal,
+          })
+          if (stopped) return
+          if (res.status === 401) {
+            setState((prev) => ({ ...prev, sessionExpired: true }))
+            return
+          }
+          if (res.status === 404) {
+            // Backend no longer knows this job (process restart, eviction).
+            // Per AC: clear state cleanly with an informative message.
+            setState({
+              ...initialState,
+              error:
+                "The previous background job is no longer available — please run it again.",
+            })
+            return
+          }
+          if (!res.ok) {
+            setState((prev) =>
+              prev.jobId === jobId
+                ? {
+                    ...prev,
+                    status: "failed",
+                    error: `GET /api/run/${jobId} failed (HTTP ${res.status})`,
+                  }
+                : prev,
+            )
+            return
+          }
+          const detail = (await res.json()) as ApiJobDetail
+          if (stopped) return
+          setState((prev) =>
+            prev.jobId === jobId
+              ? {
+                  ...prev,
+                  status: detail.status,
+                  startedAt: detail.started_at ?? prev.startedAt,
+                  finishedAt: detail.finished_at ?? prev.finishedAt,
+                  // dry_run is set on the POST response; preserve it across GETs that omit it
+                  dryRun: detail.dry_run ?? prev.dryRun,
+                  error:
+                    detail.status === "failed"
+                      ? detail.error ?? "Job failed without an error message"
+                      : prev.error,
+                }
+                : prev,
+          )
+          if (isTerminal(detail.status)) return
+        } catch (e) {
+          if (stopped) return
+          setState((prev) =>
+            prev.jobId === jobId
+              ? {
+                  ...prev,
+                  status: "failed",
+                  error: e instanceof Error ? e.message : "Network error",
+                }
+              : prev,
+          )
+          return
+        }
+      }
+    })()
+
+    return stop
+  }, [hydrated, state.jobId, inFlight])
+
+  const startJob = useCallback(async ({ dryRun }: StartOpts) => {
+    setState({
+      ...initialState,
+      status: "pending",
+      dryRun,
+    })
+    try {
+      const res = await fetch(`/api/run${dryRun ? "?dry_run=true" : ""}`, {
+        method: "POST",
+        cache: "no-store",
+      })
+      if (res.status === 401) {
+        setState({ ...initialState, sessionExpired: true })
+        return
+      }
+      if (!res.ok) {
+        const text = await res.text()
+        setState((prev) => ({
+          ...prev,
+          status: "failed",
+          error: `POST /api/run failed (HTTP ${res.status}): ${text}`,
+        }))
+        return
+      }
+      const body = (await res.json()) as ApiJobDetail
+      setState((prev) => ({
+        ...prev,
+        jobId: body.job_id ?? null,
+        status: body.status,
+        startedAt: body.started_at ?? prev.startedAt,
+        finishedAt: body.finished_at ?? prev.finishedAt,
+        dryRun: body.dry_run ?? prev.dryRun,
+      }))
+    } catch (e) {
+      setState((prev) => ({
+        ...prev,
+        status: "failed",
+        error: e instanceof Error ? e.message : "Network error",
+      }))
+    }
+  }, [])
+
+  const reset = useCallback(() => {
+    setState(initialState)
+    clearPersisted()
+  }, [])
+
+  const value = useMemo<JobStateContextValue>(
+    () => ({
+      ...state,
+      isBackgrounded: inFlight,
+      startJob,
+      reset,
+    }),
+    [state, inFlight, startJob, reset],
+  )
+
+  return (
+    <JobStateContext.Provider value={value}>
+      {children}
+    </JobStateContext.Provider>
+  )
+}
+
+export function useJobState(): JobStateContextValue {
+  const ctx = useContext(JobStateContext)
+  if (!ctx) {
+    throw new Error("useJobState must be used inside <JobStateProvider>")
+  }
+  return ctx
+}

--- a/apps/web/lib/jobStore.tsx
+++ b/apps/web/lib/jobStore.tsx
@@ -62,7 +62,12 @@ function loadPersisted(): JobState {
     const raw = window.sessionStorage.getItem(STORAGE_KEY)
     if (!raw) return initialState
     const parsed = JSON.parse(raw) as Partial<JobState>
-    return { ...initialState, ...parsed, sessionExpired: false }
+    const next = { ...initialState, ...parsed, sessionExpired: false }
+    // Drop unresumable snapshots: an in-flight status with no jobId can only
+    // come from the brief window between startJob() flipping status to
+    // "pending" and the POST returning. Polling has nothing to resume on.
+    if (!next.jobId && isInFlight(next.status)) return initialState
+    return next
   } catch {
     return initialState
   }
@@ -104,7 +109,10 @@ export function JobStateProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (!hydrated) return
-    if (!state.jobId && state.status === "idle" && !state.error) {
+    // Don't persist if there's nothing recoverable: no jobId AND no error to
+    // surface. This covers idle and the transient "pending without jobId"
+    // window during startJob() before the POST returns.
+    if (!state.jobId && !state.error) {
       clearPersisted()
     } else {
       persist(state)
@@ -154,17 +162,25 @@ export function JobStateProvider({ children }: { children: ReactNode }) {
           })
           if (stopped) return
           if (res.status === 401) {
-            setState((prev) => ({ ...prev, sessionExpired: true }))
+            setState((prev) =>
+              prev.jobId === jobId
+                ? { ...prev, sessionExpired: true }
+                : prev,
+            )
             return
           }
           if (res.status === 404) {
             // Backend no longer knows this job (process restart, eviction).
             // Per AC: clear state cleanly with an informative message.
-            setState({
-              ...initialState,
-              error:
-                "The previous background job is no longer available — please run it again.",
-            })
+            setState((prev) =>
+              prev.jobId === jobId
+                ? {
+                    ...initialState,
+                    error:
+                      "The previous background job is no longer available — please run it again.",
+                  }
+                : prev,
+            )
             return
           }
           if (!res.ok) {

--- a/apps/web/tests/job-store.test.tsx
+++ b/apps/web/tests/job-store.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { Sidebar } from "@/components/Sidebar"
+import { RunForm } from "@/components/screens/RunForm"
+import { JobStateProvider } from "@/lib/jobStore"
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/portfolio",
+}))
+
+const STORAGE_KEY = "ai-agent:run-job:v1"
+
+function seedStoredJob(state: Record<string, unknown>): void {
+  sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+}
+
+describe("JobStateProvider — resume from sessionStorage", () => {
+  const fetchMock = vi.fn()
+  let realSetTimeout: typeof setTimeout
+
+  beforeEach(() => {
+    sessionStorage.clear()
+    fetchMock.mockReset()
+    vi.stubGlobal("fetch", fetchMock)
+    realSetTimeout = global.setTimeout
+    vi.stubGlobal(
+      "setTimeout",
+      ((cb: (...a: unknown[]) => void) =>
+        realSetTimeout(cb, 0)) as unknown as typeof setTimeout,
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    sessionStorage.clear()
+  })
+
+  it("resumes polling when mounted with a stored running job (AC: page reload mid-flight)", async () => {
+    seedStoredJob({
+      jobId: "resume-1",
+      status: "running",
+      dryRun: false,
+      startedAt: "2026-05-31T12:00:00Z",
+      finishedAt: null,
+      error: null,
+    })
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          job_id: "resume-1",
+          status: "done",
+          finished_at: "2026-05-31T12:05:00Z",
+        }),
+        { status: 200 },
+      ),
+    )
+
+    render(
+      <JobStateProvider>
+        <RunForm />
+      </JobStateProvider>,
+    )
+
+    // Status is restored from sessionStorage even before the first poll lands.
+    await waitFor(() => {
+      expect(screen.getByTestId("job-status")).toHaveTextContent(/running|done/)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("job-status")).toHaveTextContent("done")
+    })
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/run/resume-1",
+      expect.objectContaining({ cache: "no-store" }),
+    )
+  })
+
+  it("does not poll when mounted with a stored terminal job (AC: no polling for done jobs)", async () => {
+    seedStoredJob({
+      jobId: "resume-done",
+      status: "done",
+      dryRun: false,
+      startedAt: "2026-05-31T12:00:00Z",
+      finishedAt: "2026-05-31T12:05:00Z",
+      error: null,
+    })
+
+    render(
+      <JobStateProvider>
+        <RunForm />
+      </JobStateProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("job-status")).toHaveTextContent("done")
+    })
+    // Give the loop a chance to run if it were going to.
+    await new Promise((r) => realSetTimeout(r, 20))
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("clears state with an informative message when the backend returns 404 on resume", async () => {
+    seedStoredJob({
+      jobId: "gone-job",
+      status: "running",
+      dryRun: false,
+      startedAt: "2026-05-31T12:00:00Z",
+      finishedAt: null,
+      error: null,
+    })
+    fetchMock.mockResolvedValueOnce(new Response("not found", { status: 404 }))
+
+    render(
+      <JobStateProvider>
+        <RunForm />
+      </JobStateProvider>,
+    )
+
+    // First confirm the seeded job hydrated.
+    await waitFor(() => {
+      expect(screen.getByTestId("job-status")).toHaveTextContent("running")
+    })
+    await waitFor(
+      () => {
+        expect(screen.getByTestId("run-error")).toBeInTheDocument()
+      },
+      { timeout: 3000, interval: 25 },
+    )
+    // Job card cleared (no more jobId), only the error remains.
+    expect(screen.queryByTestId("job-status")).toBeNull()
+    expect(screen.queryByText(/gone-job/)).toBeNull()
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeTruthy() // error state persisted
+  })
+
+  it("shows the sidebar dot on /run while a background job is in flight", async () => {
+    seedStoredJob({
+      jobId: "bg-job",
+      status: "running",
+      dryRun: false,
+      startedAt: "2026-05-31T12:00:00Z",
+      finishedAt: null,
+      error: null,
+    })
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({ job_id: "bg-job", status: "running" }),
+        { status: 200 },
+      ),
+    )
+
+    render(
+      <JobStateProvider>
+        <Sidebar />
+      </JobStateProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("sidebar-run-dot")).toBeInTheDocument()
+    })
+    // Dot is anchored on the Run nav row.
+    const runLink = screen.getByTestId("nav-run")
+    expect(runLink).toContainElement(screen.getByTestId("sidebar-run-dot"))
+  })
+})

--- a/apps/web/tests/job-store.test.tsx
+++ b/apps/web/tests/job-store.test.tsx
@@ -132,6 +132,57 @@ describe("JobStateProvider — resume from sessionStorage", () => {
     expect(sessionStorage.getItem(STORAGE_KEY)).toBeTruthy() // error state persisted
   })
 
+  it("drops an unresumable persisted snapshot (status=pending, jobId=null)", async () => {
+    // Simulates a reload during the brief window where startJob() has flipped
+    // status to "pending" but the POST has not yet returned a job_id.
+    seedStoredJob({
+      jobId: null,
+      status: "pending",
+      dryRun: false,
+      startedAt: null,
+      finishedAt: null,
+      error: null,
+    })
+
+    render(
+      <JobStateProvider>
+        <RunForm />
+      </JobStateProvider>,
+    )
+
+    // No job card (no jobId), Run button enabled (status normalized to idle).
+    await waitFor(() => {
+      expect(screen.getByTestId("run-button")).not.toBeDisabled()
+    })
+    expect(screen.queryByTestId("job-status")).toBeNull()
+    // Nothing in flight → no poll fetched.
+    await new Promise((r) => realSetTimeout(r, 20))
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("restores the dry-run checkbox to match the persisted job's mode", async () => {
+    seedStoredJob({
+      jobId: "dry-job",
+      status: "done",
+      dryRun: true,
+      startedAt: "2026-05-31T12:00:00Z",
+      finishedAt: "2026-05-31T12:05:00Z",
+      error: null,
+    })
+
+    render(
+      <JobStateProvider>
+        <RunForm />
+      </JobStateProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("dry-run-checkbox")).toBeChecked()
+    })
+    // Badge on the restored job card confirms dryRun made it through hydration.
+    expect(screen.getByText("dry_run")).toBeInTheDocument()
+  })
+
   it("shows the sidebar dot on /run while a background job is in flight", async () => {
     seedStoredJob({
       jobId: "bg-job",

--- a/apps/web/tests/run-form.test.tsx
+++ b/apps/web/tests/run-form.test.tsx
@@ -3,20 +3,31 @@ import userEvent from "@testing-library/user-event"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { RunForm } from "@/components/screens/RunForm"
+import { JobStateProvider } from "@/lib/jobStore"
+
+function renderWithProvider() {
+  return render(
+    <JobStateProvider>
+      <RunForm />
+    </JobStateProvider>,
+  )
+}
 
 describe("RunForm", () => {
   const fetchMock = vi.fn()
 
   beforeEach(() => {
+    sessionStorage.clear()
     fetchMock.mockReset()
     vi.stubGlobal("fetch", fetchMock)
   })
   afterEach(() => {
     vi.unstubAllGlobals()
+    sessionStorage.clear()
   })
 
   it("renders idle with the Run button enabled", () => {
-    render(<RunForm />)
+    renderWithProvider()
     expect(screen.getByTestId("run-button")).not.toBeDisabled()
   })
 
@@ -28,7 +39,7 @@ describe("RunForm", () => {
       ),
     )
     const user = userEvent.setup()
-    render(<RunForm />)
+    renderWithProvider()
     await user.click(screen.getByTestId("run-button"))
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/run",
@@ -44,7 +55,7 @@ describe("RunForm", () => {
       ),
     )
     const user = userEvent.setup()
-    render(<RunForm />)
+    renderWithProvider()
     await user.click(screen.getByTestId("dry-run-checkbox"))
     await user.click(screen.getByTestId("run-button"))
     expect(fetchMock).toHaveBeenCalledWith(
@@ -61,7 +72,7 @@ describe("RunForm", () => {
       ),
     )
     const user = userEvent.setup()
-    render(<RunForm />)
+    renderWithProvider()
     await user.click(screen.getByTestId("run-button"))
     await waitFor(() => {
       expect(screen.getByTestId("run-button")).toBeDisabled()
@@ -71,7 +82,7 @@ describe("RunForm", () => {
   it("shows the session-expired card when POST returns 401", async () => {
     fetchMock.mockResolvedValueOnce(new Response("", { status: 401 }))
     const user = userEvent.setup()
-    render(<RunForm />)
+    renderWithProvider()
     await user.click(screen.getByTestId("run-button"))
     await waitFor(() => {
       expect(screen.getByTestId("session-expired")).toBeInTheDocument()
@@ -92,7 +103,7 @@ describe("RunForm", () => {
       ),
     )
     const user = userEvent.setup()
-    render(<RunForm />)
+    renderWithProvider()
     await user.click(screen.getByTestId("dry-run-checkbox"))
     await user.click(screen.getByTestId("run-button"))
     await waitFor(() => {
@@ -105,7 +116,7 @@ describe("RunForm", () => {
   it("renders the error card when POST fails with non-401", async () => {
     fetchMock.mockResolvedValueOnce(new Response("oops", { status: 500 }))
     const user = userEvent.setup()
-    render(<RunForm />)
+    renderWithProvider()
     await user.click(screen.getByTestId("run-button"))
     await waitFor(() => {
       expect(screen.getByTestId("run-error")).toBeInTheDocument()
@@ -158,7 +169,7 @@ describe("RunForm", () => {
           ),
         )
       const user = userEvent.setup()
-      render(<RunForm />)
+      renderWithProvider()
       await user.click(screen.getByTestId("dry-run-checkbox"))
       await user.click(screen.getByTestId("run-button"))
 
@@ -194,7 +205,7 @@ describe("RunForm", () => {
           ),
         )
       const user = userEvent.setup()
-      render(<RunForm />)
+      renderWithProvider()
       await user.click(screen.getByTestId("run-button"))
       await waitFor(() => {
         expect(screen.getByTestId("job-status")).toHaveTextContent("failed")
@@ -212,7 +223,7 @@ describe("RunForm", () => {
         )
         .mockResolvedValueOnce(new Response("", { status: 401 }))
       const user = userEvent.setup()
-      render(<RunForm />)
+      renderWithProvider()
       await user.click(screen.getByTestId("run-button"))
       await waitFor(() => {
         expect(screen.getByTestId("session-expired")).toBeInTheDocument()

--- a/apps/web/tests/sidebar.test.tsx
+++ b/apps/web/tests/sidebar.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { Sidebar } from "@/components/Sidebar"
+import { JobStateProvider } from "@/lib/jobStore"
 import {
   SIDEBAR_COLLAPSED_ATTR as HTML_ATTR,
   SIDEBAR_COLLAPSED_KEY as COLLAPSED_KEY,
@@ -12,18 +13,28 @@ vi.mock("next/navigation", () => ({
   usePathname: () => "/portfolio",
 }))
 
+function renderSidebar() {
+  return render(
+    <JobStateProvider>
+      <Sidebar />
+    </JobStateProvider>,
+  )
+}
+
 describe("Sidebar collapse", () => {
   beforeEach(() => {
     localStorage.clear()
+    sessionStorage.clear()
     document.documentElement.removeAttribute(HTML_ATTR)
   })
   afterEach(() => {
     localStorage.clear()
+    sessionStorage.clear()
     document.documentElement.removeAttribute(HTML_ATTR)
   })
 
   it("starts expanded when neither the html attribute nor localStorage is set", () => {
-    render(<Sidebar />)
+    renderSidebar()
     expect(screen.getByTestId("sidebar")).toHaveAttribute(
       "data-collapsed",
       "false",
@@ -32,7 +43,7 @@ describe("Sidebar collapse", () => {
   })
 
   it("nav links always expose title and aria-label so tooltips work when collapsed", () => {
-    render(<Sidebar />)
+    renderSidebar()
     expect(screen.getByTestId("nav-portfolio")).toHaveAttribute(
       "title",
       "Portfolio",
@@ -45,7 +56,7 @@ describe("Sidebar collapse", () => {
 
   it("toggle writes html attribute + localStorage and round-trips", async () => {
     const user = userEvent.setup()
-    render(<Sidebar />)
+    renderSidebar()
 
     await user.click(screen.getByTestId("sidebar-toggle"))
     expect(document.documentElement.getAttribute(HTML_ATTR)).toBe("true")
@@ -66,7 +77,7 @@ describe("Sidebar collapse", () => {
 
   it("syncs to the html attribute set by the pre-hydration script after mount", async () => {
     document.documentElement.setAttribute(HTML_ATTR, "true")
-    render(<Sidebar />)
+    renderSidebar()
     // First render matches SSR (collapsed=false) so React doesn't see a
     // hydration mismatch; the mount effect then promotes state to true.
     await waitFor(() => {


### PR DESCRIPTION
## Summary
- Lift `/run` job polling state into a new `JobStateProvider` (in `apps/web/lib/jobStore.tsx`) mounted at the `(main)` layout, with state mirrored to `sessionStorage`.
- A job started on `/run` keeps polling while the user navigates to another sidebar tab and survives a page reload; on backend 404 (process restart / job evicted) the UI clears state with an informative message.
- Sidebar shows a small dot on the **Run** row while a background job is `pending`/`running`. `RunForm` is now a thin consumer of the store.

## Test plan
- [x] `npx vitest run` — 56 tests pass (incl. new `tests/job-store.test.tsx` covering mount-with-running, mount-with-done, 404-on-resume, sidebar dot)
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] Manual: start a job from `/run`, switch to `/portfolio`, return within 30s — status still updates and final state is reachable without re-running
- [ ] Manual: reload the page mid-flight — polling resumes from the persisted job id
- [ ] Manual: simulate backend restart (delete the in-memory job) — UI clears state with the recovery message

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar shows a live status dot when a background job is active.
  * Background job state is persisted in-session and resumes/polls after navigation so progress and errors remain visible.
  * The run workflow now uses shared job state so starting, status, and dry-run choices are consistent across UI.

* **Tests**
  * End-to-end tests updated to cover session resume, polling, error handling, dry-run persistence, and sidebar status rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->