### PR TITLE
feat(web): persist Q&A chat input draft across tab switches

### DIFF
--- a/apps/web/components/screens/ChatForm.tsx
+++ b/apps/web/components/screens/ChatForm.tsx
@@ -18,6 +18,36 @@ type Message = {
 
 type SSEEvent = { type: string; data: string }
 
+// Bumped if the persisted shape changes incompatibly.
+const DRAFT_STORAGE_KEY = "ai-agent:chat-draft:v1"
+
+function loadDraft(): string {
+  if (typeof window === "undefined") return ""
+  try {
+    return window.sessionStorage.getItem(DRAFT_STORAGE_KEY) ?? ""
+  } catch {
+    return ""
+  }
+}
+
+function persistDraft(draft: string) {
+  if (typeof window === "undefined") return
+  try {
+    window.sessionStorage.setItem(DRAFT_STORAGE_KEY, draft)
+  } catch {
+    // quota / unavailable — draft remains in memory for the tab
+  }
+}
+
+function clearDraft() {
+  if (typeof window === "undefined") return
+  try {
+    window.sessionStorage.removeItem(DRAFT_STORAGE_KEY)
+  } catch {
+    // ignore
+  }
+}
+
 function today(): string {
   return new Date().toISOString().slice(0, 10)
 }
@@ -68,7 +98,11 @@ function getRecognitionCtor(): RecognitionCtor | null {
 
 export function ChatForm() {
   const [messages, setMessages] = useState<Message[]>([])
+  // Render "" on first paint so SSR and the first client render agree
+  // (sessionStorage is unavailable on the server). The hydrate effect
+  // below promotes input to whatever draft was persisted in this tab.
   const [input, setInput] = useState("")
+  const [hydrated, setHydrated] = useState(false)
   const [busy, setBusy] = useState(false)
   const [sessionExpired, setSessionExpired] = useState(false)
   const [retrying, setRetrying] = useState(false)
@@ -81,10 +115,21 @@ export function ChatForm() {
 
   useEffect(() => {
     setSupportsMic(getRecognitionCtor() !== null)
+    setInput(loadDraft())
+    setHydrated(true)
     return () => {
       recRef.current?.stop()
     }
   }, [])
+
+  useEffect(() => {
+    if (!hydrated) return
+    if (input === "") {
+      clearDraft()
+    } else {
+      persistDraft(input)
+    }
+  }, [input, hydrated])
 
   // Stream one POST /api/chat round trip. Returns "stale" iff the backend
   // emitted the `stale_session` event — the caller retries exactly once.

--- a/apps/web/tests/chat-form.test.tsx
+++ b/apps/web/tests/chat-form.test.tsx
@@ -26,10 +26,12 @@ function sseResponse(parts: SSEPart[]): Response {
 
 describe("ChatForm", () => {
   const fetchMock = vi.fn()
+  const DRAFT_KEY = "ai-agent:chat-draft:v1"
 
   beforeEach(() => {
     fetchMock.mockReset()
     vi.stubGlobal("fetch", fetchMock)
+    window.sessionStorage.clear()
     // Default: no SpeechRecognition (mimics Firefox / unsupported browsers).
     delete (window as unknown as { SpeechRecognition?: unknown })
       .SpeechRecognition
@@ -151,6 +153,31 @@ describe("ChatForm", () => {
     render(<ChatForm />)
     expect(screen.getByTestId("mic-button")).toBeInTheDocument()
     expect(screen.queryByTestId("mic-unsupported")).toBeNull()
+  })
+
+  it("hydrates the input from sessionStorage on mount", async () => {
+    window.sessionStorage.setItem(DRAFT_KEY, "draft in progress")
+    render(<ChatForm />)
+    const input = await screen.findByTestId("chat-input")
+    await waitFor(() => {
+      expect(input).toHaveValue("draft in progress")
+    })
+  })
+
+  it("persists the draft on each change and clears it on successful send", async () => {
+    fetchMock.mockResolvedValueOnce(sseResponse([{ data: "ok" }]))
+    const user = userEvent.setup()
+    render(<ChatForm />)
+    const input = screen.getByTestId("chat-input")
+    await user.type(input, "ab")
+    await waitFor(() => {
+      expect(window.sessionStorage.getItem(DRAFT_KEY)).toBe("ab")
+    })
+    await user.click(screen.getByTestId("send-button"))
+    await waitFor(() => {
+      expect(window.sessionStorage.getItem(DRAFT_KEY)).toBeNull()
+    })
+    expect(input).toHaveValue("")
   })
 
   it("shows the session-expired card on 401", async () => {


### PR DESCRIPTION
## Summary
- `ChatForm` now hydrates the Q&A input from `sessionStorage` on mount and persists on every keystroke, so switching sidebar tabs or reloading no longer loses an in-progress question.
- A successful send (existing `setInput("")`) flows through the same persist effect and removes the draft entry.
- Storage key: `ai-agent:chat-draft:v1` — mirrors the run-job persistence pattern from #103.

## Test plan
- [x] \`npx vitest run tests/chat-form.test.tsx\` — 11/11 pass, including two new cases (mount hydrates from stored draft; send clears the persisted draft).
- [x] \`npx tsc --noEmit\` clean.
- [x] \`npx eslint\` on touched files clean.
- [x] Manual: type in /chat → navigate to /portfolio → return — input persists.
- [x] Manual: type in /chat → reload — input persists.
- [x] Manual: send — input clears and \`ai-agent:chat-draft:v1\` is removed in DevTools.
- [ ] Manual: close tab, open new tab → input is empty (sessionStorage scope).

Closes #104