### PR TITLE
feat(web): persist Q&A chat history across tab switches

### DIFF
--- a/apps/web/app/(main)/layout.tsx
+++ b/apps/web/app/(main)/layout.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation"
 
 import { apiFetch } from "@/lib/api"
 import { Sidebar } from "@/components/Sidebar"
+import { ChatStateProvider } from "@/lib/chatStore"
 import { JobStateProvider } from "@/lib/jobStore"
 
 async function isOnboarded(): Promise<boolean> {
@@ -26,10 +27,12 @@ export default async function MainLayout({
   if (!(await isOnboarded())) redirect("/")
   return (
     <JobStateProvider>
-      <div className="flex min-h-screen">
-        <Sidebar />
-        <main className="flex-1 p-8">{children}</main>
-      </div>
+      <ChatStateProvider>
+        <div className="flex min-h-screen">
+          <Sidebar />
+          <main className="flex-1 p-8">{children}</main>
+        </div>
+      </ChatStateProvider>
     </JobStateProvider>
   )
 }

--- a/apps/web/components/screens/ChatForm.tsx
+++ b/apps/web/components/screens/ChatForm.tsx
@@ -7,14 +7,9 @@ import { SessionExpiredCard } from "@/components/SessionExpiredCard"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { LoadingDots } from "@/components/ui/loading-dots"
+import { useChatState } from "@/lib/chatStore"
 import { useAbortableMount } from "@/lib/hooks/useAbortableMount"
 import { cn } from "@/lib/utils"
-
-type Message = {
-  role: "user" | "assistant"
-  content: string
-  error?: string | null
-}
 
 type SSEEvent = { type: string; data: string }
 
@@ -97,7 +92,7 @@ function getRecognitionCtor(): RecognitionCtor | null {
 }
 
 export function ChatForm() {
-  const [messages, setMessages] = useState<Message[]>([])
+  const { messages, setMessages } = useChatState()
   // Render "" on first paint so SSR and the first client render agree
   // (sessionStorage is unavailable on the server). The hydrate effect
   // below promotes input to whatever draft was persisted in this tab.
@@ -193,7 +188,7 @@ export function ChatForm() {
       }
       return stale ? "stale" : "ok"
     },
-    [mountedRef],
+    [mountedRef, setMessages],
   )
 
   const send = useCallback(async () => {
@@ -258,7 +253,7 @@ export function ChatForm() {
         setRetrying(false)
       }
     }
-  }, [abortRef, busy, input, mountedRef, stream])
+  }, [abortRef, busy, input, mountedRef, setMessages, stream])
 
   const toggleMic = useCallback(() => {
     if (listening) {

--- a/apps/web/lib/chatStore.tsx
+++ b/apps/web/lib/chatStore.tsx
@@ -1,0 +1,133 @@
+"use client"
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react"
+
+export type ChatMessage = {
+  role: "user" | "assistant"
+  content: string
+  error?: string | null
+}
+
+export type ChatStateContextValue = {
+  messages: ChatMessage[]
+  setMessages: (
+    updater: ChatMessage[] | ((prev: ChatMessage[]) => ChatMessage[]),
+  ) => void
+  reset: () => void
+}
+
+// Bumped if the persisted shape changes incompatibly.
+const STORAGE_KEY = "ai-agent:chat-history:v1"
+// FIFO cap on individual messages — bounds sessionStorage growth against the
+// ~5 MB browser quota while still covering long working sessions.
+const MAX_MESSAGES = 50
+
+function capMessages(messages: ChatMessage[]): ChatMessage[] {
+  if (messages.length <= MAX_MESSAGES) return messages
+  return messages.slice(messages.length - MAX_MESSAGES)
+}
+
+function isChatMessage(value: unknown): value is ChatMessage {
+  if (typeof value !== "object" || value === null) return false
+  const m = value as Partial<ChatMessage>
+  return (
+    (m.role === "user" || m.role === "assistant") &&
+    typeof m.content === "string"
+  )
+}
+
+function loadPersisted(): ChatMessage[] {
+  if (typeof window === "undefined") return []
+  try {
+    const raw = window.sessionStorage.getItem(STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return []
+    return capMessages(parsed.filter(isChatMessage))
+  } catch {
+    return []
+  }
+}
+
+function persist(messages: ChatMessage[]) {
+  if (typeof window === "undefined") return
+  try {
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(messages))
+  } catch {
+    // quota / unavailable — state remains in memory for the tab
+  }
+}
+
+function clearPersisted() {
+  if (typeof window === "undefined") return
+  try {
+    window.sessionStorage.removeItem(STORAGE_KEY)
+  } catch {
+    // ignore
+  }
+}
+
+const ChatStateContext = createContext<ChatStateContextValue | null>(null)
+
+export function ChatStateProvider({ children }: { children: ReactNode }) {
+  // Render [] on first paint so SSR and the first client render agree
+  // (sessionStorage is unavailable on the server). The hydrate effect below
+  // promotes messages to whatever was persisted in this tab.
+  const [messages, setMessagesState] = useState<ChatMessage[]>([])
+  const [hydrated, setHydrated] = useState(false)
+
+  useEffect(() => {
+    setMessagesState(loadPersisted())
+    setHydrated(true)
+  }, [])
+
+  useEffect(() => {
+    if (!hydrated) return
+    if (messages.length === 0) {
+      clearPersisted()
+    } else {
+      persist(messages)
+    }
+  }, [messages, hydrated])
+
+  const setMessages = useCallback<ChatStateContextValue["setMessages"]>(
+    (updater) => {
+      setMessagesState((prev) => {
+        const next = typeof updater === "function" ? updater(prev) : updater
+        return capMessages(next)
+      })
+    },
+    [],
+  )
+
+  const reset = useCallback(() => {
+    setMessagesState([])
+    clearPersisted()
+  }, [])
+
+  const value = useMemo<ChatStateContextValue>(
+    () => ({ messages, setMessages, reset }),
+    [messages, setMessages, reset],
+  )
+
+  return (
+    <ChatStateContext.Provider value={value}>
+      {children}
+    </ChatStateContext.Provider>
+  )
+}
+
+export function useChatState(): ChatStateContextValue {
+  const ctx = useContext(ChatStateContext)
+  if (!ctx) {
+    throw new Error("useChatState must be used inside <ChatStateProvider>")
+  }
+  return ctx
+}

--- a/apps/web/lib/chatStore.tsx
+++ b/apps/web/lib/chatStore.tsx
@@ -39,7 +39,8 @@ function isChatMessage(value: unknown): value is ChatMessage {
   const m = value as Partial<ChatMessage>
   return (
     (m.role === "user" || m.role === "assistant") &&
-    typeof m.content === "string"
+    typeof m.content === "string" &&
+    (m.error === undefined || m.error === null || typeof m.error === "string")
   )
 }
 

--- a/apps/web/tests/chat-form.test.tsx
+++ b/apps/web/tests/chat-form.test.tsx
@@ -3,6 +3,15 @@ import userEvent from "@testing-library/user-event"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { ChatForm } from "@/components/screens/ChatForm"
+import { ChatStateProvider } from "@/lib/chatStore"
+
+function renderChatForm() {
+  return render(
+    <ChatStateProvider>
+      <ChatForm />
+    </ChatStateProvider>,
+  )
+}
 
 type SSEPart = { event?: string; data: string }
 
@@ -43,14 +52,14 @@ describe("ChatForm", () => {
   })
 
   it("renders the empty state and a disabled send button", () => {
-    render(<ChatForm />)
+    renderChatForm()
     expect(screen.getByTestId("chat-input")).toBeInTheDocument()
     expect(screen.getByTestId("send-button")).toBeDisabled()
   })
 
   it("enables send once the input is non-empty", async () => {
     const user = userEvent.setup()
-    render(<ChatForm />)
+    renderChatForm()
     await user.type(screen.getByTestId("chat-input"), "hi")
     expect(screen.getByTestId("send-button")).not.toBeDisabled()
   })
@@ -60,7 +69,7 @@ describe("ChatForm", () => {
       sseResponse([{ data: "hello" }, { data: "world" }]),
     )
     const user = userEvent.setup()
-    render(<ChatForm />)
+    renderChatForm()
     await user.type(screen.getByTestId("chat-input"), "what's new?")
     await user.click(screen.getByTestId("send-button"))
 
@@ -85,7 +94,7 @@ describe("ChatForm", () => {
   it("renders markdown in assistant output via react-markdown", async () => {
     fetchMock.mockResolvedValueOnce(sseResponse([{ data: "**bold** text" }]))
     const user = userEvent.setup()
-    render(<ChatForm />)
+    renderChatForm()
     await user.type(screen.getByTestId("chat-input"), "q")
     await user.click(screen.getByTestId("send-button"))
 
@@ -102,7 +111,7 @@ describe("ChatForm", () => {
       )
       .mockResolvedValueOnce(sseResponse([{ data: "after retry" }]))
     const user = userEvent.setup()
-    render(<ChatForm />)
+    renderChatForm()
     await user.type(screen.getByTestId("chat-input"), "q")
     await user.click(screen.getByTestId("send-button"))
 
@@ -121,7 +130,7 @@ describe("ChatForm", () => {
       sseResponse([{ event: "error", data: "boom" }]),
     )
     const user = userEvent.setup()
-    render(<ChatForm />)
+    renderChatForm()
     await user.type(screen.getByTestId("chat-input"), "q")
     await user.click(screen.getByTestId("send-button"))
 
@@ -132,7 +141,7 @@ describe("ChatForm", () => {
   })
 
   it("hides the mic button when SpeechRecognition is unavailable", () => {
-    render(<ChatForm />)
+    renderChatForm()
     expect(screen.queryByTestId("mic-button")).toBeNull()
     expect(screen.getByTestId("mic-unsupported")).toBeInTheDocument()
   })
@@ -150,14 +159,14 @@ describe("ChatForm", () => {
     }
     ;(window as unknown as { SpeechRecognition: unknown }).SpeechRecognition =
       FakeRecognition
-    render(<ChatForm />)
+    renderChatForm()
     expect(screen.getByTestId("mic-button")).toBeInTheDocument()
     expect(screen.queryByTestId("mic-unsupported")).toBeNull()
   })
 
   it("hydrates the input from sessionStorage on mount", async () => {
     window.sessionStorage.setItem(DRAFT_KEY, "draft in progress")
-    render(<ChatForm />)
+    renderChatForm()
     const input = await screen.findByTestId("chat-input")
     await waitFor(() => {
       expect(input).toHaveValue("draft in progress")
@@ -167,7 +176,7 @@ describe("ChatForm", () => {
   it("persists the draft on each change and clears it on successful send", async () => {
     fetchMock.mockResolvedValueOnce(sseResponse([{ data: "ok" }]))
     const user = userEvent.setup()
-    render(<ChatForm />)
+    renderChatForm()
     const input = screen.getByTestId("chat-input")
     await user.type(input, "ab")
     await waitFor(() => {
@@ -183,7 +192,7 @@ describe("ChatForm", () => {
   it("shows the session-expired card on 401", async () => {
     fetchMock.mockResolvedValueOnce(new Response("", { status: 401 }))
     const user = userEvent.setup()
-    render(<ChatForm />)
+    renderChatForm()
     await user.type(screen.getByTestId("chat-input"), "q")
     await user.click(screen.getByTestId("send-button"))
 

--- a/apps/web/tests/chat-store.test.tsx
+++ b/apps/web/tests/chat-store.test.tsx
@@ -106,8 +106,11 @@ describe("ChatStateProvider — sessionStorage persistence", () => {
       STORAGE_KEY,
       JSON.stringify([
         { role: "user", content: "kept" },
+        { role: "assistant", content: "kept too", error: null },
+        { role: "assistant", content: "kept three", error: "stream error" },
         { role: "bogus", content: "dropped" },
         { role: "assistant" }, // missing content
+        { role: "assistant", content: "bad error", error: 123 }, // non-string error
         "string entry",
         null,
       ]),
@@ -119,9 +122,11 @@ describe("ChatStateProvider — sessionStorage persistence", () => {
       </ChatStateProvider>,
     )
     await waitFor(() => {
-      expect(screen.getByTestId("count")).toHaveTextContent("1")
+      expect(screen.getByTestId("count")).toHaveTextContent("3")
     })
     expect(screen.getByTestId("msg-0")).toHaveTextContent("kept")
+    expect(screen.getByTestId("msg-1")).toHaveTextContent("kept too")
+    expect(screen.getByTestId("msg-2")).toHaveTextContent("kept three")
   })
 
   it("enforces a FIFO cap of 50 messages — the oldest drops when the 51st arrives", async () => {
@@ -146,7 +151,7 @@ describe("ChatStateProvider — sessionStorage persistence", () => {
     await waitFor(() => {
       expect(screen.getByTestId("count")).toHaveTextContent("50")
     })
-    // Oldest two seeded entries dropped — first surviving is seed-1.
+    // Oldest seeded entry (seed-0) dropped — first surviving is seed-1.
     expect(screen.getByTestId("msg-0")).toHaveTextContent("seed-1")
     // Persisted snapshot matches the in-memory cap.
     const persisted = JSON.parse(

--- a/apps/web/tests/chat-store.test.tsx
+++ b/apps/web/tests/chat-store.test.tsx
@@ -1,0 +1,223 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import {
+  ChatStateProvider,
+  type ChatMessage,
+  useChatState,
+} from "@/lib/chatStore"
+
+const STORAGE_KEY = "ai-agent:chat-history:v1"
+
+// Renders the messages array as one <div data-testid="msg-N"> per entry so
+// tests can assert on hydrated content without depending on ChatForm's chrome.
+function MessageProbe() {
+  const { messages, setMessages, reset } = useChatState()
+  return (
+    <div>
+      <span data-testid="count">{messages.length}</span>
+      {messages.map((m, i) => (
+        <div key={i} data-testid={`msg-${i}`} data-role={m.role}>
+          {m.content}
+        </div>
+      ))}
+      <button
+        data-testid="append-pair"
+        onClick={() =>
+          setMessages((prev) => [
+            ...prev,
+            { role: "user", content: `u${prev.length}` },
+            { role: "assistant", content: `a${prev.length}` },
+          ])
+        }
+      />
+      <button
+        data-testid="grow-last"
+        onClick={() =>
+          setMessages((prev) => {
+            const copy = [...prev]
+            const last = copy[copy.length - 1]
+            if (last && last.role === "assistant") {
+              copy[copy.length - 1] = { ...last, content: last.content + "x" }
+            }
+            return copy
+          })
+        }
+      />
+      <button data-testid="reset" onClick={reset} />
+    </div>
+  )
+}
+
+describe("ChatStateProvider — sessionStorage persistence", () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+  afterEach(() => {
+    sessionStorage.clear()
+  })
+
+  it("hydrates messages from sessionStorage on mount (AC: tab-switch restores conversation)", async () => {
+    const stored: ChatMessage[] = [
+      { role: "user", content: "what's new?" },
+      { role: "assistant", content: "today: …" },
+    ]
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(stored))
+
+    render(
+      <ChatStateProvider>
+        <MessageProbe />
+      </ChatStateProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("count")).toHaveTextContent("2")
+    })
+    expect(screen.getByTestId("msg-0")).toHaveTextContent("what's new?")
+    expect(screen.getByTestId("msg-1")).toHaveTextContent("today: …")
+  })
+
+  it("starts empty when nothing is stored", async () => {
+    render(
+      <ChatStateProvider>
+        <MessageProbe />
+      </ChatStateProvider>,
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId("count")).toHaveTextContent("0")
+    })
+  })
+
+  it("ignores malformed sessionStorage payloads instead of throwing", async () => {
+    sessionStorage.setItem(STORAGE_KEY, "{not-json")
+
+    render(
+      <ChatStateProvider>
+        <MessageProbe />
+      </ChatStateProvider>,
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId("count")).toHaveTextContent("0")
+    })
+  })
+
+  it("filters out entries that don't look like ChatMessage on hydration", async () => {
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([
+        { role: "user", content: "kept" },
+        { role: "bogus", content: "dropped" },
+        { role: "assistant" }, // missing content
+        "string entry",
+        null,
+      ]),
+    )
+
+    render(
+      <ChatStateProvider>
+        <MessageProbe />
+      </ChatStateProvider>,
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId("count")).toHaveTextContent("1")
+    })
+    expect(screen.getByTestId("msg-0")).toHaveTextContent("kept")
+  })
+
+  it("enforces a FIFO cap of 50 messages — the oldest drops when the 51st arrives", async () => {
+    // Seed 49 messages; one click of "append-pair" pushes the count to 51,
+    // which must be capped back to 50 with the oldest entry removed.
+    const seeded: ChatMessage[] = Array.from({ length: 49 }, (_, i) => ({
+      role: i % 2 === 0 ? "user" : "assistant",
+      content: `seed-${i}`,
+    }))
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(seeded))
+
+    render(
+      <ChatStateProvider>
+        <MessageProbe />
+      </ChatStateProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("count")).toHaveTextContent("49")
+    })
+    screen.getByTestId("append-pair").click()
+    await waitFor(() => {
+      expect(screen.getByTestId("count")).toHaveTextContent("50")
+    })
+    // Oldest two seeded entries dropped — first surviving is seed-1.
+    expect(screen.getByTestId("msg-0")).toHaveTextContent("seed-1")
+    // Persisted snapshot matches the in-memory cap.
+    const persisted = JSON.parse(
+      sessionStorage.getItem(STORAGE_KEY) ?? "[]",
+    ) as ChatMessage[]
+    expect(persisted).toHaveLength(50)
+    expect(persisted[0].content).toBe("seed-1")
+  })
+
+  it("round-trips a partial assistant message (mid-stream content) through storage", async () => {
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([
+        { role: "user", content: "q" },
+        { role: "assistant", content: "partial answer so fa" }, // mid-stream
+      ]),
+    )
+
+    const { unmount } = render(
+      <ChatStateProvider>
+        <MessageProbe />
+      </ChatStateProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("msg-1")).toHaveTextContent(
+        "partial answer so fa",
+      )
+    })
+
+    // Simulate another streaming chunk arriving while still mounted, then
+    // remount (tab-switch) and verify the appended content survives.
+    screen.getByTestId("grow-last").click()
+    await waitFor(() => {
+      expect(screen.getByTestId("msg-1")).toHaveTextContent(
+        "partial answer so fax",
+      )
+    })
+    unmount()
+
+    render(
+      <ChatStateProvider>
+        <MessageProbe />
+      </ChatStateProvider>,
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId("msg-1")).toHaveTextContent(
+        "partial answer so fax",
+      )
+    })
+  })
+
+  it("reset() clears messages and removes the sessionStorage entry", async () => {
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([{ role: "user", content: "hi" }]),
+    )
+
+    render(
+      <ChatStateProvider>
+        <MessageProbe />
+      </ChatStateProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("count")).toHaveTextContent("1")
+    })
+    screen.getByTestId("reset").click()
+    await waitFor(() => {
+      expect(screen.getByTestId("count")).toHaveTextContent("0")
+    })
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- Add `ChatStateProvider` (sessionStorage-backed, key `ai-agent:chat-history:v1`, FIFO cap of 50 messages, `reset()` exposed for a future Clear-chat UI).
- Wire it into `app/(main)/layout.tsx` alongside `JobStateProvider`.
- Lift `messages` out of `ChatForm.tsx` into `useChatState()` so tab navigation and reload restore the conversation, including partial mid-stream content.
- Add `chat-store.test.tsx` covering hydrate, malformed payload, schema filter, FIFO cap, mid-stream round-trip, and `reset()`.

Mirrors the pattern from #103 / `jobStore.tsx`.

Closes #105

## Test plan
- [x] `npm test -- --run` — 67/67 pass (includes 7 new `ChatStateProvider` cases + `ChatForm` tests wrapped in the provider).
- [x] `npm run lint` — clean.
- [ ] Manual: send a question in `/chat`, navigate to `/portfolio`, return to `/chat` — conversation preserved.
- [ ] Manual: reload `/chat` mid-conversation — history restored from sessionStorage.
- [ ] Manual: close the tab, reopen — chat starts empty (sessionStorage scope).
- [ ] Manual: send the 51st message — oldest entry drops (verify via DevTools → Application → Session Storage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat messages are now persisted during your session, allowing your conversation history to survive page refreshes and maintain continuity.

* **Updates**
  * Improved chat state management architecture for better performance and reliability.
  * Chat history is capped at 50 recent messages to optimize storage and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->