### PR TITLE
feat(web): Q&A chat → Notion via the existing /notion-import skill

### DIFF
--- a/apps/python/tests/test_api_chat.py
+++ b/apps/python/tests/test_api_chat.py
@@ -296,3 +296,255 @@ async def test_chat_requires_bearer(async_client, briefing_setup):
         json={"date": "2026-05-30", "question": "Q?"},
     )
     assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# POST /api/chat/notion-import — delegates to /notion-import skill via claude CLI
+# ---------------------------------------------------------------------------
+
+
+def _seed_notion_creds():
+    from src import credentials as cred_mod
+    cred_mod.set_credential("NOTION_API_KEY", "k-test")
+    cred_mod.set_credential("NOTION_DATABASE_ID", "db-test")
+
+
+def _stream_json_result(text: str) -> str:
+    """Build a minimal --output-format stream-json stdout containing a result
+    record with the given final text."""
+    import json as _json
+    return _json.dumps({"type": "result", "subtype": "success", "result": text}) + "\n"
+
+
+def _fake_run_factory(stdout: str = "", stderr: str = "", returncode: int = 0):
+    """Return a fake subprocess.run that records the call and returns a
+    CompletedProcess-shaped object. The first positional arg (cmd list) is
+    captured into `.calls` so tests can assert on flags / model selection."""
+    calls: list[dict] = []
+
+    class _Result:
+        def __init__(self):
+            self.stdout = stdout
+            self.stderr = stderr
+            self.returncode = returncode
+
+    def factory(cmd, **kwargs):
+        calls.append({"cmd": cmd, "kwargs": kwargs})
+        return _Result()
+
+    factory.calls = calls  # type: ignore[attr-defined]
+    return factory
+
+
+async def test_chat_notion_import_400_when_both_credentials_missing(
+    authed_client, isolated_keyring, clear_credential_env
+):
+    response = await authed_client.post(
+        "/api/chat/notion-import",
+        json={"date": "2026-05-30", "question": "Q?", "answer": "A!"},
+    )
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert "NOTION_API_KEY" in detail
+    assert "NOTION_DATABASE_ID" in detail
+
+
+async def test_chat_notion_import_400_when_api_key_missing(
+    authed_client, isolated_keyring, clear_credential_env
+):
+    from src import credentials as cred_mod
+    cred_mod.set_credential("NOTION_DATABASE_ID", "db-test")
+
+    response = await authed_client.post(
+        "/api/chat/notion-import",
+        json={"date": "2026-05-30", "question": "Q?", "answer": "A!"},
+    )
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert "NOTION_API_KEY" in detail
+    assert "NOTION_DATABASE_ID" not in detail
+
+
+async def test_chat_notion_import_success_invokes_skill_and_extracts_url(
+    authed_client, isolated_keyring, clear_credential_env, monkeypatch
+):
+    _seed_notion_creds()
+    page_url = "https://www.notion.so/created-page-abc123"
+    factory = _fake_run_factory(
+        stdout=_stream_json_result(
+            f"追記しました。\nNotion: {page_url}\n保存: output/chat-2026-05-30_2026-05-30.md"
+        ),
+        returncode=0,
+    )
+    monkeypatch.setattr("web.routers.chat.subprocess.run", factory)
+    monkeypatch.setattr("web.routers.chat.shutil.which", lambda _: "/fake/bin/claude")
+
+    response = await authed_client.post(
+        "/api/chat/notion-import",
+        json={
+            "date": "2026-05-30",
+            "question": "半導体セクターの新着リスクは？",
+            "answer": "TSMC の地政学リスクと NVDA 在庫…",
+            "model": "opus",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["url"] == page_url
+    assert "追記しました" in payload["summary"]
+
+    # The CLI invocation must carry the slash command, the model selection,
+    # bypass perms, stream-json output, and an --add-dir for skill discovery.
+    cmd = factory.calls[0]["cmd"]
+    prompt = cmd[cmd.index("-p") + 1]
+    assert "/notion-import chat-2026-05-30" in prompt
+    assert "半導体セクターの新着リスクは？" in prompt
+    assert "TSMC" in prompt
+    assert "bypassPermissions" in cmd
+    assert "stream-json" in cmd
+    assert cmd[cmd.index("--model") + 1] == "opus"
+    assert "--add-dir" in cmd
+
+
+async def test_chat_notion_import_defaults_to_sonnet_model(
+    authed_client, isolated_keyring, clear_credential_env, monkeypatch
+):
+    _seed_notion_creds()
+    factory = _fake_run_factory(
+        stdout=_stream_json_result("done https://www.notion.so/abc"),
+        returncode=0,
+    )
+    monkeypatch.setattr("web.routers.chat.subprocess.run", factory)
+    monkeypatch.setattr("web.routers.chat.shutil.which", lambda _: "/fake/bin/claude")
+
+    await authed_client.post(
+        "/api/chat/notion-import",
+        json={"date": "2026-05-30", "question": "Q?", "answer": "A!"},
+    )
+
+    cmd = factory.calls[0]["cmd"]
+    assert cmd[cmd.index("--model") + 1] == "sonnet"
+
+
+async def test_chat_notion_import_rejects_unknown_model(
+    authed_client, isolated_keyring, clear_credential_env, monkeypatch
+):
+    _seed_notion_creds()
+    monkeypatch.setattr("web.routers.chat.shutil.which", lambda _: "/fake/bin/claude")
+    response = await authed_client.post(
+        "/api/chat/notion-import",
+        json={"date": "2026-05-30", "question": "Q?", "answer": "A!", "model": "gpt-4"},
+    )
+    assert response.status_code == 422
+
+
+async def test_chat_notion_import_404_when_skill_reports_no_briefing_page(
+    authed_client, isolated_keyring, clear_credential_env, monkeypatch
+):
+    _seed_notion_creds()
+    # Skill ran cleanly (rc=0) but the result text contains no Notion URL —
+    # SKILL.md mandates this when the page isn't found.
+    factory = _fake_run_factory(
+        stdout=_stream_json_result(
+            "対象ページが見つかりませんでした: マーケットブリーフィング — 2026-05-30"
+        ),
+        returncode=0,
+    )
+    monkeypatch.setattr("web.routers.chat.subprocess.run", factory)
+    monkeypatch.setattr("web.routers.chat.shutil.which", lambda _: "/fake/bin/claude")
+
+    response = await authed_client.post(
+        "/api/chat/notion-import",
+        json={"date": "2026-05-30", "question": "Q?", "answer": "A!"},
+    )
+    assert response.status_code == 404
+    # Skill's own report is echoed verbatim so the operator sees why.
+    assert "2026-05-30" in response.json()["detail"]
+    assert "対象ページが見つかりません" in response.json()["detail"]
+
+
+async def test_chat_notion_import_502_when_cli_exits_nonzero(
+    authed_client, isolated_keyring, clear_credential_env, monkeypatch
+):
+    _seed_notion_creds()
+    factory = _fake_run_factory(
+        stdout="",
+        stderr="claude: authentication failed",
+        returncode=1,
+    )
+    monkeypatch.setattr("web.routers.chat.subprocess.run", factory)
+    monkeypatch.setattr("web.routers.chat.shutil.which", lambda _: "/fake/bin/claude")
+
+    response = await authed_client.post(
+        "/api/chat/notion-import",
+        json={"date": "2026-05-30", "question": "Q?", "answer": "A!"},
+    )
+    assert response.status_code == 502
+    assert "rc=1" in response.json()["detail"]
+
+
+async def test_chat_notion_import_502_when_claude_binary_missing(
+    authed_client, isolated_keyring, clear_credential_env, monkeypatch
+):
+    _seed_notion_creds()
+    monkeypatch.setattr("web.routers.chat.shutil.which", lambda _: None)
+
+    response = await authed_client.post(
+        "/api/chat/notion-import",
+        json={"date": "2026-05-30", "question": "Q?", "answer": "A!"},
+    )
+    assert response.status_code == 502
+    assert "claude CLI not found" in response.json()["detail"]
+
+
+async def test_chat_notion_import_502_on_subprocess_timeout(
+    authed_client, isolated_keyring, clear_credential_env, monkeypatch
+):
+    import subprocess as sp
+    _seed_notion_creds()
+
+    def raise_timeout(*a, **kw):
+        raise sp.TimeoutExpired(cmd=a[0] if a else [], timeout=120)
+
+    monkeypatch.setattr("web.routers.chat.subprocess.run", raise_timeout)
+    monkeypatch.setattr("web.routers.chat.shutil.which", lambda _: "/fake/bin/claude")
+
+    response = await authed_client.post(
+        "/api/chat/notion-import",
+        json={"date": "2026-05-30", "question": "Q?", "answer": "A!"},
+    )
+    assert response.status_code == 502
+    assert "did not finish" in response.json()["detail"]
+
+
+async def test_chat_notion_import_rejects_invalid_date(
+    authed_client, isolated_keyring, clear_credential_env, monkeypatch
+):
+    _seed_notion_creds()
+    monkeypatch.setattr("web.routers.chat.shutil.which", lambda _: "/fake/bin/claude")
+    response = await authed_client.post(
+        "/api/chat/notion-import",
+        json={"date": "../foo", "question": "Q?", "answer": "A!"},
+    )
+    assert response.status_code == 422
+
+
+async def test_chat_notion_import_rejects_empty_answer(
+    authed_client, isolated_keyring, clear_credential_env, monkeypatch
+):
+    _seed_notion_creds()
+    monkeypatch.setattr("web.routers.chat.shutil.which", lambda _: "/fake/bin/claude")
+    response = await authed_client.post(
+        "/api/chat/notion-import",
+        json={"date": "2026-05-30", "question": "Q?", "answer": ""},
+    )
+    assert response.status_code == 422
+
+
+async def test_chat_notion_import_requires_bearer(async_client):
+    response = await async_client.post(
+        "/api/chat/notion-import",
+        json={"date": "2026-05-30", "question": "Q?", "answer": "A!"},
+    )
+    assert response.status_code == 401

--- a/apps/python/tests/test_api_chat.py
+++ b/apps/python/tests/test_api_chat.py
@@ -405,6 +405,11 @@ async def test_chat_notion_import_success_invokes_skill_and_extracts_url(
     assert "stream-json" in cmd
     assert cmd[cmd.index("--model") + 1] == "opus"
     assert "--add-dir" in cmd
+    # Notion credentials must reach the subprocess env so a non-MCP fallback
+    # path (e.g. notion-client reading env directly) can still authenticate.
+    env = factory.calls[0]["kwargs"]["env"]
+    assert env.get("NOTION_API_KEY") == "k-test"
+    assert env.get("NOTION_DATABASE_ID") == "db-test"
 
 
 async def test_chat_notion_import_defaults_to_sonnet_model(

--- a/apps/python/web/routers/chat.py
+++ b/apps/python/web/routers/chat.py
@@ -18,20 +18,41 @@ via ``claude_runner.build_env`` — same toggle used by ``run_claude``.
 Stderr is drained in a background thread to avoid a pipe-buffer deadlock
 (if stderr ever exceeded the OS pipe buffer ~64KB without being read,
 claude would block writing and stdout streaming would stall).
+
+POST /api/chat/notion-import: delegates to the local ``/notion-import``
+skill via the ``claude`` CLI (subprocess + ``--output-format stream-json``),
+so the skill definition under ``.claude/skills/notion-import/SKILL.md``
+remains the single source of truth — no duplicate Python implementation.
 """
+import json
+import re
+import shutil
 import subprocess
 import threading
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
+from src import credentials as cred_mod
 from src import state as state_mod
 from src.chat_session import build_cmd
 from src.claude_runner import build_env
+from src.logger import get_logger
 from web.auth import require_bearer
+
+logger = get_logger(__name__)
+# apps/python/web/routers/chat.py → repo root is parents[3] (chat.py → routers → web → python → apps → repo).
+REPO_ROOT = Path(__file__).resolve().parents[4]
+NOTION_URL_RE = re.compile(r"https://www\.notion\.so/[A-Za-z0-9\-]+")
+NOTION_IMPORT_TIMEOUT_SEC = 120
+# Allow-list of model aliases the user can pick from the UI. Anything else
+# is rejected at the schema level so a malicious payload can't make us spawn
+# a claude subprocess pinned to an unintended model.
+ChatNotionImportModel = Literal["sonnet", "opus", "haiku"]
 
 PYTHON_APP = Path(__file__).resolve().parents[2]  # apps/python/
 BRIEFING_DIR = PYTHON_APP / "output" / "briefing"
@@ -101,6 +122,156 @@ def _stream(cmd: list[str], session_file: Path, env: dict[str, str]) -> Iterator
             )
         else:
             yield _sse_event(stderr.strip(), event="error")
+
+
+class ChatNotionImportBody(BaseModel):
+    # Same path-traversal guard as ChatBody; the date scopes the briefing page.
+    date: str = Field(pattern=r"^\d{4}-\d{2}-\d{2}$")
+    question: str = Field(min_length=1)
+    answer: str = Field(min_length=1)
+    model: ChatNotionImportModel = "sonnet"
+
+
+class ChatNotionImportResponse(BaseModel):
+    url: str
+    summary: str = ""
+
+
+def _build_skill_prompt(body: ChatNotionImportBody) -> str:
+    """Compose the prompt we pass to ``claude -p`` so it runs the skill.
+
+    The skill reads the *preceding assistant answer* as its source of truth,
+    so we surface the Q&A inline in the prompt and explicitly call out the
+    slash command + the briefing-page hint the skill expects.
+    """
+    slug = f"chat-{body.date}"
+    return (
+        f"以下の Q&A を `/notion-import {slug}` スキルで Notion の "
+        f"「マーケットブリーフィング — {body.date}」ページ末尾に追記してください。\n"
+        "対象ページが見つからない場合は SKILL の手順どおり処理を停止し、その旨を簡潔に報告してください。\n\n"
+        "## Question\n"
+        f"{body.question}\n\n"
+        "## Answer\n"
+        f"{body.answer}\n"
+    )
+
+
+def _extract_final_text(stream_json_stdout: str) -> str:
+    """Pick the final assistant text out of a ``--output-format stream-json`` blob.
+
+    The CLI emits one JSON object per line. The terminal record is
+    ``{"type":"result", "subtype":"success"|..., "result":"<text>"}``;
+    its ``result`` field is exactly what an interactive ``claude -p`` would
+    have printed, which is also where the skill surfaces the final Notion URL.
+    """
+    final = ""
+    for line in stream_json_stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if obj.get("type") == "result":
+            final = obj.get("result", "") or ""
+    return final
+
+
+@router.post("/chat/notion-import", response_model=ChatNotionImportResponse)
+def post_chat_notion_import(body: ChatNotionImportBody) -> ChatNotionImportResponse:
+    """Delegate the save to the local `/notion-import` skill via the CLI.
+
+    Status map:
+      400 — NOTION_API_KEY / NOTION_DATABASE_ID not configured
+      404 — skill ran but reported no briefing page for the date
+      502 — claude CLI failed (non-zero exit, missing binary, timeout, or no URL surfaced)
+
+    The skill itself owns the Notion page lookup + append logic. This
+    endpoint only orchestrates the subprocess and surfaces whatever the
+    skill reports back.
+    """
+    # AC: short-circuit with a descriptive message so the UI can tell the
+    # operator exactly which credential to set, rather than letting the
+    # subprocess fail opaquely deep inside the MCP call.
+    api_key = cred_mod.get_credential("NOTION_API_KEY")
+    database_id = cred_mod.get_credential("NOTION_DATABASE_ID")
+    missing = [
+        name
+        for name, value in (
+            ("NOTION_API_KEY", api_key),
+            ("NOTION_DATABASE_ID", database_id),
+        )
+        if not value
+    ]
+    if missing:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Notion credentials not configured: {', '.join(missing)}",
+        )
+
+    claude_path = shutil.which("claude")
+    if claude_path is None:
+        raise HTTPException(
+            status_code=502,
+            detail="claude CLI not found on PATH — install Claude Code to enable Notion save.",
+        )
+
+    cmd = [
+        claude_path,
+        "-p",
+        _build_skill_prompt(body),
+        "--permission-mode", "bypassPermissions",
+        "--output-format", "stream-json",
+        "--verbose",
+        "--add-dir", str(REPO_ROOT),
+        "--model", body.model,
+    ]
+    env = build_env(auth_mode=state_mod.read_state().auth_mode)
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=NOTION_IMPORT_TIMEOUT_SEC,
+            stdin=subprocess.DEVNULL,
+            env=env,
+            cwd=str(REPO_ROOT),
+        )
+    except subprocess.TimeoutExpired:
+        logger.error("notion-import skill timed out after %ds", NOTION_IMPORT_TIMEOUT_SEC)
+        raise HTTPException(
+            status_code=502,
+            detail=f"The /notion-import skill did not finish within {NOTION_IMPORT_TIMEOUT_SEC}s.",
+        ) from None
+
+    if result.returncode != 0:
+        stderr = (result.stderr or "")[:500]
+        logger.error("claude CLI exited rc=%d during notion-import: %s", result.returncode, stderr)
+        raise HTTPException(
+            status_code=502,
+            detail=f"claude CLI failed (rc={result.returncode}). Check the server logs.",
+        )
+
+    final_text = _extract_final_text(result.stdout)
+    url_match = NOTION_URL_RE.search(final_text)
+    if not url_match:
+        # The skill ran but didn't surface a Notion URL — most commonly because
+        # the target briefing page doesn't exist. SKILL.md explicitly tells the
+        # model to "stop and report" in that case, so we map this to 404 and
+        # echo the model's report so the operator sees the actual reason.
+        snippet = final_text.strip().splitlines()
+        report = " ".join(snippet)[:300] if snippet else "(no output)"
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"No Notion briefing page found for {body.date} "
+                f"(skill report: {report})"
+            ),
+        )
+
+    return ChatNotionImportResponse(url=url_match.group(0), summary=final_text.strip()[:500])
 
 
 @router.post("/chat")

--- a/apps/python/web/routers/chat.py
+++ b/apps/python/web/routers/chat.py
@@ -228,6 +228,13 @@ def post_chat_notion_import(body: ChatNotionImportBody) -> ChatNotionImportRespo
         "--model", body.model,
     ]
     env = build_env(auth_mode=state_mod.read_state().auth_mode)
+    # The /notion-import skill currently authenticates via the Notion MCP server
+    # (configured in ~/.claude.json), but Python fallbacks like notion-client
+    # read these env vars directly. Forwarding them keeps the skill working
+    # even if a future revision switches off MCP, and matches what the
+    # interactive `claude` CLI sees in the operator's shell.
+    env["NOTION_API_KEY"] = api_key
+    env["NOTION_DATABASE_ID"] = database_id
 
     try:
         result = subprocess.run(

--- a/apps/web/components/screens/ChatForm.tsx
+++ b/apps/web/components/screens/ChatForm.tsx
@@ -21,8 +21,6 @@ type NotionSaveState = {
   error?: string
 }
 
-type NotionModel = "sonnet" | "opus" | "haiku"
-
 // Bumped if the persisted shape changes incompatibly.
 const DRAFT_STORAGE_KEY = "ai-agent:chat-draft:v1"
 
@@ -95,14 +93,10 @@ type RecognitionCtor = new () => Recognition
 function NotionSaveRow({
   state,
   enabled,
-  model,
-  onModelChange,
   onSave,
 }: {
   state: NotionSaveState | undefined
   enabled: boolean
-  model: NotionModel
-  onModelChange: (m: NotionModel) => void
   onSave: () => void
 }) {
   const status: NotionSaveStatus = state?.status ?? "idle"
@@ -127,18 +121,6 @@ function NotionSaveRow({
           ? "✓ Notion に追記済"
           : "Notion ブリーフィングに追記"}
       </Button>
-      <select
-        value={model}
-        onChange={(e) => onModelChange(e.target.value as NotionModel)}
-        disabled={status === "saving"}
-        className="h-8 rounded-md border bg-background px-2 text-xs"
-        data-testid="notion-model-select"
-        title="このリクエストで claude CLI に渡すモデル"
-      >
-        <option value="sonnet">sonnet</option>
-        <option value="opus">opus</option>
-        <option value="haiku">haiku</option>
-      </select>
       {status === "saved" && state?.url && (
         <a
           href={state.url}
@@ -191,12 +173,6 @@ export function ChatForm() {
   // page itself is the durable artifact.
   const [notionState, setNotionState] = useState<
     Record<number, NotionSaveState>
-  >({})
-  // Per-message model selection. Keeping it per-row (instead of one shared
-  // state) means changing the dropdown on one row doesn't rewrite the others,
-  // and a saved row keeps showing the model that was actually used.
-  const [notionModelByMessage, setNotionModelByMessage] = useState<
-    Record<number, NotionModel>
   >({})
 
   // Suppress setState and cancel in-flight work after unmount.
@@ -386,7 +362,6 @@ export function ChatForm() {
       if (!question) return
 
       setNotionState((prev) => ({ ...prev, [idx]: { status: "saving" } }))
-      const model = notionModelByMessage[idx] ?? "sonnet"
       try {
         const res = await fetch("/api/chat/notion-import", {
           method: "POST",
@@ -396,7 +371,6 @@ export function ChatForm() {
             date: today(),
             question,
             answer: assistant.content,
-            model,
           }),
         })
         if (!res.ok) {
@@ -433,7 +407,7 @@ export function ChatForm() {
         }))
       }
     },
-    [messages, mountedRef, notionModelByMessage],
+    [messages, mountedRef],
   )
 
   const toggleMic = useCallback(() => {
@@ -528,13 +502,6 @@ export function ChatForm() {
                     // partial answer.
                     enabled={
                       notionReady && !(busy && i === messages.length - 1)
-                    }
-                    model={notionModelByMessage[i] ?? "sonnet"}
-                    onModelChange={(model) =>
-                      setNotionModelByMessage((prev) => ({
-                        ...prev,
-                        [i]: model,
-                      }))
                     }
                     onSave={() => void saveToNotion(i)}
                   />

--- a/apps/web/components/screens/ChatForm.tsx
+++ b/apps/web/components/screens/ChatForm.tsx
@@ -192,7 +192,12 @@ export function ChatForm() {
   const [notionState, setNotionState] = useState<
     Record<number, NotionSaveState>
   >({})
-  const [notionModel, setNotionModel] = useState<NotionModel>("sonnet")
+  // Per-message model selection. Keeping it per-row (instead of one shared
+  // state) means changing the dropdown on one row doesn't rewrite the others,
+  // and a saved row keeps showing the model that was actually used.
+  const [notionModelByMessage, setNotionModelByMessage] = useState<
+    Record<number, NotionModel>
+  >({})
 
   // Suppress setState and cancel in-flight work after unmount.
   const { mountedRef, abortRef } = useAbortableMount()
@@ -381,6 +386,7 @@ export function ChatForm() {
       if (!question) return
 
       setNotionState((prev) => ({ ...prev, [idx]: { status: "saving" } }))
+      const model = notionModelByMessage[idx] ?? "sonnet"
       try {
         const res = await fetch("/api/chat/notion-import", {
           method: "POST",
@@ -390,7 +396,7 @@ export function ChatForm() {
             date: today(),
             question,
             answer: assistant.content,
-            model: notionModel,
+            model,
           }),
         })
         if (!res.ok) {
@@ -427,7 +433,7 @@ export function ChatForm() {
         }))
       }
     },
-    [messages, mountedRef, notionModel],
+    [messages, mountedRef, notionModelByMessage],
   )
 
   const toggleMic = useCallback(() => {
@@ -517,9 +523,19 @@ export function ChatForm() {
                 {m.role === "assistant" && m.content && (
                   <NotionSaveRow
                     state={notionState[i]}
-                    enabled={notionReady}
-                    model={notionModel}
-                    onModelChange={setNotionModel}
+                    // Disable while this assistant message is still streaming
+                    // (last message + busy) so the user can't persist a
+                    // partial answer.
+                    enabled={
+                      notionReady && !(busy && i === messages.length - 1)
+                    }
+                    model={notionModelByMessage[i] ?? "sonnet"}
+                    onModelChange={(model) =>
+                      setNotionModelByMessage((prev) => ({
+                        ...prev,
+                        [i]: model,
+                      }))
+                    }
                     onSave={() => void saveToNotion(i)}
                   />
                 )}

--- a/apps/web/components/screens/ChatForm.tsx
+++ b/apps/web/components/screens/ChatForm.tsx
@@ -13,6 +13,16 @@ import { cn } from "@/lib/utils"
 
 type SSEEvent = { type: string; data: string }
 
+type NotionSaveStatus = "idle" | "saving" | "saved" | "error"
+
+type NotionSaveState = {
+  status: NotionSaveStatus
+  url?: string
+  error?: string
+}
+
+type NotionModel = "sonnet" | "opus" | "haiku"
+
 // Bumped if the persisted shape changes incompatibly.
 const DRAFT_STORAGE_KEY = "ai-agent:chat-draft:v1"
 
@@ -82,6 +92,76 @@ type Recognition = {
 }
 type RecognitionCtor = new () => Recognition
 
+function NotionSaveRow({
+  state,
+  enabled,
+  model,
+  onModelChange,
+  onSave,
+}: {
+  state: NotionSaveState | undefined
+  enabled: boolean
+  model: NotionModel
+  onModelChange: (m: NotionModel) => void
+  onSave: () => void
+}) {
+  const status: NotionSaveStatus = state?.status ?? "idle"
+  const disabled = !enabled || status === "saving" || status === "saved"
+  const title = enabled
+    ? undefined
+    : "Notion 認証情報が未設定です（Credentials タブで設定してください）"
+  return (
+    <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={onSave}
+        disabled={disabled}
+        title={title}
+        data-testid="notion-save-button"
+      >
+        {status === "saving"
+          ? "追記中…"
+          : status === "saved"
+          ? "✓ Notion に追記済"
+          : "Notion ブリーフィングに追記"}
+      </Button>
+      <select
+        value={model}
+        onChange={(e) => onModelChange(e.target.value as NotionModel)}
+        disabled={status === "saving"}
+        className="h-8 rounded-md border bg-background px-2 text-xs"
+        data-testid="notion-model-select"
+        title="このリクエストで claude CLI に渡すモデル"
+      >
+        <option value="sonnet">sonnet</option>
+        <option value="opus">opus</option>
+        <option value="haiku">haiku</option>
+      </select>
+      {status === "saved" && state?.url && (
+        <a
+          href={state.url}
+          target="_blank"
+          rel="noreferrer"
+          className="text-primary underline"
+          data-testid="notion-save-link"
+        >
+          ページを開く
+        </a>
+      )}
+      {status === "error" && state?.error && (
+        <span
+          className="text-destructive"
+          data-testid="notion-save-error"
+        >
+          {state.error}
+        </span>
+      )}
+    </div>
+  )
+}
+
 function getRecognitionCtor(): RecognitionCtor | null {
   if (typeof window === "undefined") return null
   const w = window as unknown as {
@@ -103,6 +183,16 @@ export function ChatForm() {
   const [retrying, setRetrying] = useState(false)
   const [listening, setListening] = useState(false)
   const [supportsMic, setSupportsMic] = useState(false)
+  // null until /api/credentials answers; the Notion button stays disabled
+  // until we know whether both NOTION_* keys exist (no premature enable).
+  const [creds, setCreds] = useState<Record<string, boolean> | null>(null)
+  // Per-message Notion save state. Keyed by message index — transient by
+  // design (not part of the persisted chat history) because the Notion
+  // page itself is the durable artifact.
+  const [notionState, setNotionState] = useState<
+    Record<number, NotionSaveState>
+  >({})
+  const [notionModel, setNotionModel] = useState<NotionModel>("sonnet")
 
   // Suppress setState and cancel in-flight work after unmount.
   const { mountedRef, abortRef } = useAbortableMount()
@@ -116,6 +206,27 @@ export function ChatForm() {
       recRef.current?.stop()
     }
   }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    fetch("/api/credentials", { cache: "no-store" })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: Record<string, boolean> | null) => {
+        if (cancelled) return
+        setCreds(data ?? {})
+      })
+      .catch(() => {
+        // Network failure — leave creds null so the button stays disabled
+        // rather than enabling it on incomplete information.
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const notionReady = Boolean(
+    creds && creds.NOTION_API_KEY && creds.NOTION_DATABASE_ID,
+  )
 
   useEffect(() => {
     if (!hydrated) return
@@ -255,6 +366,70 @@ export function ChatForm() {
     }
   }, [abortRef, busy, input, mountedRef, setMessages, stream])
 
+  const saveToNotion = useCallback(
+    async (idx: number) => {
+      const assistant = messages[idx]
+      if (!assistant || assistant.role !== "assistant" || !assistant.content) return
+      // Walk back to find the user question this answer is responding to.
+      let question = ""
+      for (let j = idx - 1; j >= 0; j--) {
+        if (messages[j].role === "user") {
+          question = messages[j].content
+          break
+        }
+      }
+      if (!question) return
+
+      setNotionState((prev) => ({ ...prev, [idx]: { status: "saving" } }))
+      try {
+        const res = await fetch("/api/chat/notion-import", {
+          method: "POST",
+          cache: "no-store",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            date: today(),
+            question,
+            answer: assistant.content,
+            model: notionModel,
+          }),
+        })
+        if (!res.ok) {
+          // AC: surface the backend's `detail` verbatim so the operator
+          // sees the skill's own error message (e.g. "page not found").
+          let detail = `HTTP ${res.status}`
+          try {
+            const body = (await res.json()) as { detail?: string }
+            if (body.detail) detail = body.detail
+          } catch {
+            // Body wasn't JSON — keep the HTTP fallback.
+          }
+          if (!mountedRef.current) return
+          setNotionState((prev) => ({
+            ...prev,
+            [idx]: { status: "error", error: detail },
+          }))
+          return
+        }
+        const body = (await res.json()) as { url: string }
+        if (!mountedRef.current) return
+        setNotionState((prev) => ({
+          ...prev,
+          [idx]: { status: "saved", url: body.url },
+        }))
+      } catch (e) {
+        if (!mountedRef.current) return
+        setNotionState((prev) => ({
+          ...prev,
+          [idx]: {
+            status: "error",
+            error: e instanceof Error ? e.message : "Network error",
+          },
+        }))
+      }
+    },
+    [messages, mountedRef, notionModel],
+  )
+
   const toggleMic = useCallback(() => {
     if (listening) {
       recRef.current?.stop()
@@ -338,6 +513,15 @@ export function ChatForm() {
                   >
                     {m.error}
                   </p>
+                )}
+                {m.role === "assistant" && m.content && (
+                  <NotionSaveRow
+                    state={notionState[i]}
+                    enabled={notionReady}
+                    model={notionModel}
+                    onModelChange={setNotionModel}
+                    onSave={() => void saveToNotion(i)}
+                  />
                 )}
               </div>
             ))

--- a/apps/web/components/screens/ChatForm.tsx
+++ b/apps/web/components/screens/ChatForm.tsx
@@ -9,7 +9,7 @@ import { Card, CardContent } from "@/components/ui/card"
 import { LoadingDots } from "@/components/ui/loading-dots"
 import { useChatState } from "@/lib/chatStore"
 import { useAbortableMount } from "@/lib/hooks/useAbortableMount"
-import { cn } from "@/lib/utils"
+import { cn, formatLocalDate } from "@/lib/utils"
 
 type SSEEvent = { type: string; data: string }
 
@@ -52,7 +52,7 @@ function clearDraft() {
 }
 
 function today(): string {
-  return new Date().toISOString().slice(0, 10)
+  return formatLocalDate()
 }
 
 // Parse buffered SSE text. Events are terminated by a blank line ("\n\n");

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -4,3 +4,13 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+// YYYY-MM-DD in the browser's local timezone. `toISOString()` would return
+// UTC, which silently shifts the date in non-UTC zones (e.g. 07:47 JST is
+// still the previous UTC day) and lands appends on yesterday's briefing.
+export function formatLocalDate(d: Date = new Date()): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, "0")
+  const day = String(d.getDate()).padStart(2, "0")
+  return `${y}-${m}-${day}`
+}

--- a/apps/web/tests/chat-form.test.tsx
+++ b/apps/web/tests/chat-form.test.tsx
@@ -349,6 +349,70 @@ describe("ChatForm", () => {
     expect(sent.model).toBe("sonnet")
   })
 
+  it("keeps Notion save disabled while the assistant message is still streaming", async () => {
+    on("/api/credentials", () =>
+      mockCreds({ NOTION_API_KEY: true, NOTION_DATABASE_ID: true }),
+    )
+
+    // Hand-rolled SSE stream we can hold open: enqueue a partial chunk, let
+    // the UI render, then assert the button is disabled before closing.
+    const encoder = new TextEncoder()
+    let controllerRef: ReadableStreamDefaultController<Uint8Array> | null = null
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controllerRef = controller
+        controller.enqueue(encoder.encode("data: partial\n\n"))
+      },
+    })
+    on("/api/chat", () => new Response(stream, { status: 200 }))
+
+    const user = userEvent.setup()
+    renderChatForm()
+    await user.type(screen.getByTestId("chat-input"), "q")
+    await user.click(screen.getByTestId("send-button"))
+
+    // First chunk arrived — content rendered, button visible but disabled.
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-msg-assistant")).toHaveTextContent(
+        "partial",
+      )
+    })
+    const button = screen.getByTestId("notion-save-button")
+    expect(button).toBeDisabled()
+
+    // Close the stream → busy flips false → button re-enables.
+    controllerRef!.close()
+    await waitFor(() => {
+      expect(screen.getByTestId("notion-save-button")).not.toBeDisabled()
+    })
+  })
+
+  it("keeps the Notion model selection independent per message", async () => {
+    on("/api/credentials", () =>
+      mockCreds({ NOTION_API_KEY: true, NOTION_DATABASE_ID: true }),
+    )
+    const user = userEvent.setup()
+    renderChatForm()
+
+    // Two complete turns → two assistant messages → two NotionSaveRow rows.
+    await sendOneTurn(user)
+    on("/api/chat", () => sseResponse([{ data: "another answer" }]))
+    await user.type(screen.getByTestId("chat-input"), "second q")
+    await user.click(screen.getByTestId("send-button"))
+    await waitFor(() => {
+      expect(screen.getAllByTestId("chat-msg-assistant")).toHaveLength(2)
+    })
+
+    const selects = screen.getAllByTestId("notion-model-select")
+    expect(selects).toHaveLength(2)
+
+    // Change only the first row's model.
+    await user.selectOptions(selects[0], "opus")
+    expect((selects[0] as HTMLSelectElement).value).toBe("opus")
+    // Second row stays on its own default.
+    expect((selects[1] as HTMLSelectElement).value).toBe("sonnet")
+  })
+
   it("surfaces the backend detail verbatim on 4xx (skill failure)", async () => {
     on("/api/credentials", () =>
       mockCreds({ NOTION_API_KEY: true, NOTION_DATABASE_ID: true }),

--- a/apps/web/tests/chat-form.test.tsx
+++ b/apps/web/tests/chat-form.test.tsx
@@ -37,8 +37,39 @@ describe("ChatForm", () => {
   const fetchMock = vi.fn()
   const DRAFT_KEY = "ai-agent:chat-draft:v1"
 
+  // Per-URL response queue. URL-keyed (rather than vitest's global
+  // once-queue) keeps the mount-time /api/credentials fetch from
+  // accidentally consuming a chat-POST response.
+  type Handler = (init?: RequestInit) => Promise<Response> | Response
+  let queues: Record<string, Handler[]>
+
+  function on(url: string, handler: Handler) {
+    if (!queues[url]) queues[url] = []
+    queues[url].push(handler)
+  }
+
+  function mockCreds(creds: Record<string, boolean> = {}) {
+    return new Response(JSON.stringify(creds), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })
+  }
+
   beforeEach(() => {
+    queues = {}
     fetchMock.mockReset()
+    fetchMock.mockImplementation(async (url: string | URL, init?: RequestInit) => {
+      const u = typeof url === "string" ? url : url.toString()
+      const queue = queues[u]
+      if (queue && queue.length > 0) {
+        const next = queue.shift()!
+        return await next(init)
+      }
+      // Default credentials response so existing tests don't have to queue
+      // one explicitly. Tests can override by calling on("/api/credentials", ...).
+      if (u === "/api/credentials") return mockCreds()
+      throw new Error(`Unmocked fetch in ChatForm test: ${u}`)
+    })
     vi.stubGlobal("fetch", fetchMock)
     window.sessionStorage.clear()
     // Default: no SpeechRecognition (mimics Firefox / unsupported browsers).
@@ -65,9 +96,7 @@ describe("ChatForm", () => {
   })
 
   it("POSTs today's date + question and streams assistant output", async () => {
-    fetchMock.mockResolvedValueOnce(
-      sseResponse([{ data: "hello" }, { data: "world" }]),
-    )
+    on("/api/chat", () => sseResponse([{ data: "hello" }, { data: "world" }]))
     const user = userEvent.setup()
     renderChatForm()
     await user.type(screen.getByTestId("chat-input"), "what's new?")
@@ -80,10 +109,12 @@ describe("ChatForm", () => {
     })
     expect(screen.getByTestId("chat-msg-user")).toHaveTextContent("what's new?")
 
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
-    expect(url).toBe("/api/chat")
-    expect(init.method).toBe("POST")
-    const body = JSON.parse(init.body as string) as {
+    const chatCall = fetchMock.mock.calls.find(
+      ([u]) => u === "/api/chat",
+    ) as [string, RequestInit] | undefined
+    expect(chatCall).toBeDefined()
+    expect(chatCall![1].method).toBe("POST")
+    const body = JSON.parse(chatCall![1].body as string) as {
       date: string
       question: string
     }
@@ -92,7 +123,7 @@ describe("ChatForm", () => {
   })
 
   it("renders markdown in assistant output via react-markdown", async () => {
-    fetchMock.mockResolvedValueOnce(sseResponse([{ data: "**bold** text" }]))
+    on("/api/chat", () => sseResponse([{ data: "**bold** text" }]))
     const user = userEvent.setup()
     renderChatForm()
     await user.type(screen.getByTestId("chat-input"), "q")
@@ -105,11 +136,10 @@ describe("ChatForm", () => {
   })
 
   it("retries exactly once on stale_session with the same payload", async () => {
-    fetchMock
-      .mockResolvedValueOnce(
-        sseResponse([{ event: "stale_session", data: "expired" }]),
-      )
-      .mockResolvedValueOnce(sseResponse([{ data: "after retry" }]))
+    on("/api/chat", () =>
+      sseResponse([{ event: "stale_session", data: "expired" }]),
+    )
+    on("/api/chat", () => sseResponse([{ data: "after retry" }]))
     const user = userEvent.setup()
     renderChatForm()
     await user.type(screen.getByTestId("chat-input"), "q")
@@ -120,15 +150,15 @@ describe("ChatForm", () => {
         "after retry",
       )
     })
-    expect(fetchMock).toHaveBeenCalledTimes(2)
-    const [first, second] = fetchMock.mock.calls as Array<[string, RequestInit]>
-    expect(first[1].body).toBe(second[1].body)
+    const chatCalls = fetchMock.mock.calls.filter(
+      ([u]) => u === "/api/chat",
+    ) as Array<[string, RequestInit]>
+    expect(chatCalls).toHaveLength(2)
+    expect(chatCalls[0][1].body).toBe(chatCalls[1][1].body)
   })
 
   it("shows event:error inline and does not retry", async () => {
-    fetchMock.mockResolvedValueOnce(
-      sseResponse([{ event: "error", data: "boom" }]),
-    )
+    on("/api/chat", () => sseResponse([{ event: "error", data: "boom" }]))
     const user = userEvent.setup()
     renderChatForm()
     await user.type(screen.getByTestId("chat-input"), "q")
@@ -137,7 +167,8 @@ describe("ChatForm", () => {
     await waitFor(() => {
       expect(screen.getByTestId("chat-error")).toHaveTextContent("boom")
     })
-    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const chatCalls = fetchMock.mock.calls.filter(([u]) => u === "/api/chat")
+    expect(chatCalls).toHaveLength(1)
   })
 
   it("hides the mic button when SpeechRecognition is unavailable", () => {
@@ -174,7 +205,7 @@ describe("ChatForm", () => {
   })
 
   it("persists the draft on each change and clears it on successful send", async () => {
-    fetchMock.mockResolvedValueOnce(sseResponse([{ data: "ok" }]))
+    on("/api/chat", () => sseResponse([{ data: "ok" }]))
     const user = userEvent.setup()
     renderChatForm()
     const input = screen.getByTestId("chat-input")
@@ -190,7 +221,7 @@ describe("ChatForm", () => {
   })
 
   it("shows the session-expired card on 401", async () => {
-    fetchMock.mockResolvedValueOnce(new Response("", { status: 401 }))
+    on("/api/chat", () => new Response("", { status: 401 }))
     const user = userEvent.setup()
     renderChatForm()
     await user.type(screen.getByTestId("chat-input"), "q")
@@ -200,5 +231,151 @@ describe("ChatForm", () => {
       expect(screen.getByTestId("session-expired")).toBeInTheDocument()
     })
     expect(screen.queryByTestId("chat-input")).toBeNull()
+  })
+
+  // ----- Notion save (Issue #87) ----------------------------------------
+
+  async function sendOneTurn(user: ReturnType<typeof userEvent.setup>) {
+    on("/api/chat", () => sseResponse([{ data: "an answer" }]))
+    await user.type(screen.getByTestId("chat-input"), "a question")
+    await user.click(screen.getByTestId("send-button"))
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-msg-assistant")).toHaveTextContent(
+        "an answer",
+      )
+    })
+  }
+
+  it("disables the Notion button when credentials are absent", async () => {
+    const user = userEvent.setup()
+    renderChatForm()
+    await sendOneTurn(user)
+    const button = await screen.findByTestId("notion-save-button")
+    expect(button).toBeDisabled()
+    expect(button).toHaveAttribute(
+      "title",
+      expect.stringContaining("Notion 認証情報が未設定"),
+    )
+  })
+
+  it("disables the Notion button when only NOTION_API_KEY is set", async () => {
+    on("/api/credentials", () =>
+      mockCreds({ NOTION_API_KEY: true, NOTION_DATABASE_ID: false }),
+    )
+    const user = userEvent.setup()
+    renderChatForm()
+    await sendOneTurn(user)
+    const button = await screen.findByTestId("notion-save-button")
+    expect(button).toBeDisabled()
+  })
+
+  it("enables the Notion button when both NOTION_* keys are set", async () => {
+    on("/api/credentials", () =>
+      mockCreds({ NOTION_API_KEY: true, NOTION_DATABASE_ID: true }),
+    )
+    const user = userEvent.setup()
+    renderChatForm()
+    await sendOneTurn(user)
+    await waitFor(() => {
+      expect(screen.getByTestId("notion-save-button")).not.toBeDisabled()
+    })
+  })
+
+  it("POSTs the picked model with the Q&A and surfaces the returned URL", async () => {
+    on("/api/credentials", () =>
+      mockCreds({ NOTION_API_KEY: true, NOTION_DATABASE_ID: true }),
+    )
+    let importBody: string | null = null
+    on("/api/chat/notion-import", (init) => {
+      importBody = (init?.body as string) ?? null
+      return new Response(
+        JSON.stringify({ url: "https://www.notion.so/abc", summary: "ok" }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      )
+    })
+    const user = userEvent.setup()
+    renderChatForm()
+    await sendOneTurn(user)
+    await waitFor(() => {
+      expect(screen.getByTestId("notion-save-button")).not.toBeDisabled()
+    })
+    // Pick opus before saving.
+    await user.selectOptions(screen.getByTestId("notion-model-select"), "opus")
+    await user.click(screen.getByTestId("notion-save-button"))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("notion-save-link")).toHaveAttribute(
+        "href",
+        "https://www.notion.so/abc",
+      )
+    })
+    expect(screen.getByTestId("notion-save-button")).toBeDisabled()
+    expect(importBody).not.toBeNull()
+    const sent = JSON.parse(importBody!) as {
+      date: string
+      question: string
+      answer: string
+      model: string
+    }
+    expect(sent.question).toBe("a question")
+    expect(sent.answer).toBe("an answer")
+    expect(sent.model).toBe("opus")
+    expect(sent.date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+
+  it("defaults to model=sonnet when the user doesn't change it", async () => {
+    on("/api/credentials", () =>
+      mockCreds({ NOTION_API_KEY: true, NOTION_DATABASE_ID: true }),
+    )
+    let importBody: string | null = null
+    on("/api/chat/notion-import", (init) => {
+      importBody = (init?.body as string) ?? null
+      return new Response(JSON.stringify({ url: "https://www.notion.so/x" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    })
+    const user = userEvent.setup()
+    renderChatForm()
+    await sendOneTurn(user)
+    await waitFor(() => {
+      expect(screen.getByTestId("notion-save-button")).not.toBeDisabled()
+    })
+    await user.click(screen.getByTestId("notion-save-button"))
+    await waitFor(() => {
+      expect(importBody).not.toBeNull()
+    })
+    const sent = JSON.parse(importBody!) as { model: string }
+    expect(sent.model).toBe("sonnet")
+  })
+
+  it("surfaces the backend detail verbatim on 4xx (skill failure)", async () => {
+    on("/api/credentials", () =>
+      mockCreds({ NOTION_API_KEY: true, NOTION_DATABASE_ID: true }),
+    )
+    on("/api/chat/notion-import", () =>
+      new Response(
+        JSON.stringify({
+          detail:
+            "No Notion briefing page found for 2026-05-30 (skill report: 対象ページが見つかりませんでした)",
+        }),
+        { status: 404, headers: { "content-type": "application/json" } },
+      ),
+    )
+    const user = userEvent.setup()
+    renderChatForm()
+    await sendOneTurn(user)
+    await waitFor(() => {
+      expect(screen.getByTestId("notion-save-button")).not.toBeDisabled()
+    })
+    await user.click(screen.getByTestId("notion-save-button"))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("notion-save-error")).toHaveTextContent(
+        "No Notion briefing page found for 2026-05-30",
+      )
+    })
+    // After an error the button re-enables so the user can retry.
+    expect(screen.getByTestId("notion-save-button")).not.toBeDisabled()
   })
 })

--- a/apps/web/tests/chat-form.test.tsx
+++ b/apps/web/tests/chat-form.test.tsx
@@ -281,7 +281,7 @@ describe("ChatForm", () => {
     })
   })
 
-  it("POSTs the picked model with the Q&A and surfaces the returned URL", async () => {
+  it("POSTs the Q&A on click and surfaces the returned URL", async () => {
     on("/api/credentials", () =>
       mockCreds({ NOTION_API_KEY: true, NOTION_DATABASE_ID: true }),
     )
@@ -299,8 +299,11 @@ describe("ChatForm", () => {
     await waitFor(() => {
       expect(screen.getByTestId("notion-save-button")).not.toBeDisabled()
     })
-    // Pick opus before saving.
-    await user.selectOptions(screen.getByTestId("notion-model-select"), "opus")
+    // The model selector was removed (PR #110 review feedback): saving the
+    // already-streamed answer doesn't benefit from a fresh model choice —
+    // the only work left is a Notion API append, for which the backend
+    // default (sonnet) is sufficient. So no UI control to assert here.
+    expect(screen.queryByTestId("notion-model-select")).toBeNull()
     await user.click(screen.getByTestId("notion-save-button"))
 
     await waitFor(() => {
@@ -315,38 +318,14 @@ describe("ChatForm", () => {
       date: string
       question: string
       answer: string
-      model: string
+      model?: string
     }
     expect(sent.question).toBe("a question")
     expect(sent.answer).toBe("an answer")
-    expect(sent.model).toBe("opus")
     expect(sent.date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
-  })
-
-  it("defaults to model=sonnet when the user doesn't change it", async () => {
-    on("/api/credentials", () =>
-      mockCreds({ NOTION_API_KEY: true, NOTION_DATABASE_ID: true }),
-    )
-    let importBody: string | null = null
-    on("/api/chat/notion-import", (init) => {
-      importBody = (init?.body as string) ?? null
-      return new Response(JSON.stringify({ url: "https://www.notion.so/x" }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      })
-    })
-    const user = userEvent.setup()
-    renderChatForm()
-    await sendOneTurn(user)
-    await waitFor(() => {
-      expect(screen.getByTestId("notion-save-button")).not.toBeDisabled()
-    })
-    await user.click(screen.getByTestId("notion-save-button"))
-    await waitFor(() => {
-      expect(importBody).not.toBeNull()
-    })
-    const sent = JSON.parse(importBody!) as { model: string }
-    expect(sent.model).toBe("sonnet")
+    // model is omitted from the request body now that the UI no longer
+    // surfaces a picker; the backend's Pydantic default (sonnet) kicks in.
+    expect(sent.model).toBeUndefined()
   })
 
   it("keeps Notion save disabled while the assistant message is still streaming", async () => {
@@ -385,32 +364,6 @@ describe("ChatForm", () => {
     await waitFor(() => {
       expect(screen.getByTestId("notion-save-button")).not.toBeDisabled()
     })
-  })
-
-  it("keeps the Notion model selection independent per message", async () => {
-    on("/api/credentials", () =>
-      mockCreds({ NOTION_API_KEY: true, NOTION_DATABASE_ID: true }),
-    )
-    const user = userEvent.setup()
-    renderChatForm()
-
-    // Two complete turns → two assistant messages → two NotionSaveRow rows.
-    await sendOneTurn(user)
-    on("/api/chat", () => sseResponse([{ data: "another answer" }]))
-    await user.type(screen.getByTestId("chat-input"), "second q")
-    await user.click(screen.getByTestId("send-button"))
-    await waitFor(() => {
-      expect(screen.getAllByTestId("chat-msg-assistant")).toHaveLength(2)
-    })
-
-    const selects = screen.getAllByTestId("notion-model-select")
-    expect(selects).toHaveLength(2)
-
-    // Change only the first row's model.
-    await user.selectOptions(selects[0], "opus")
-    expect((selects[0] as HTMLSelectElement).value).toBe("opus")
-    // Second row stays on its own default.
-    expect((selects[1] as HTMLSelectElement).value).toBe("sonnet")
   })
 
   it("surfaces the backend detail verbatim on 4xx (skill failure)", async () => {

--- a/apps/web/tests/utils.test.ts
+++ b/apps/web/tests/utils.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest"
+
+import { formatLocalDate } from "@/lib/utils"
+
+describe("formatLocalDate", () => {
+  it("formats a Date via local-time getters (not UTC)", () => {
+    // new Date(y, m, d, h, ...) constructs in local time, and the matching
+    // getFullYear / getMonth / getDate readers return those same local
+    // components — so this round-trip is TZ-independent.
+    const d = new Date(2026, 5, 3, 7, 47, 0) // local Jun 3 2026 07:47
+    expect(formatLocalDate(d)).toBe("2026-06-03")
+  })
+
+  it("zero-pads single-digit months and days", () => {
+    expect(formatLocalDate(new Date(2026, 0, 5))).toBe("2026-01-05")
+  })
+})


### PR DESCRIPTION
## Summary
Re-implement Issue #87 to **re-use the local `/notion-import` Claude Code skill** (`.claude/skills/notion-import/SKILL.md`) instead of duplicating the Notion append logic in Python. The skill stays the single source of truth — future edits propagate automatically.

### Why not the Claude Agent SDK
Investigated and confirmed (via `claude-code-guide` agent + official docs):
- The Anthropic Agent SDK / Skills API **does not discover** `.claude/skills/<name>/SKILL.md` (filesystem-based skills are Claude Code-only)
- "API Skills" uploaded to the workspace run in a **network-isolated** sandbox, so the skill's Notion MCP calls (`mcp__claude_ai_Notion__*`) wouldn't work there even if uploaded
- The `claude` CLI is the only path that resolves project-local skills + MCP simultaneously

POC verified: `claude -p "/notion-import …" --permission-mode bypassPermissions --output-format stream-json` surfaces `slash_commands: [..., "notion-import", ...]` in the init record, inherits the Notion MCP server from `~/.claude.json`, and runs the skill's logic correctly (validated by the skill's own "no preceding answer → stop" branch firing as expected).

### What landed
- **Backend** (`POST /api/chat/notion-import`): spawns `claude -p` with the prompt `/notion-import chat-<date>` + Q&A inline; parses the terminal stream-json `result` record and pulls the Notion URL out. Status map: **400** creds missing (lists which), **404** skill ran but reported no briefing page (echoes the skill's own report), **502** for CLI exit nonzero / missing binary / 120s timeout.
- **Model picker**: `body.model` allow-listed to `sonnet | opus | haiku` via Pydantic `Literal` (rejects others as 422). Default `sonnet`. POC cost: Opus 4.7 ≈ $0.13/call, Sonnet ≈ $0.02–0.04.
- **Frontend** (`ChatForm.tsx`): per-assistant-message `NotionSaveRow` with button + model `<select>` + inline success link / error text. Button disabled with tooltip when `GET /api/credentials` shows either NOTION_* key missing. Backend `detail` surfaced verbatim on 4xx; button re-enables for retry.
- **Tests**: 11 pytest cases on the endpoint, 6 vitest cases on the UI. Existing chat-form tests refactored onto a per-URL dispatch mock.

Closes #87

## Test plan
- [x] pytest 283/283 (`web/routers/chat.py` 96% coverage; uncovered = REPO_ROOT / verbose-init log lines)
- [x] vitest 73/73, `next lint` clean
- [x] Manual: configure NOTION_API_KEY + NOTION_DATABASE_ID, send a chat question, click `Notion ブリーフィングに追記` — page is appended to today's "マーケットブリーフィング — YYYY-MM-DD" page; success link opens to it.
- [ ] Manual: pick a date with no briefing page → button click returns 404 with the skill's "page not found" text inline.
- [ ] Manual: delete NOTION_API_KEY → button disabled with tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add Notion save row/button on assistant messages with credential-aware enable/disable, model selector (defaults to Sonnet), and direct link to the created Notion page.
  * Add POST /api/chat/notion-import backend endpoint and client wiring to trigger saves.

* **Bug Fixes**
  * Better validation and mapped error responses for missing credentials, auth, invalid input, CLI failures, and timeouts.

* **Tests**
  * New end-to-end and unit tests covering the Notion save flow and a local date formatter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->