### PR TITLE
chore(web): add rehype-sanitize to Chat markdown renderer

### DIFF
--- a/apps/web/components/screens/ChatForm.tsx
+++ b/apps/web/components/screens/ChatForm.tsx
@@ -1,6 +1,7 @@
 "use client"
 import { useCallback, useEffect, useRef, useState } from "react"
 import ReactMarkdown from "react-markdown"
+import rehypeSanitize from "rehype-sanitize"
 import remarkGfm from "remark-gfm"
 
 import { SessionExpiredCard } from "@/components/SessionExpiredCard"
@@ -473,7 +474,10 @@ export function ChatForm() {
                 {m.role === "assistant" ? (
                   m.content ? (
                     <div className="prose prose-sm max-w-none dark:prose-invert">
-                      <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                      <ReactMarkdown
+                        remarkPlugins={[remarkGfm]}
+                        rehypePlugins={[rehypeSanitize]}
+                      >
                         {m.content}
                       </ReactMarkdown>
                     </div>

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -17,6 +17,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-markdown": "^10.1.0",
+        "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.6.0",
         "tailwindcss-animate": "^1.0.7"
@@ -4634,6 +4635,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -7375,7 +7391,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7875,6 +7890,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-gfm": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-markdown": "^10.1.0",
+    "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.6.0",
     "tailwindcss-animate": "^1.0.7"

--- a/apps/web/tests/chat-form.test.tsx
+++ b/apps/web/tests/chat-form.test.tsx
@@ -135,6 +135,23 @@ describe("ChatForm", () => {
     })
   })
 
+  it("strips dangerous raw HTML from assistant markdown (rehype-sanitize)", async () => {
+    on("/api/chat", () =>
+      sseResponse([{ data: "<img src=x onerror=alert(1)> after" }]),
+    )
+    const user = userEvent.setup()
+    renderChatForm()
+    await user.type(screen.getByTestId("chat-input"), "q")
+    await user.click(screen.getByTestId("send-button"))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-msg-assistant")).toHaveTextContent("after")
+    })
+    const assistant = screen.getByTestId("chat-msg-assistant")
+    expect(assistant.querySelector("img")).toBeNull()
+    expect(assistant.innerHTML).not.toMatch(/onerror/i)
+  })
+
   it("retries exactly once on stale_session with the same payload", async () => {
     on("/api/chat", () =>
       sseResponse([{ event: "stale_session", data: "expired" }]),


### PR DESCRIPTION
## Summary
- Add `rehype-sanitize` as a `rehypePlugin` on `<ReactMarkdown>` in `apps/web/components/screens/ChatForm.tsx` to keep LLM-rendered markdown free of executable HTML even if a future change enables raw HTML rendering.
- Add `rehype-sanitize@^6.0.0` to `apps/web/package.json` (lockfile refreshed).
- Add a vitest that streams `<img src=x onerror=alert(1)>` through the SSE mock and asserts no `<img>` element renders and no `onerror` attribute survives in the assistant bubble.

## Test plan
- [x] `cd apps/web && npm test` — 76/76 pass (includes the new sanitization test).
- [x] `cd apps/web && npm run build` — passes.
- [x] Manual: send a chat where the assistant emits `<img src=x onerror=alert(1)>` and confirm no alert fires and no `<img>` element appears under `[data-testid="chat-msg-assistant"]`.

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Messages now safely render content, preventing potential security issues from malicious code in messages.

* **Tests**
  * Added test coverage for message content handling and rendering safety.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KazusaNakagawa/ai-agent-cli/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->