### PR TITLE
feat(web): add Cancel control to abort in-flight Q&A streaming

### DIFF
--- a/apps/web/components/screens/ChatForm.tsx
+++ b/apps/web/components/screens/ChatForm.tsx
@@ -362,6 +362,9 @@ export function ChatForm() {
     const ctl = abortRef.current
     if (!ctl || !busy) return
     ctl.abort()
+    // Esc fires at window scope, so a late keystroke could land after unmount —
+    // skip the state writes if so. abort() above is safe either way.
+    if (!mountedRef.current) return
     setInput(pendingQuestionRef.current)
     setMessages((prev) => {
       const copy = [...prev]
@@ -371,7 +374,7 @@ export function ChatForm() {
       }
       return copy
     })
-  }, [abortRef, busy, setMessages])
+  }, [abortRef, busy, mountedRef, setMessages])
 
   // Window-level Esc handler — only active while streaming so it doesn't
   // intercept Esc in other contexts (modals, popovers).

--- a/apps/web/components/screens/ChatForm.tsx
+++ b/apps/web/components/screens/ChatForm.tsx
@@ -181,6 +181,9 @@ export function ChatForm() {
   const recRef = useRef<Recognition | null>(null)
   const composingRef = useRef(false)
   const micPrefixRef = useRef("")
+  // The question currently in flight — restored into the textarea on cancel
+  // so the user can edit and resend without retyping.
+  const pendingQuestionRef = useRef("")
 
   useEffect(() => {
     setSupportsMic(getRecognitionCtor() !== null)
@@ -293,6 +296,7 @@ export function ChatForm() {
     abortRef.current?.abort()
     const ctl = new AbortController()
     abortRef.current = ctl
+    pendingQuestionRef.current = question
 
     setInput("")
     setBusy(true)
@@ -349,6 +353,39 @@ export function ChatForm() {
       }
     }
   }, [abortRef, busy, input, mountedRef, setMessages, stream])
+
+  // Abort the in-flight stream, mark the last assistant message as cancelled
+  // (distinct visual from an error), and restore the original question into
+  // the textarea so the user can edit and resend. `busy` flips back to false
+  // via send()'s finally{} once the abort propagates through the reader.
+  const cancel = useCallback(() => {
+    const ctl = abortRef.current
+    if (!ctl || !busy) return
+    ctl.abort()
+    setInput(pendingQuestionRef.current)
+    setMessages((prev) => {
+      const copy = [...prev]
+      const last = copy[copy.length - 1]
+      if (last && last.role === "assistant") {
+        copy[copy.length - 1] = { ...last, cancelled: true, error: null }
+      }
+      return copy
+    })
+  }, [abortRef, busy, setMessages])
+
+  // Window-level Esc handler — only active while streaming so it doesn't
+  // intercept Esc in other contexts (modals, popovers).
+  useEffect(() => {
+    if (!busy) return
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault()
+        cancel()
+      }
+    }
+    window.addEventListener("keydown", onKeyDown)
+    return () => window.removeEventListener("keydown", onKeyDown)
+  }, [busy, cancel])
 
   const saveToNotion = useCallback(
     async (idx: number) => {
@@ -487,7 +524,7 @@ export function ChatForm() {
                         {m.content}
                       </ReactMarkdown>
                     </div>
-                  ) : busy && i === messages.length - 1 ? (
+                  ) : busy && i === messages.length - 1 && !m.cancelled ? (
                     <LoadingDots
                       label="調査中"
                       data-testid="chat-thinking"
@@ -502,6 +539,14 @@ export function ChatForm() {
                     data-testid="chat-error"
                   >
                     {m.error}
+                  </p>
+                )}
+                {m.role === "assistant" && m.cancelled && (
+                  <p
+                    className="mt-2 text-xs text-muted-foreground"
+                    data-testid="chat-cancelled"
+                  >
+                    Cancelled
                   </p>
                 )}
                 {m.role === "assistant" && m.content && (
@@ -557,7 +602,6 @@ export function ChatForm() {
               rows={2}
               className="flex-1 resize-none rounded-md border bg-background px-3 py-2 text-sm"
               data-testid="chat-input"
-              disabled={busy}
             />
             {supportsMic && (
               <Button
@@ -571,13 +615,25 @@ export function ChatForm() {
                 {listening ? "🛑" : "🎤"}
               </Button>
             )}
-            <Button
-              onClick={() => void send()}
-              disabled={busy || input.trim().length === 0}
-              data-testid="send-button"
-            >
-              {busy ? "Sending…" : "Send"}
-            </Button>
+            {busy ? (
+              <Button
+                type="button"
+                variant="destructive"
+                onClick={cancel}
+                data-testid="cancel-button"
+                title="送信中の応答を中止 (Esc)"
+              >
+                Cancel
+              </Button>
+            ) : (
+              <Button
+                onClick={() => void send()}
+                disabled={input.trim().length === 0}
+                data-testid="send-button"
+              >
+                Send
+              </Button>
+            )}
           </div>
           {!supportsMic && (
             <p

--- a/apps/web/lib/chatStore.tsx
+++ b/apps/web/lib/chatStore.tsx
@@ -13,6 +13,7 @@ export type ChatMessage = {
   role: "user" | "assistant"
   content: string
   error?: string | null
+  cancelled?: boolean
 }
 
 export type ChatStateContextValue = {
@@ -40,7 +41,8 @@ function isChatMessage(value: unknown): value is ChatMessage {
   return (
     (m.role === "user" || m.role === "assistant") &&
     typeof m.content === "string" &&
-    (m.error === undefined || m.error === null || typeof m.error === "string")
+    (m.error === undefined || m.error === null || typeof m.error === "string") &&
+    (m.cancelled === undefined || typeof m.cancelled === "boolean")
   )
 }
 

--- a/apps/web/tests/chat-form.test.tsx
+++ b/apps/web/tests/chat-form.test.tsx
@@ -596,6 +596,26 @@ describe("ChatForm", () => {
     })
   })
 
+  it("does not log a React warning when unmounted mid-stream", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    on("/api/chat", openChatStream())
+    const user = userEvent.setup()
+    const { unmount } = renderChatForm()
+    await user.type(screen.getByTestId("chat-input"), "q")
+    await user.click(screen.getByTestId("send-button"))
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-msg-assistant")).toHaveTextContent(
+        "partial",
+      )
+    })
+    // useAbortableMount's cleanup aborts the in-flight fetch on unmount —
+    // any post-unmount setState would surface as a React console.error.
+    unmount()
+    await new Promise((r) => setTimeout(r, 20))
+    expect(errorSpy).not.toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+
   it("allows sending a fresh request after cancel", async () => {
     on("/api/chat", openChatStream("first"))
     on("/api/chat", () => sseResponse([{ data: "second answer" }]))

--- a/apps/web/tests/chat-form.test.tsx
+++ b/apps/web/tests/chat-form.test.tsx
@@ -485,4 +485,144 @@ describe("ChatForm", () => {
     // After an error the button re-enables so the user can retry.
     expect(screen.getByTestId("notion-save-button")).not.toBeDisabled()
   })
+
+  // ----- Cancel in-flight streaming (Issue #98) ------------------------
+
+  // Open a streaming response that emits one chunk and stays open until the
+  // request's AbortSignal fires — emulating real fetch+SSE cancellation so
+  // send()'s reader.read() actually resolves after cancel.
+  function openChatStream(firstChunk = "partial"): Handler {
+    const encoder = new TextEncoder()
+    return (init) => {
+      const signal = init?.signal ?? undefined
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode(`data: ${firstChunk}\n\n`))
+          signal?.addEventListener("abort", () => {
+            try {
+              controller.close()
+            } catch {
+              // already closed
+            }
+          })
+        },
+      })
+      return new Response(stream, { status: 200 })
+    }
+  }
+
+  it("replaces Send with Cancel while streaming", async () => {
+    on("/api/chat", openChatStream())
+    const user = userEvent.setup()
+    renderChatForm()
+    await user.type(screen.getByTestId("chat-input"), "my question")
+    await user.click(screen.getByTestId("send-button"))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-msg-assistant")).toHaveTextContent(
+        "partial",
+      )
+    })
+    expect(screen.queryByTestId("send-button")).toBeNull()
+    expect(screen.getByTestId("cancel-button")).toBeInTheDocument()
+
+    // Clean up so the test doesn't leave a pending stream.
+    await user.click(screen.getByTestId("cancel-button"))
+    await waitFor(() => {
+      expect(screen.getByTestId("send-button")).toBeInTheDocument()
+    })
+  })
+
+  it("clicking Cancel aborts, marks the message cancelled, and restores the question", async () => {
+    on("/api/chat", openChatStream())
+    const user = userEvent.setup()
+    renderChatForm()
+    await user.type(screen.getByTestId("chat-input"), "my question")
+    await user.click(screen.getByTestId("send-button"))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-msg-assistant")).toHaveTextContent(
+        "partial",
+      )
+    })
+    await user.click(screen.getByTestId("cancel-button"))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-cancelled")).toHaveTextContent("Cancelled")
+    })
+    expect(screen.getByTestId("chat-input")).toHaveValue("my question")
+    expect(screen.queryByTestId("chat-error")).toBeNull()
+    // Cancel button gone, Send back so the user can resend.
+    await waitFor(() => {
+      expect(screen.getByTestId("send-button")).toBeInTheDocument()
+    })
+  })
+
+  it("Esc cancels the in-flight stream", async () => {
+    on("/api/chat", openChatStream("hi"))
+    const user = userEvent.setup()
+    renderChatForm()
+    await user.type(screen.getByTestId("chat-input"), "q")
+    await user.click(screen.getByTestId("send-button"))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-msg-assistant")).toHaveTextContent("hi")
+    })
+    await user.keyboard("{Escape}")
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-cancelled")).toBeInTheDocument()
+    })
+    expect(screen.getByTestId("chat-input")).toHaveValue("q")
+  })
+
+  it("keeps the textarea editable while streaming", async () => {
+    on("/api/chat", openChatStream())
+    const user = userEvent.setup()
+    renderChatForm()
+    await user.type(screen.getByTestId("chat-input"), "q")
+    await user.click(screen.getByTestId("send-button"))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-msg-assistant")).toHaveTextContent(
+        "partial",
+      )
+    })
+    expect(screen.getByTestId("chat-input")).not.toBeDisabled()
+
+    await user.click(screen.getByTestId("cancel-button"))
+    await waitFor(() => {
+      expect(screen.getByTestId("send-button")).toBeInTheDocument()
+    })
+  })
+
+  it("allows sending a fresh request after cancel", async () => {
+    on("/api/chat", openChatStream("first"))
+    on("/api/chat", () => sseResponse([{ data: "second answer" }]))
+
+    const user = userEvent.setup()
+    renderChatForm()
+    await user.type(screen.getByTestId("chat-input"), "q1")
+    await user.click(screen.getByTestId("send-button"))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-msg-assistant")).toHaveTextContent("first")
+    })
+    await user.click(screen.getByTestId("cancel-button"))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("send-button")).toBeInTheDocument()
+    })
+    const input = screen.getByTestId("chat-input")
+    await user.clear(input)
+    await user.type(input, "q2")
+    await user.click(screen.getByTestId("send-button"))
+
+    await waitFor(() => {
+      const assistants = screen.getAllByTestId("chat-msg-assistant")
+      expect(assistants[assistants.length - 1]).toHaveTextContent(
+        "second answer",
+      )
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- Replace the Send button with a Cancel button (`data-testid="cancel-button"`) while a Q&A request is streaming, and bind `Esc` to the same action.
- On cancel: abort the SSE stream, restore the just-sent question into the textarea, and mark the last assistant message with a small `Cancelled` footer (not the error style).
- Unlock the textarea during streaming so the user can edit while waiting.
- Add an optional `cancelled` flag to `ChatMessage` (sessionStorage validator updated).

## Test plan
- [x] `npm run test` — 84 tests pass (5 new chat-cancel tests added)
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [ ] Manual smoke in dev server: start a long-running question, click Cancel mid-stream and confirm the textarea restores the question, the answer shows `Cancelled`, and pressing Send again issues a fresh request

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cancel in-flight chat streams using the Cancel button or by pressing Escape.
  * Cancelled responses are clearly marked with a visible "Cancelled" status indicator.
  * Original question text is automatically restored when you cancel a stream.
  * Input area remains fully editable during streaming.
  * Chat error states are cleared when cancelling a response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->