### PR TITLE
refactor(web): extract ChatForm side-effect logic into hooks

### DIFF
--- a/apps/web/components/screens/ChatForm.tsx
+++ b/apps/web/components/screens/ChatForm.tsx
@@ -10,47 +10,16 @@ import { Card, CardContent } from "@/components/ui/card"
 import { LoadingDots } from "@/components/ui/loading-dots"
 import { useChatState } from "@/lib/chatStore"
 import { useAbortableMount } from "@/lib/hooks/useAbortableMount"
+import { useDraftPersistence } from "@/lib/hooks/useDraftPersistence"
+import { useNotionCredentials } from "@/lib/hooks/useNotionCredentials"
+import {
+  useNotionSave,
+  type NotionSaveState,
+} from "@/lib/hooks/useNotionSave"
+import { useSpeechRecognition } from "@/lib/hooks/useSpeechRecognition"
 import { cn, formatLocalDate } from "@/lib/utils"
 
 type SSEEvent = { type: string; data: string }
-
-type NotionSaveStatus = "idle" | "saving" | "saved" | "error"
-
-type NotionSaveState = {
-  status: NotionSaveStatus
-  url?: string
-  error?: string
-}
-
-// Bumped if the persisted shape changes incompatibly.
-const DRAFT_STORAGE_KEY = "ai-agent:chat-draft:v1"
-
-function loadDraft(): string {
-  if (typeof window === "undefined") return ""
-  try {
-    return window.sessionStorage.getItem(DRAFT_STORAGE_KEY) ?? ""
-  } catch {
-    return ""
-  }
-}
-
-function persistDraft(draft: string) {
-  if (typeof window === "undefined") return
-  try {
-    window.sessionStorage.setItem(DRAFT_STORAGE_KEY, draft)
-  } catch {
-    // quota / unavailable — draft remains in memory for the tab
-  }
-}
-
-function clearDraft() {
-  if (typeof window === "undefined") return
-  try {
-    window.sessionStorage.removeItem(DRAFT_STORAGE_KEY)
-  } catch {
-    // ignore
-  }
-}
 
 function today(): string {
   return formatLocalDate()
@@ -76,21 +45,6 @@ function parseSSE(buffer: string): { events: SSEEvent[]; rest: string } {
   return { events, rest }
 }
 
-// SpeechRecognition globals — typed loosely because the TS DOM lib omits them.
-type Recognition = {
-  lang: string
-  continuous: boolean
-  interimResults: boolean
-  onresult:
-    | ((e: { results: ArrayLike<ArrayLike<{ transcript: string }>> }) => void)
-    | null
-  onend: (() => void) | null
-  onerror: ((e: { error: string }) => void) | null
-  start(): void
-  stop(): void
-}
-type RecognitionCtor = new () => Recognition
-
 function NotionSaveRow({
   state,
   enabled,
@@ -100,7 +54,7 @@ function NotionSaveRow({
   enabled: boolean
   onSave: () => void
 }) {
-  const status: NotionSaveStatus = state?.status ?? "idle"
+  const status: NotionSaveState["status"] = state?.status ?? "idle"
   const disabled = !enabled || status === "saving" || status === "saved"
   const title = enabled
     ? undefined
@@ -145,84 +99,26 @@ function NotionSaveRow({
   )
 }
 
-function getRecognitionCtor(): RecognitionCtor | null {
-  if (typeof window === "undefined") return null
-  const w = window as unknown as {
-    SpeechRecognition?: RecognitionCtor
-    webkitSpeechRecognition?: RecognitionCtor
-  }
-  return w.SpeechRecognition ?? w.webkitSpeechRecognition ?? null
-}
-
 export function ChatForm() {
   const { messages, setMessages } = useChatState()
-  // Render "" on first paint so SSR and the first client render agree
-  // (sessionStorage is unavailable on the server). The hydrate effect
-  // below promotes input to whatever draft was persisted in this tab.
-  const [input, setInput] = useState("")
-  const [hydrated, setHydrated] = useState(false)
+  const { draft: input, setDraft: setInput } = useDraftPersistence({
+    storageKey: "ai-agent:chat-draft:v1",
+  })
   const [busy, setBusy] = useState(false)
   const [sessionExpired, setSessionExpired] = useState(false)
   const [retrying, setRetrying] = useState(false)
-  const [listening, setListening] = useState(false)
-  const [supportsMic, setSupportsMic] = useState(false)
-  // null until /api/credentials answers; the Notion button stays disabled
-  // until we know whether both NOTION_* keys exist (no premature enable).
-  const [creds, setCreds] = useState<Record<string, boolean> | null>(null)
-  // Per-message Notion save state. Keyed by message index — transient by
-  // design (not part of the persisted chat history) because the Notion
-  // page itself is the durable artifact.
-  const [notionState, setNotionState] = useState<
-    Record<number, NotionSaveState>
-  >({})
+  const { notionReady } = useNotionCredentials()
+  const { supportsMic, listening, toggle: toggleMic } = useSpeechRecognition({
+    onTranscript: setInput,
+  })
+  const { notionState, saveToNotion } = useNotionSave({ messages })
 
   // Suppress setState and cancel in-flight work after unmount.
   const { mountedRef, abortRef } = useAbortableMount()
-  const recRef = useRef<Recognition | null>(null)
   const composingRef = useRef(false)
-  const micPrefixRef = useRef("")
   // The question currently in flight — restored into the textarea on cancel
   // so the user can edit and resend without retyping.
   const pendingQuestionRef = useRef("")
-
-  useEffect(() => {
-    setSupportsMic(getRecognitionCtor() !== null)
-    setInput(loadDraft())
-    setHydrated(true)
-    return () => {
-      recRef.current?.stop()
-    }
-  }, [])
-
-  useEffect(() => {
-    let cancelled = false
-    fetch("/api/credentials", { cache: "no-store" })
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data: Record<string, boolean> | null) => {
-        if (cancelled) return
-        setCreds(data ?? {})
-      })
-      .catch(() => {
-        // Network failure — leave creds null so the button stays disabled
-        // rather than enabling it on incomplete information.
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [])
-
-  const notionReady = Boolean(
-    creds && creds.NOTION_API_KEY && creds.NOTION_DATABASE_ID,
-  )
-
-  useEffect(() => {
-    if (!hydrated) return
-    if (input === "") {
-      clearDraft()
-    } else {
-      persistDraft(input)
-    }
-  }, [input, hydrated])
 
   // Stream one POST /api/chat round trip. Returns "stale" iff the backend
   // emitted the `stale_session` event — the caller retries exactly once.
@@ -352,7 +248,7 @@ export function ChatForm() {
         setRetrying(false)
       }
     }
-  }, [abortRef, busy, input, mountedRef, setMessages, stream])
+  }, [abortRef, busy, input, mountedRef, setInput, setMessages, stream])
 
   // Abort the in-flight stream, mark the last assistant message as cancelled
   // (distinct visual from an error), and restore the original question into
@@ -374,7 +270,7 @@ export function ChatForm() {
       }
       return copy
     })
-  }, [abortRef, busy, mountedRef, setMessages])
+  }, [abortRef, busy, mountedRef, setInput, setMessages])
 
   // Window-level Esc handler — only active while streaming so it doesn't
   // intercept Esc in other contexts (modals, popovers).
@@ -389,102 +285,6 @@ export function ChatForm() {
     window.addEventListener("keydown", onKeyDown)
     return () => window.removeEventListener("keydown", onKeyDown)
   }, [busy, cancel])
-
-  const saveToNotion = useCallback(
-    async (idx: number) => {
-      const assistant = messages[idx]
-      if (!assistant || assistant.role !== "assistant" || !assistant.content) return
-      // Walk back to find the user question this answer is responding to.
-      let question = ""
-      for (let j = idx - 1; j >= 0; j--) {
-        if (messages[j].role === "user") {
-          question = messages[j].content
-          break
-        }
-      }
-      if (!question) return
-
-      setNotionState((prev) => ({ ...prev, [idx]: { status: "saving" } }))
-      try {
-        const res = await fetch("/api/chat/notion-import", {
-          method: "POST",
-          cache: "no-store",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({
-            date: today(),
-            question,
-            answer: assistant.content,
-          }),
-        })
-        if (!res.ok) {
-          // AC: surface the backend's `detail` verbatim so the operator
-          // sees the skill's own error message (e.g. "page not found").
-          let detail = `HTTP ${res.status}`
-          try {
-            const body = (await res.json()) as { detail?: string }
-            if (body.detail) detail = body.detail
-          } catch {
-            // Body wasn't JSON — keep the HTTP fallback.
-          }
-          if (!mountedRef.current) return
-          setNotionState((prev) => ({
-            ...prev,
-            [idx]: { status: "error", error: detail },
-          }))
-          return
-        }
-        const body = (await res.json()) as { url: string }
-        if (!mountedRef.current) return
-        setNotionState((prev) => ({
-          ...prev,
-          [idx]: { status: "saved", url: body.url },
-        }))
-      } catch (e) {
-        if (!mountedRef.current) return
-        setNotionState((prev) => ({
-          ...prev,
-          [idx]: {
-            status: "error",
-            error: e instanceof Error ? e.message : "Network error",
-          },
-        }))
-      }
-    },
-    [messages, mountedRef],
-  )
-
-  const toggleMic = useCallback(() => {
-    if (listening) {
-      recRef.current?.stop()
-      return
-    }
-    const Ctor = getRecognitionCtor()
-    if (!Ctor) return
-    const rec = new Ctor()
-    rec.lang = "ja-JP"
-    rec.continuous = true
-    rec.interimResults = true
-    micPrefixRef.current = input
-    rec.onresult = (e) => {
-      let transcript = ""
-      for (let i = 0; i < e.results.length; i++) {
-        transcript += e.results[i][0].transcript
-      }
-      const prefix = micPrefixRef.current
-      const sep = prefix && !/\s$/.test(prefix) ? " " : ""
-      setInput(prefix + sep + transcript)
-    }
-    const stop = () => {
-      if (mountedRef.current) setListening(false)
-      recRef.current = null
-      micPrefixRef.current = ""
-    }
-    rec.onend = stop
-    rec.onerror = stop
-    rec.start()
-    recRef.current = rec
-    setListening(true)
-  }, [listening, mountedRef, input])
 
   if (sessionExpired) {
     return <SessionExpiredCard />
@@ -610,7 +410,7 @@ export function ChatForm() {
               <Button
                 type="button"
                 variant={listening ? "destructive" : "outline"}
-                onClick={toggleMic}
+                onClick={() => toggleMic(input)}
                 data-testid="mic-button"
                 aria-pressed={listening}
                 title={listening ? "音声入力停止" : "音声入力開始 (ja-JP)"}

--- a/apps/web/lib/hooks/useDraftPersistence.ts
+++ b/apps/web/lib/hooks/useDraftPersistence.ts
@@ -1,0 +1,48 @@
+"use client"
+import { useEffect, useState } from "react"
+
+type Options = {
+  // Bumped if the persisted shape changes incompatibly.
+  storageKey: string
+}
+
+export type UseDraftPersistence = {
+  draft: string
+  setDraft: (value: string) => void
+  hydrated: boolean
+}
+
+// Render "" on first paint so SSR and the first client render agree
+// (sessionStorage is unavailable on the server). After mount the hook
+// promotes draft to whatever was persisted in this tab.
+export function useDraftPersistence({ storageKey }: Options): UseDraftPersistence {
+  const [draft, setDraft] = useState("")
+  const [hydrated, setHydrated] = useState(false)
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      try {
+        setDraft(window.sessionStorage.getItem(storageKey) ?? "")
+      } catch {
+        // sessionStorage unavailable — keep the empty initial.
+      }
+    }
+    setHydrated(true)
+  }, [storageKey])
+
+  useEffect(() => {
+    if (!hydrated) return
+    if (typeof window === "undefined") return
+    try {
+      if (draft === "") {
+        window.sessionStorage.removeItem(storageKey)
+      } else {
+        window.sessionStorage.setItem(storageKey, draft)
+      }
+    } catch {
+      // quota / unavailable — draft remains in memory for the tab
+    }
+  }, [draft, hydrated, storageKey])
+
+  return { draft, setDraft, hydrated }
+}

--- a/apps/web/lib/hooks/useNotionCredentials.ts
+++ b/apps/web/lib/hooks/useNotionCredentials.ts
@@ -1,0 +1,35 @@
+"use client"
+import { useEffect, useState } from "react"
+
+export type UseNotionCredentials = {
+  notionReady: boolean
+  // false until /api/credentials answers — the consumer should keep its
+  // Notion controls disabled while this is false (no premature enable).
+  hydrated: boolean
+}
+
+export function useNotionCredentials(): UseNotionCredentials {
+  const [creds, setCreds] = useState<Record<string, boolean> | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    fetch("/api/credentials", { cache: "no-store" })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: Record<string, boolean> | null) => {
+        if (cancelled) return
+        setCreds(data ?? {})
+      })
+      .catch(() => {
+        // Network failure — leave creds null so the gate stays closed
+        // rather than enabling controls on incomplete information.
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return {
+    notionReady: Boolean(creds && creds.NOTION_API_KEY && creds.NOTION_DATABASE_ID),
+    hydrated: creds !== null,
+  }
+}

--- a/apps/web/lib/hooks/useNotionSave.ts
+++ b/apps/web/lib/hooks/useNotionSave.ts
@@ -1,0 +1,103 @@
+"use client"
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import type { ChatMessage } from "@/lib/chatStore"
+import { formatLocalDate } from "@/lib/utils"
+
+type NotionSaveStatus = "idle" | "saving" | "saved" | "error"
+
+export type NotionSaveState = {
+  status: NotionSaveStatus
+  url?: string
+  error?: string
+}
+
+type Options = {
+  messages: ChatMessage[]
+}
+
+export type UseNotionSave = {
+  notionState: Record<number, NotionSaveState>
+  saveToNotion: (idx: number) => Promise<void>
+}
+
+// Per-message Notion save state. Keyed by message index — transient by
+// design (not part of the persisted chat history) because the Notion page
+// itself is the durable artifact.
+export function useNotionSave({ messages }: Options): UseNotionSave {
+  const [notionState, setNotionState] = useState<
+    Record<number, NotionSaveState>
+  >({})
+  const mountedRef = useRef(true)
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  const saveToNotion = useCallback(
+    async (idx: number) => {
+      const assistant = messages[idx]
+      if (!assistant || assistant.role !== "assistant" || !assistant.content) return
+      // Walk back to find the user question this answer is responding to.
+      let question = ""
+      for (let j = idx - 1; j >= 0; j--) {
+        if (messages[j].role === "user") {
+          question = messages[j].content
+          break
+        }
+      }
+      if (!question) return
+
+      setNotionState((prev) => ({ ...prev, [idx]: { status: "saving" } }))
+      try {
+        const res = await fetch("/api/chat/notion-import", {
+          method: "POST",
+          cache: "no-store",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            date: formatLocalDate(),
+            question,
+            answer: assistant.content,
+          }),
+        })
+        if (!res.ok) {
+          // AC: surface the backend's `detail` verbatim so the operator
+          // sees the skill's own error message (e.g. "page not found").
+          let detail = `HTTP ${res.status}`
+          try {
+            const body = (await res.json()) as { detail?: string }
+            if (body.detail) detail = body.detail
+          } catch {
+            // Body wasn't JSON — keep the HTTP fallback.
+          }
+          if (!mountedRef.current) return
+          setNotionState((prev) => ({
+            ...prev,
+            [idx]: { status: "error", error: detail },
+          }))
+          return
+        }
+        const body = (await res.json()) as { url: string }
+        if (!mountedRef.current) return
+        setNotionState((prev) => ({
+          ...prev,
+          [idx]: { status: "saved", url: body.url },
+        }))
+      } catch (e) {
+        if (!mountedRef.current) return
+        setNotionState((prev) => ({
+          ...prev,
+          [idx]: {
+            status: "error",
+            error: e instanceof Error ? e.message : "Network error",
+          },
+        }))
+      }
+    },
+    [messages],
+  )
+
+  return { notionState, saveToNotion }
+}

--- a/apps/web/lib/hooks/useSpeechRecognition.ts
+++ b/apps/web/lib/hooks/useSpeechRecognition.ts
@@ -1,0 +1,101 @@
+"use client"
+import { useCallback, useEffect, useRef, useState } from "react"
+
+// Loose typing for the SpeechRecognition globals — the TS DOM lib omits them.
+type Recognition = {
+  lang: string
+  continuous: boolean
+  interimResults: boolean
+  onresult:
+    | ((e: { results: ArrayLike<ArrayLike<{ transcript: string }>> }) => void)
+    | null
+  onend: (() => void) | null
+  onerror: ((e: { error: string }) => void) | null
+  start(): void
+  stop(): void
+}
+type RecognitionCtor = new () => Recognition
+
+function getRecognitionCtor(): RecognitionCtor | null {
+  if (typeof window === "undefined") return null
+  const w = window as unknown as {
+    SpeechRecognition?: RecognitionCtor
+    webkitSpeechRecognition?: RecognitionCtor
+  }
+  return w.SpeechRecognition ?? w.webkitSpeechRecognition ?? null
+}
+
+type Options = {
+  // Called on each interim/final result with the prefix + concatenated
+  // transcript. The prefix is captured once at start() time.
+  onTranscript: (combined: string) => void
+  lang?: string
+}
+
+export type UseSpeechRecognition = {
+  supportsMic: boolean
+  listening: boolean
+  // `prefix` is the textarea's current value at toggle-on time; new transcripts
+  // are appended to it so the user doesn't lose what they had typed.
+  toggle: (prefix: string) => void
+}
+
+export function useSpeechRecognition({
+  onTranscript,
+  lang = "ja-JP",
+}: Options): UseSpeechRecognition {
+  const [supportsMic, setSupportsMic] = useState(false)
+  const [listening, setListening] = useState(false)
+  const recRef = useRef<Recognition | null>(null)
+  const prefixRef = useRef("")
+  const mountedRef = useRef(true)
+  // Keep the latest onTranscript without re-binding rec.onresult.
+  const callbackRef = useRef(onTranscript)
+  callbackRef.current = onTranscript
+
+  useEffect(() => {
+    setSupportsMic(getRecognitionCtor() !== null)
+    return () => {
+      mountedRef.current = false
+      recRef.current?.stop()
+    }
+  }, [])
+
+  const toggle = useCallback(
+    (prefix: string) => {
+      if (listening) {
+        recRef.current?.stop()
+        return
+      }
+      const Ctor = getRecognitionCtor()
+      if (!Ctor) return
+      const rec = new Ctor()
+      rec.lang = lang
+      rec.continuous = true
+      rec.interimResults = true
+      prefixRef.current = prefix
+      rec.onresult = (e) => {
+        let transcript = ""
+        for (let i = 0; i < e.results.length; i++) {
+          transcript += e.results[i][0].transcript
+        }
+        const p = prefixRef.current
+        const sep = p && !/\s$/.test(p) ? " " : ""
+        callbackRef.current(p + sep + transcript)
+      }
+      const stop = () => {
+        if (mountedRef.current) setListening(false)
+        recRef.current = null
+        prefixRef.current = ""
+      }
+      rec.onend = stop
+      rec.onerror = stop
+      rec.start()
+      recRef.current = rec
+      setListening(true)
+    },
+    [lang, listening],
+  )
+
+  return { supportsMic, listening, toggle }
+}


### PR DESCRIPTION
## Summary
Step **1 of 4** of the ChatForm refactor sequence. Splits four independent concerns out of `ChatForm.tsx` (653 → 453 LOC) into reusable hooks under `apps/web/lib/hooks/`:

| Hook | Concern | LOC |
|---|---|---|
| `useDraftPersistence({storageKey})` | sessionStorage-backed input draft | 48 |
| `useSpeechRecognition({onTranscript})` | Web Speech API + `supportsMic` / `listening` | 101 |
| `useNotionCredentials()` | `/api/credentials` fetch + readiness flag | 35 |
| `useNotionSave({messages})` | per-message Notion append + state map | 103 |

No behavior changes. The streaming / cancel / Esc logic stays inline — that's step 3, intentionally postponed because Issue #112 (SSE resume) will touch the same area and it's better to extract once.

## Test plan
- [x] `npm run test` — 85 tests pass (no test changes; the existing chat-form suite exercises every hook transitively)
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [ ] Manual smoke: type/send a question, toggle mic, save to Notion, hit Cancel — all unchanged

## Refactor sequence (for context)
1. **This PR** — hooks extraction
2. Component extraction (`ChatMessageList`, `ChatComposer`)
3. `useChatStream` (stream / send / cancel / Esc / abortRef)
4. `notion.py` split (markdown converter vs API client)

🤖 Generated with [Claude Code](https://claude.com/claude-code)