### PR TITLE
refactor(web): extract ChatMessageList and ChatComposer

### DIFF
--- a/apps/web/components/chat/ChatComposer.tsx
+++ b/apps/web/components/chat/ChatComposer.tsx
@@ -35,6 +35,7 @@ export function ChatComposer({
       <CardContent className="space-y-2 pt-6">
         <div className="flex items-end gap-2">
           <textarea
+            aria-label="Chat message"
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onCompositionStart={() => {
@@ -65,6 +66,7 @@ export function ChatComposer({
               variant={listening ? "destructive" : "outline"}
               onClick={() => onToggleMic(input)}
               data-testid="mic-button"
+              aria-label={listening ? "音声入力停止" : "音声入力開始"}
               aria-pressed={listening}
               title={listening ? "音声入力停止" : "音声入力開始 (ja-JP)"}
             >

--- a/apps/web/components/chat/ChatComposer.tsx
+++ b/apps/web/components/chat/ChatComposer.tsx
@@ -1,0 +1,105 @@
+"use client"
+import { useRef } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+
+type Props = {
+  input: string
+  setInput: (value: string) => void
+  busy: boolean
+  supportsMic: boolean
+  listening: boolean
+  // Receives the textarea's current value at toggle-on time so the mic
+  // hook can append transcripts to whatever the user already typed.
+  onToggleMic: (prefix: string) => void
+  onSend: () => void
+  onCancel: () => void
+}
+
+export function ChatComposer({
+  input,
+  setInput,
+  busy,
+  supportsMic,
+  listening,
+  onToggleMic,
+  onSend,
+  onCancel,
+}: Props) {
+  // Tracks IME composition so Enter doesn't submit while picking kanji.
+  const composingRef = useRef(false)
+
+  return (
+    <Card>
+      <CardContent className="space-y-2 pt-6">
+        <div className="flex items-end gap-2">
+          <textarea
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onCompositionStart={() => {
+              composingRef.current = true
+            }}
+            onCompositionEnd={() => {
+              composingRef.current = false
+            }}
+            onKeyDown={(e) => {
+              if (
+                e.key === "Enter" &&
+                !e.shiftKey &&
+                !composingRef.current &&
+                !e.nativeEvent.isComposing
+              ) {
+                e.preventDefault()
+                onSend()
+              }
+            }}
+            placeholder="Ask about today's briefing…"
+            rows={2}
+            className="flex-1 resize-none rounded-md border bg-background px-3 py-2 text-sm"
+            data-testid="chat-input"
+          />
+          {supportsMic && (
+            <Button
+              type="button"
+              variant={listening ? "destructive" : "outline"}
+              onClick={() => onToggleMic(input)}
+              data-testid="mic-button"
+              aria-pressed={listening}
+              title={listening ? "音声入力停止" : "音声入力開始 (ja-JP)"}
+            >
+              {listening ? "🛑" : "🎤"}
+            </Button>
+          )}
+          {busy ? (
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={onCancel}
+              data-testid="cancel-button"
+              title="送信中の応答を中止 (Esc)"
+            >
+              Cancel
+            </Button>
+          ) : (
+            <Button
+              onClick={onSend}
+              disabled={input.trim().length === 0}
+              data-testid="send-button"
+            >
+              Send
+            </Button>
+          )}
+        </div>
+        {!supportsMic && (
+          <p
+            className="text-xs text-muted-foreground"
+            data-testid="mic-unsupported"
+          >
+            Voice input is unavailable in this browser (Chrome / Edge supported).
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/components/chat/ChatMessageList.tsx
+++ b/apps/web/components/chat/ChatMessageList.tsx
@@ -85,16 +85,21 @@ export function ChatMessageList({
                   Cancelled
                 </p>
               )}
-              {m.role === "assistant" && m.content && (
-                <NotionSaveRow
-                  state={notionState[i]}
-                  // Disable while this assistant message is still streaming
-                  // (last message + busy) so the user can't persist a
-                  // partial answer.
-                  enabled={notionReady && !(busy && i === messages.length - 1)}
-                  onSave={() => onNotionSave(i)}
-                />
-              )}
+              {m.role === "assistant" &&
+                m.content &&
+                !m.error &&
+                !m.cancelled && (
+                  <NotionSaveRow
+                    state={notionState[i]}
+                    // Disable while this assistant message is still streaming
+                    // (last message + busy) so the user can't persist a
+                    // partial answer.
+                    enabled={
+                      notionReady && !(busy && i === messages.length - 1)
+                    }
+                    onSave={() => onNotionSave(i)}
+                  />
+                )}
             </div>
           ))
         )}

--- a/apps/web/components/chat/ChatMessageList.tsx
+++ b/apps/web/components/chat/ChatMessageList.tsx
@@ -1,0 +1,163 @@
+"use client"
+import ReactMarkdown from "react-markdown"
+import rehypeSanitize from "rehype-sanitize"
+import remarkGfm from "remark-gfm"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { LoadingDots } from "@/components/ui/loading-dots"
+import type { ChatMessage } from "@/lib/chatStore"
+import type { NotionSaveState } from "@/lib/hooks/useNotionSave"
+import { cn } from "@/lib/utils"
+
+type Props = {
+  messages: ChatMessage[]
+  busy: boolean
+  retrying: boolean
+  notionReady: boolean
+  notionState: Record<number, NotionSaveState>
+  onNotionSave: (idx: number) => void
+}
+
+export function ChatMessageList({
+  messages,
+  busy,
+  retrying,
+  notionReady,
+  notionState,
+  onNotionSave,
+}: Props) {
+  return (
+    <Card>
+      <CardContent
+        className="max-h-[60vh] space-y-3 overflow-y-auto pt-6"
+        data-testid="chat-log"
+      >
+        {messages.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Ask anything about today&apos;s briefing — e.g.
+            {" "}&ldquo;半導体セクターの新着リスクは？&rdquo;
+          </p>
+        ) : (
+          messages.map((m, i) => (
+            <div
+              key={i}
+              className={cn(
+                "rounded-md border p-3 text-sm",
+                m.role === "user"
+                  ? "border-primary/30 bg-primary/5"
+                  : "border-muted bg-muted/30",
+              )}
+              data-testid={`chat-msg-${m.role}`}
+            >
+              <p className="mb-1 text-[10px] font-medium uppercase text-muted-foreground">
+                {m.role}
+              </p>
+              {m.role === "assistant" ? (
+                m.content ? (
+                  <div className="prose prose-sm max-w-none dark:prose-invert">
+                    <ReactMarkdown
+                      remarkPlugins={[remarkGfm]}
+                      rehypePlugins={[rehypeSanitize]}
+                    >
+                      {m.content}
+                    </ReactMarkdown>
+                  </div>
+                ) : busy && i === messages.length - 1 && !m.cancelled ? (
+                  <LoadingDots label="調査中" data-testid="chat-thinking" />
+                ) : null
+              ) : (
+                <p className="whitespace-pre-wrap">{m.content}</p>
+              )}
+              {m.error && (
+                <p
+                  className="mt-2 text-xs text-destructive"
+                  data-testid="chat-error"
+                >
+                  {m.error}
+                </p>
+              )}
+              {m.role === "assistant" && m.cancelled && (
+                <p
+                  className="mt-2 text-xs text-muted-foreground"
+                  data-testid="chat-cancelled"
+                >
+                  Cancelled
+                </p>
+              )}
+              {m.role === "assistant" && m.content && (
+                <NotionSaveRow
+                  state={notionState[i]}
+                  // Disable while this assistant message is still streaming
+                  // (last message + busy) so the user can't persist a
+                  // partial answer.
+                  enabled={notionReady && !(busy && i === messages.length - 1)}
+                  onSave={() => onNotionSave(i)}
+                />
+              )}
+            </div>
+          ))
+        )}
+        {retrying && (
+          <p
+            className="text-xs text-muted-foreground"
+            data-testid="chat-retrying"
+          >
+            Session expired upstream, retrying…
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function NotionSaveRow({
+  state,
+  enabled,
+  onSave,
+}: {
+  state: NotionSaveState | undefined
+  enabled: boolean
+  onSave: () => void
+}) {
+  const status: NotionSaveState["status"] = state?.status ?? "idle"
+  const disabled = !enabled || status === "saving" || status === "saved"
+  const title = enabled
+    ? undefined
+    : "Notion 認証情報が未設定です（Credentials タブで設定してください）"
+  return (
+    <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={onSave}
+        disabled={disabled}
+        title={title}
+        data-testid="notion-save-button"
+      >
+        {status === "saving"
+          ? "追記中…"
+          : status === "saved"
+          ? "✓ Notion に追記済"
+          : "Notion ブリーフィングに追記"}
+      </Button>
+      {status === "saved" && state?.url && (
+        <a
+          href={state.url}
+          target="_blank"
+          rel="noreferrer"
+          className="text-primary underline"
+          data-testid="notion-save-link"
+        >
+          ページを開く
+        </a>
+      )}
+      {status === "error" && state?.error && (
+        <span className="text-destructive" data-testid="notion-save-error">
+          {state.error}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/apps/web/components/screens/ChatForm.tsx
+++ b/apps/web/components/screens/ChatForm.tsx
@@ -1,23 +1,16 @@
 "use client"
 import { useCallback, useEffect, useRef, useState } from "react"
-import ReactMarkdown from "react-markdown"
-import rehypeSanitize from "rehype-sanitize"
-import remarkGfm from "remark-gfm"
 
+import { ChatComposer } from "@/components/chat/ChatComposer"
+import { ChatMessageList } from "@/components/chat/ChatMessageList"
 import { SessionExpiredCard } from "@/components/SessionExpiredCard"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent } from "@/components/ui/card"
-import { LoadingDots } from "@/components/ui/loading-dots"
 import { useChatState } from "@/lib/chatStore"
 import { useAbortableMount } from "@/lib/hooks/useAbortableMount"
 import { useDraftPersistence } from "@/lib/hooks/useDraftPersistence"
 import { useNotionCredentials } from "@/lib/hooks/useNotionCredentials"
-import {
-  useNotionSave,
-  type NotionSaveState,
-} from "@/lib/hooks/useNotionSave"
+import { useNotionSave } from "@/lib/hooks/useNotionSave"
 import { useSpeechRecognition } from "@/lib/hooks/useSpeechRecognition"
-import { cn, formatLocalDate } from "@/lib/utils"
+import { formatLocalDate } from "@/lib/utils"
 
 type SSEEvent = { type: string; data: string }
 
@@ -45,60 +38,6 @@ function parseSSE(buffer: string): { events: SSEEvent[]; rest: string } {
   return { events, rest }
 }
 
-function NotionSaveRow({
-  state,
-  enabled,
-  onSave,
-}: {
-  state: NotionSaveState | undefined
-  enabled: boolean
-  onSave: () => void
-}) {
-  const status: NotionSaveState["status"] = state?.status ?? "idle"
-  const disabled = !enabled || status === "saving" || status === "saved"
-  const title = enabled
-    ? undefined
-    : "Notion 認証情報が未設定です（Credentials タブで設定してください）"
-  return (
-    <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        onClick={onSave}
-        disabled={disabled}
-        title={title}
-        data-testid="notion-save-button"
-      >
-        {status === "saving"
-          ? "追記中…"
-          : status === "saved"
-          ? "✓ Notion に追記済"
-          : "Notion ブリーフィングに追記"}
-      </Button>
-      {status === "saved" && state?.url && (
-        <a
-          href={state.url}
-          target="_blank"
-          rel="noreferrer"
-          className="text-primary underline"
-          data-testid="notion-save-link"
-        >
-          ページを開く
-        </a>
-      )}
-      {status === "error" && state?.error && (
-        <span
-          className="text-destructive"
-          data-testid="notion-save-error"
-        >
-          {state.error}
-        </span>
-      )}
-    </div>
-  )
-}
-
 export function ChatForm() {
   const { messages, setMessages } = useChatState()
   const { draft: input, setDraft: setInput } = useDraftPersistence({
@@ -115,7 +54,6 @@ export function ChatForm() {
 
   // Suppress setState and cancel in-flight work after unmount.
   const { mountedRef, abortRef } = useAbortableMount()
-  const composingRef = useRef(false)
   // The question currently in flight — restored into the textarea on cancel
   // so the user can edit and resend without retyping.
   const pendingQuestionRef = useRef("")
@@ -292,162 +230,24 @@ export function ChatForm() {
 
   return (
     <div className="space-y-4">
-      <Card>
-        <CardContent
-          className="max-h-[60vh] space-y-3 overflow-y-auto pt-6"
-          data-testid="chat-log"
-        >
-          {messages.length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              Ask anything about today&apos;s briefing — e.g.
-              {" "}&ldquo;半導体セクターの新着リスクは？&rdquo;
-            </p>
-          ) : (
-            messages.map((m, i) => (
-              <div
-                key={i}
-                className={cn(
-                  "rounded-md border p-3 text-sm",
-                  m.role === "user"
-                    ? "border-primary/30 bg-primary/5"
-                    : "border-muted bg-muted/30",
-                )}
-                data-testid={`chat-msg-${m.role}`}
-              >
-                <p className="mb-1 text-[10px] font-medium uppercase text-muted-foreground">
-                  {m.role}
-                </p>
-                {m.role === "assistant" ? (
-                  m.content ? (
-                    <div className="prose prose-sm max-w-none dark:prose-invert">
-                      <ReactMarkdown
-                        remarkPlugins={[remarkGfm]}
-                        rehypePlugins={[rehypeSanitize]}
-                      >
-                        {m.content}
-                      </ReactMarkdown>
-                    </div>
-                  ) : busy && i === messages.length - 1 && !m.cancelled ? (
-                    <LoadingDots
-                      label="調査中"
-                      data-testid="chat-thinking"
-                    />
-                  ) : null
-                ) : (
-                  <p className="whitespace-pre-wrap">{m.content}</p>
-                )}
-                {m.error && (
-                  <p
-                    className="mt-2 text-xs text-destructive"
-                    data-testid="chat-error"
-                  >
-                    {m.error}
-                  </p>
-                )}
-                {m.role === "assistant" && m.cancelled && (
-                  <p
-                    className="mt-2 text-xs text-muted-foreground"
-                    data-testid="chat-cancelled"
-                  >
-                    Cancelled
-                  </p>
-                )}
-                {m.role === "assistant" && m.content && (
-                  <NotionSaveRow
-                    state={notionState[i]}
-                    // Disable while this assistant message is still streaming
-                    // (last message + busy) so the user can't persist a
-                    // partial answer.
-                    enabled={
-                      notionReady && !(busy && i === messages.length - 1)
-                    }
-                    onSave={() => void saveToNotion(i)}
-                  />
-                )}
-              </div>
-            ))
-          )}
-          {retrying && (
-            <p
-              className="text-xs text-muted-foreground"
-              data-testid="chat-retrying"
-            >
-              Session expired upstream, retrying…
-            </p>
-          )}
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardContent className="space-y-2 pt-6">
-          <div className="flex items-end gap-2">
-            <textarea
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              onCompositionStart={() => {
-                composingRef.current = true
-              }}
-              onCompositionEnd={() => {
-                composingRef.current = false
-              }}
-              onKeyDown={(e) => {
-                if (
-                  e.key === "Enter" &&
-                  !e.shiftKey &&
-                  !composingRef.current &&
-                  !e.nativeEvent.isComposing
-                ) {
-                  e.preventDefault()
-                  void send()
-                }
-              }}
-              placeholder="Ask about today's briefing…"
-              rows={2}
-              className="flex-1 resize-none rounded-md border bg-background px-3 py-2 text-sm"
-              data-testid="chat-input"
-            />
-            {supportsMic && (
-              <Button
-                type="button"
-                variant={listening ? "destructive" : "outline"}
-                onClick={() => toggleMic(input)}
-                data-testid="mic-button"
-                aria-pressed={listening}
-                title={listening ? "音声入力停止" : "音声入力開始 (ja-JP)"}
-              >
-                {listening ? "🛑" : "🎤"}
-              </Button>
-            )}
-            {busy ? (
-              <Button
-                type="button"
-                variant="destructive"
-                onClick={cancel}
-                data-testid="cancel-button"
-                title="送信中の応答を中止 (Esc)"
-              >
-                Cancel
-              </Button>
-            ) : (
-              <Button
-                onClick={() => void send()}
-                disabled={input.trim().length === 0}
-                data-testid="send-button"
-              >
-                Send
-              </Button>
-            )}
-          </div>
-          {!supportsMic && (
-            <p
-              className="text-xs text-muted-foreground"
-              data-testid="mic-unsupported"
-            >
-              Voice input is unavailable in this browser (Chrome / Edge supported).
-            </p>
-          )}
-        </CardContent>
-      </Card>
+      <ChatMessageList
+        messages={messages}
+        busy={busy}
+        retrying={retrying}
+        notionReady={notionReady}
+        notionState={notionState}
+        onNotionSave={(idx) => void saveToNotion(idx)}
+      />
+      <ChatComposer
+        input={input}
+        setInput={setInput}
+        busy={busy}
+        supportsMic={supportsMic}
+        listening={listening}
+        onToggleMic={toggleMic}
+        onSend={() => void send()}
+        onCancel={cancel}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
Step **2 of 4** of the ChatForm refactor sequence. Pulls two pure-JSX clusters out of `ChatForm.tsx` (453 → 253 LOC) under new `apps/web/components/chat/`:

| Component | Concern | LOC |
|---|---|---|
| `ChatMessageList` | Chat-log Card + co-located `NotionSaveRow` | 163 |
| `ChatComposer` | Textarea + mic + send/cancel buttons; owns its own `composingRef` (IME guard) | 105 |

ChatForm is now orchestration-only — state plumbing + `stream`/`send`/`cancel` callbacks. The next step pulls those into a `useChatStream` hook.

No behavior changes. The tests don't move; existing chat-form suite still exercises every reachable testid through `<ChatForm>`.

## Test plan
- [x] `npm run test` — 85 tests pass (unchanged from Step 1)
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [ ] Manual smoke: send / cancel / mic toggle / Notion save still work end to end

## Refactor sequence (for context)
1. hooks extraction ✅ (#118)
2. **This PR** — component extraction
3. `useChatStream` (stream / send / cancel / Esc / abortRef)
4. `notion.py` split (markdown converter vs API client)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Chat UI split into separate composer and message-list components for more modular behavior without changing user workflows.

* **New Features**
  * Improved message list with empty-state, per-message save actions, retrying notice, streaming “thinking” indicator, and clearer cancelled/error displays.
  * Composer now supports IME-safe Enter-to-send, microphone toggle, and context-aware Send/Cancel states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->