### PR TITLE
fix(web): keep mic stop working after StrictMode remount

### DIFF
--- a/apps/web/lib/hooks/useSpeechRecognition.ts
+++ b/apps/web/lib/hooks/useSpeechRecognition.ts
@@ -54,6 +54,11 @@ export function useSpeechRecognition({
   callbackRef.current = onTranscript
 
   useEffect(() => {
+    // React Strict Mode (and any unmount/remount cycle) runs the cleanup
+    // between mounts; without re-arming mountedRef here it stays false on
+    // the second mount, which causes the rec.onend stop callback to skip
+    // setListening(false) and leave the mic UI stuck in the listening state.
+    mountedRef.current = true
     setSupportsMic(getRecognitionCtor() !== null)
     return () => {
       mountedRef.current = false

--- a/apps/web/tests/chat-form.test.tsx
+++ b/apps/web/tests/chat-form.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import { StrictMode } from "react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { ChatForm } from "@/components/screens/ChatForm"
@@ -10,6 +11,16 @@ function renderChatForm() {
     <ChatStateProvider>
       <ChatForm />
     </ChatStateProvider>,
+  )
+}
+
+function renderChatFormStrict() {
+  return render(
+    <StrictMode>
+      <ChatStateProvider>
+        <ChatForm />
+      </ChatStateProvider>
+    </StrictMode>,
   )
 }
 
@@ -283,6 +294,58 @@ describe("ChatForm", () => {
     })
 
     expect(screen.getByTestId("chat-input")).toHaveValue("前段の文字列 音声入力")
+  })
+
+  it("returns the mic button to idle after stop, even under StrictMode double-mount", async () => {
+    type FakeRec = {
+      lang: string
+      continuous: boolean
+      interimResults: boolean
+      onresult: ((e: { results: { 0: { transcript: string } }[] }) => void) | null
+      onend: (() => void) | null
+      onerror: ((e: unknown) => void) | null
+      start: () => void
+      stop: () => void
+    }
+    class FakeRecognition implements FakeRec {
+      lang = ""
+      continuous = false
+      interimResults = false
+      onresult: FakeRec["onresult"] = null
+      onend: FakeRec["onend"] = null
+      onerror: FakeRec["onerror"] = null
+      start() {}
+      stop() {
+        // Simulate the browser firing onend in response to stop().
+        this.onend?.()
+      }
+    }
+    ;(window as unknown as { SpeechRecognition: unknown }).SpeechRecognition =
+      FakeRecognition
+
+    const user = userEvent.setup()
+    renderChatFormStrict()
+
+    const micBtn = await screen.findByTestId("mic-button")
+    expect(micBtn).toHaveAttribute("aria-pressed", "false")
+
+    await user.click(micBtn)
+    expect(screen.getByTestId("mic-button")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    )
+
+    // Click again to stop. Before the fix, StrictMode's mount → cleanup →
+    // remount sequence left mountedRef stuck at false, so the onend stop
+    // callback would skip setListening(false) and the button would stay
+    // pressed.
+    await user.click(screen.getByTestId("mic-button"))
+    await waitFor(() => {
+      expect(screen.getByTestId("mic-button")).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      )
+    })
   })
 
   it("hydrates the input from sessionStorage on mount", async () => {


### PR DESCRIPTION
## Summary
Regression introduced in #118 (`useSpeechRecognition` extraction). The hook never re-armed `mountedRef` on the second mount of React Strict Mode's mount → cleanup → remount cycle, so the `rec.onend` stop callback's guard

```ts
if (mountedRef.current) setListening(false)
```

silently skipped the UI update. Symptom: clicking the mic button to stop did nothing — `aria-pressed` stayed `true` and the button remained in the destructive "listening" variant.

## Fix
One line: re-arm `mountedRef.current = true` at the top of the effect, matching the pattern used by `useAbortableMount`.

```ts
useEffect(() => {
  mountedRef.current = true   // ← added
  setSupportsMic(getRecognitionCtor() !== null)
  return () => {
    mountedRef.current = false
    recRef.current?.stop()
  }
}, [])
```

## Regression test
`tests/chat-form.test.tsx`: renders `<ChatForm>` inside `<StrictMode>`, clicks the mic to start (FakeRecognition fires onend on stop), clicks again to stop, waits for `aria-pressed=false`. Without the fix this test times out at the `waitFor`.

## Test plan
- [x] `npm run test` — 86 tests pass (1 new)
- [x] Confirmed the new test **fails** before the fix (button stays `aria-pressed="true"`)
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] Manual smoke in dev server: start mic → stop mic → button returns to idle 🎤

## Note
PR #120 (Step 2 refactor) is also open against `dev` and does not touch the hook. Merge order doesn't matter; whichever lands first, the other rebases cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)