### PR TITLE
refactor(python): add chat_job_store with replay buffer + process handle

### DIFF
--- a/apps/python/src/chat_job_store.py
+++ b/apps/python/src/chat_job_store.py
@@ -1,0 +1,143 @@
+"""In-memory store for Q&A chat background jobs.
+
+Mirrors ``src.job_store`` for briefing runs but with chat-specific fields:
+
+- ``events``: bounded ring buffer of SSE-encoded bytes so a re-attaching
+  client can replay everything since the subprocess started (needed to
+  survive tab switches and page reloads — see #112 / #126).
+- ``process``: the live ``subprocess.Popen`` handle so the cancel and
+  grace-timeout paths can reach it.
+
+Phase 1 single-process assumption matches ``src.job_store``; swap for
+Redis-class storage when going multi-worker.
+"""
+import subprocess
+import threading
+import uuid
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+from src.job_store import JobStatus
+
+# Caps the replay buffer per job. ~1000 SSE events covers a long answer
+# (thousands of tokens at one line per event) while bounding memory.
+DEFAULT_EVENT_BUFFER_MAX = 1000
+
+
+@dataclass
+class ChatJob:
+    job_id: str
+    status: JobStatus
+    started_at: str | None = None
+    finished_at: str | None = None
+    error: str | None = None
+    events: deque[bytes] = field(
+        default_factory=lambda: deque(maxlen=DEFAULT_EVENT_BUFFER_MAX),
+    )
+    process: subprocess.Popen | None = None
+
+
+_lock = threading.Lock()
+_store: dict[str, ChatJob] = {}
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def create_job() -> ChatJob:
+    job_id = str(uuid.uuid4())
+    job = ChatJob(job_id=job_id, status="pending")
+    with _lock:
+        _store[job_id] = job
+    return job
+
+
+def get_job(job_id: str) -> ChatJob | None:
+    with _lock:
+        return _store.get(job_id)
+
+
+def mark_running(job_id: str) -> ChatJob | None:
+    with _lock:
+        job = _store.get(job_id)
+        if not job:
+            return None
+        job.status = "running"
+        job.started_at = _now_iso()
+        return job
+
+
+def mark_done(job_id: str) -> ChatJob | None:
+    with _lock:
+        job = _store.get(job_id)
+        if not job:
+            return None
+        job.status = "done"
+        job.finished_at = _now_iso()
+        return job
+
+
+def mark_failed(job_id: str, error: str) -> ChatJob | None:
+    with _lock:
+        job = _store.get(job_id)
+        if not job:
+            return None
+        job.status = "failed"
+        job.finished_at = _now_iso()
+        job.error = error
+        return job
+
+
+def append_event(job_id: str, event: bytes) -> bool:
+    """Append an SSE-encoded event to the job's replay buffer.
+
+    Returns ``True`` if the job existed (event was buffered) or ``False``
+    if the job is unknown (event dropped). The bounded ``deque`` silently
+    trims the oldest event when the cap is reached.
+    """
+    with _lock:
+        job = _store.get(job_id)
+        if not job:
+            return False
+        job.events.append(event)
+        return True
+
+
+def attach_process(job_id: str, process: subprocess.Popen) -> None:
+    """Record the subprocess handle so cancel / grace-timeout can reach it.
+
+    Silent no-op if the job is already missing (already GC'd)."""
+    with _lock:
+        job = _store.get(job_id)
+        if job is not None:
+            job.process = process
+
+
+def detach_process(job_id: str) -> None:
+    """Clear the subprocess handle once the process has exited.
+
+    The events buffer is intentionally preserved so a late-attaching client
+    can still replay the full transcript."""
+    with _lock:
+        job = _store.get(job_id)
+        if job is not None:
+            job.process = None
+
+
+def remove_job(job_id: str) -> ChatJob | None:
+    """Drop the job from the store.
+
+    The caller is responsible for terminating the subprocess if one is
+    still attached — we keep that explicit so callers don't hold the
+    store lock across a slow ``terminate()``/``wait()``.
+    """
+    with _lock:
+        return _store.pop(job_id, None)
+
+
+def _reset_for_tests() -> None:
+    """Test-only: clear the store so individual tests don't see each other's jobs."""
+    with _lock:
+        _store.clear()

--- a/apps/python/tests/test_chat_job_store.py
+++ b/apps/python/tests/test_chat_job_store.py
@@ -1,0 +1,129 @@
+"""Tests for src/chat_job_store.py — in-memory chat job store."""
+import subprocess
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+
+from src import chat_job_store
+
+
+@pytest.fixture(autouse=True)
+def reset_store():
+    chat_job_store._reset_for_tests()
+    yield
+    chat_job_store._reset_for_tests()
+
+
+def test_create_job_assigns_uuid_and_pending_defaults():
+    job = chat_job_store.create_job()
+    uuid.UUID(job.job_id)  # raises if not a valid UUID
+    assert job.status == "pending"
+    assert job.started_at is None
+    assert job.finished_at is None
+    assert job.error is None
+    assert len(job.events) == 0
+    assert job.process is None
+
+
+def test_create_job_returns_unique_ids():
+    j1 = chat_job_store.create_job()
+    j2 = chat_job_store.create_job()
+    assert j1.job_id != j2.job_id
+
+
+def test_get_job_returns_created_job():
+    job = chat_job_store.create_job()
+    assert chat_job_store.get_job(job.job_id) is job
+
+
+def test_get_job_returns_none_for_unknown():
+    assert chat_job_store.get_job("nope") is None
+
+
+def test_mark_running_sets_status_and_started_at():
+    job = chat_job_store.create_job()
+    updated = chat_job_store.mark_running(job.job_id)
+    assert updated is job
+    assert job.status == "running"
+    assert job.started_at is not None
+
+
+def test_mark_done_sets_finished_at():
+    job = chat_job_store.create_job()
+    chat_job_store.mark_done(job.job_id)
+    assert job.status == "done"
+    assert job.finished_at is not None
+
+
+def test_mark_failed_records_error_and_finished_at():
+    job = chat_job_store.create_job()
+    chat_job_store.mark_failed(job.job_id, "boom")
+    assert job.status == "failed"
+    assert job.error == "boom"
+    assert job.finished_at is not None
+
+
+def test_state_transitions_for_unknown_job_return_none():
+    assert chat_job_store.mark_running("nope") is None
+    assert chat_job_store.mark_done("nope") is None
+    assert chat_job_store.mark_failed("nope", "x") is None
+
+
+def test_append_event_buffers_in_order_and_returns_true():
+    job = chat_job_store.create_job()
+    assert chat_job_store.append_event(job.job_id, b"data: a\n\n") is True
+    assert chat_job_store.append_event(job.job_id, b"data: b\n\n") is True
+    assert list(job.events) == [b"data: a\n\n", b"data: b\n\n"]
+
+
+def test_append_event_returns_false_for_unknown_job():
+    assert chat_job_store.append_event("nope", b"data: lost\n\n") is False
+
+
+def test_event_buffer_trims_oldest_at_max(monkeypatch):
+    # The field default factory reads DEFAULT_EVENT_BUFFER_MAX at call time,
+    # so monkeypatching before create_job() changes the maxlen of new deques.
+    monkeypatch.setattr(chat_job_store, "DEFAULT_EVENT_BUFFER_MAX", 3)
+    job = chat_job_store.create_job()
+    for i in range(5):
+        chat_job_store.append_event(job.job_id, f"data: {i}\n\n".encode())
+    assert list(job.events) == [b"data: 2\n\n", b"data: 3\n\n", b"data: 4\n\n"]
+
+
+def test_attach_process_records_handle():
+    job = chat_job_store.create_job()
+    fake_proc = MagicMock(spec=subprocess.Popen)
+    chat_job_store.attach_process(job.job_id, fake_proc)
+    assert job.process is fake_proc
+
+
+def test_attach_process_silent_on_unknown_job():
+    fake_proc = MagicMock(spec=subprocess.Popen)
+    # Must not raise even though no job exists for this id.
+    chat_job_store.attach_process("nope", fake_proc)
+
+
+def test_detach_process_clears_handle_but_keeps_events():
+    job = chat_job_store.create_job()
+    chat_job_store.attach_process(job.job_id, MagicMock(spec=subprocess.Popen))
+    chat_job_store.append_event(job.job_id, b"data: kept\n\n")
+    chat_job_store.detach_process(job.job_id)
+    assert job.process is None
+    assert list(job.events) == [b"data: kept\n\n"]
+
+
+def test_detach_process_silent_on_unknown_job():
+    # Must not raise.
+    chat_job_store.detach_process("nope")
+
+
+def test_remove_job_pops_and_returns_the_job():
+    job = chat_job_store.create_job()
+    removed = chat_job_store.remove_job(job.job_id)
+    assert removed is job
+    assert chat_job_store.get_job(job.job_id) is None
+
+
+def test_remove_job_returns_none_for_unknown():
+    assert chat_job_store.remove_job("nope") is None


### PR DESCRIPTION
## Summary
First step of Epic #126 (jobify Q&A chat — Option B from #112). Introduces a parallel store for chat jobs alongside `src.job_store` rather than discriminating on a `kind` field — the chat-only fields would otherwise leak as `Optional[None]` into every briefing job.

`ChatJob` carries:
- a bounded `deque[bytes]` of SSE-encoded events so a re-attaching client (#125) can replay the full transcript after a tab switch / reload
- a `subprocess.Popen` handle so the cancel and grace-timeout paths in #123 can reach it

Store API mirrors `job_store` (`create_job` / `get_job` / `mark_*`) plus chat-specific `append_event` / `attach_process` / `detach_process` / `remove_job`. `JobStatus` is imported from `job_store` so the two stores stay in sync if the status set evolves.

**No HTTP endpoint changes in this PR** — that lands in #123.

## Test plan
- [x] `pytest -q` — 325 tests pass (17 new in `test_chat_job_store.py`; existing `test_job_store.py` and `test_api_run.py` unchanged)
- [x] `chat_job_store.py` at 100% line coverage in the new tests
- [x] No edits to `src/job_store.py` or any `/api/run` code path

Closes #122 — Epic: #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)