### PR TITLE
fix(python): retry claude CLI on socket-close and network errors

### DIFF
--- a/apps/python/src/claude_runner.py
+++ b/apps/python/src/claude_runner.py
@@ -1,5 +1,4 @@
 import os
-import re
 import shutil
 import subprocess
 import time
@@ -13,22 +12,15 @@ from src.constants import (
     RETRY_MAX_ATTEMPTS,
 )
 from src.logger import get_logger
+from src.transient_errors import is_transient
 
 logger = get_logger(__name__)
-
-# Anthropic API の 5xx 系一時障害 (例: "API Error: 529 Overloaded.") を検出
-_TRANSIENT_ERROR_RE = re.compile(r"API Error:\s*5\d\d")
 
 
 def get_model() -> str:
     """環境変数 CLAUDE_MODEL を読み、空・空白の場合はデフォルトを返す。"""
     env_model = os.environ.get("CLAUDE_MODEL", "").strip()
     return env_model if env_model else DEFAULT_MODEL
-
-
-def _is_transient_error(stdout: str, stderr: str) -> bool:
-    """stdout/stderr に Anthropic API の 5xx エラー表記が含まれるか判定する。"""
-    return bool(_TRANSIENT_ERROR_RE.search((stdout or "") + "\n" + (stderr or "")))
 
 
 def _backoff_delay(attempt: int) -> float:
@@ -111,7 +103,7 @@ def run_claude(
         last_returncode = result.returncode
         last_detail = (result.stderr or result.stdout or "").strip()
 
-        if _is_transient_error(result.stdout, result.stderr) and attempt < max_attempts:
+        if is_transient(result.stdout, result.stderr) and attempt < max_attempts:
             delay = _backoff_delay(attempt)
             logger.warning(
                 "一時的なエラーを検出、%.1fs 後にリトライします [%s] (attempt %d/%d)",

--- a/apps/python/src/transient_errors.py
+++ b/apps/python/src/transient_errors.py
@@ -1,0 +1,41 @@
+"""Classifier for transient claude CLI failures that warrant a retry.
+
+The claude CLI surfaces upstream Anthropic API errors and node-fetch
+network errors verbatim in its stdout/stderr. Both categories include
+genuinely transient conditions (overload, dropped sockets, DNS hiccups)
+that recover within seconds, so ``run_claude`` retries them with
+exponential backoff. Permanent errors (auth, bad request, invalid model)
+must NOT be retried — retrying them only wastes the cron's wall-clock
+budget and can amplify the failure.
+
+This module is the single place to extend that policy: append a new
+compiled pattern to ``_TRANSIENT_PATTERNS`` with a one-line comment
+recording where the symptom was first observed.
+"""
+
+import re
+
+_TRANSIENT_PATTERNS: list[re.Pattern[str]] = [
+    # Anthropic API 5xx (e.g. "API Error: 529 Overloaded.")
+    re.compile(r"API Error:\s*5\d\d"),
+    # node-fetch socket-close (observed 2026-06-05 on briefing + weekly jobs)
+    re.compile(r"socket connection was closed unexpectedly", re.IGNORECASE),
+    # node-fetch generic network failure
+    re.compile(r"\bfetch failed\b", re.IGNORECASE),
+    # libc/Node networking errno strings bubbled up from the underlying fetch
+    re.compile(r"\b(?:ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|ENETUNREACH)\b"),
+]
+
+
+def is_transient(stdout: str | None, stderr: str | None) -> bool:
+    """Return True if the combined stdout+stderr matches a known transient
+    failure signature.
+
+    Callers should pair this with a bounded retry + exponential backoff
+    policy. Never call in a tight loop — the patterns also match recoverable
+    server overloads that need time to drain.
+    """
+    haystack = (stdout or "") + "\n" + (stderr or "")
+    if not haystack.strip():
+        return False
+    return any(p.search(haystack) for p in _TRANSIENT_PATTERNS)

--- a/apps/python/tests/test_claude_runner.py
+++ b/apps/python/tests/test_claude_runner.py
@@ -123,6 +123,31 @@ class TestRunClaudeRetry:
         assert mock_run.call_count == 2
         assert mock_sleep.call_count == 1
 
+    def test_retries_on_socket_close(self):
+        """Verifies: the node-fetch 'socket connection was closed unexpectedly'
+        message (no HTTP code) is detected as transient and retried.
+        Why: regression for the weekly job failure on 2026-06-05. Previously
+        the classifier only matched 5xx codes, so this short-circuited after
+        a single attempt and required manual rerun.
+        """
+        error_result = _make_result(
+            returncode=1,
+            stdout="API Error: The socket connection was closed unexpectedly. "
+            "For more information, pass `verbose: true` in the second argument to fetch()",
+        )
+        success_result = _make_result(returncode=0, stdout="recovered")
+
+        with patch("src.claude_runner.shutil.which", return_value="/usr/bin/claude"):
+            with patch("src.claude_runner.time.sleep"):
+                with patch(
+                    "src.claude_runner.subprocess.run",
+                    side_effect=[error_result, success_result],
+                ) as mock_run:
+                    result = run_claude("prompt", "test")
+
+        assert result == "recovered"
+        assert mock_run.call_count == 2
+
     def test_retries_on_503_in_stdout(self):
         """Verifies: a 5xx error written to stdout (not stderr) is still
         detected and retried.

--- a/apps/python/tests/test_transient_errors.py
+++ b/apps/python/tests/test_transient_errors.py
@@ -1,0 +1,76 @@
+"""Unit tests for src.transient_errors.is_transient.
+
+This module classifies claude CLI stdout/stderr to decide whether a
+non-zero exit should be retried with backoff. Adding a pattern here is
+the supported extension point; these tests pin the current set so future
+changes are intentional.
+"""
+
+import pytest
+
+from src.transient_errors import is_transient
+
+
+class TestIsTransient:
+    @pytest.mark.parametrize(
+        "haystack",
+        [
+            "API Error: 529 Overloaded.",
+            "API Error: 503 Service Unavailable",
+            "API Error: 500 Internal Server Error",
+            "API Error: 504 Gateway Timeout",
+        ],
+    )
+    def test_5xx_codes_are_transient(self, haystack):
+        assert is_transient(haystack, "") is True
+        assert is_transient("", haystack) is True
+
+    def test_socket_close_is_transient(self):
+        """Regression: weekly job 2026-06-05 07:41 raised this and was not
+        retried because the previous classifier only matched 5xx codes."""
+        msg = (
+            "API Error: The socket connection was closed unexpectedly. "
+            "For more information, pass `verbose: true` in the second argument to fetch()"
+        )
+        assert is_transient(msg, "") is True
+
+    @pytest.mark.parametrize(
+        "haystack",
+        [
+            "fetch failed",
+            "FetchError: Connection reset by peer (ECONNRESET)",
+            "connect ECONNREFUSED 127.0.0.1:443",
+            "request to https://api.anthropic.com failed, reason: ETIMEDOUT",
+            "getaddrinfo EAI_AGAIN api.anthropic.com",
+        ],
+    )
+    def test_network_level_errors_are_transient(self, haystack):
+        assert is_transient(haystack, "") is True
+
+    @pytest.mark.parametrize(
+        "haystack",
+        [
+            "API Error: 401 Unauthorized",
+            "API Error: 400 Bad Request",
+            "API Error: 404 Not Found",
+            "Invalid model: foo",
+            "auth error",
+            "",
+        ],
+    )
+    def test_non_transient_errors_are_not_retried(self, haystack):
+        assert is_transient(haystack, "") is False
+        assert is_transient("", haystack) is False
+
+    def test_none_inputs_are_handled(self):
+        assert is_transient(None, None) is False
+        assert is_transient(None, "API Error: 529 Overloaded") is True
+        assert is_transient("API Error: 529 Overloaded", None) is True
+
+    def test_matches_across_stdout_and_stderr_combined(self):
+        """The classifier searches stdout + stderr together, so a token split
+        across the two should still match (defensive — the CLI does not
+        actually split messages, but the contract is 'either stream')."""
+        assert is_transient("API Error: 5", "29 Overloaded") is False
+        assert is_transient("API Error: 503", "extra noise") is True
+        assert is_transient("noise", "API Error: 503") is True


### PR DESCRIPTION
## Summary
- 週次/ブリーフィングが socket close でリトライされず失敗していた件を修正
- 判定ロジックを `src/transient_errors.py` に分離し 5xx/socket/ECONN*/fetch failed を網羅

## Test plan
- [x] `pytest -v` 全 344 件パス

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error detection to properly identify and retry on transient failures including socket closures, network connectivity issues, and API rate-limiting responses.

* **Tests**
  * Added test coverage for socket closure handling and comprehensive transient error classification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->