### PR TITLE
refactor(web): extract createJobStoreProvider factory from jobStore

### DIFF
--- a/apps/web/lib/createJobStoreProvider.tsx
+++ b/apps/web/lib/createJobStoreProvider.tsx
@@ -24,7 +24,6 @@ import {
 export type JobStoreSetState<State> = (mapper: (prev: State) => State) => void
 
 export type StartCtx<State> = {
-  signal: AbortSignal
   setState: JobStoreSetState<State>
 }
 
@@ -68,6 +67,10 @@ export type JobStoreConfig<State, StartOpts> = {
    * Kicks the job off. Called from the consumer's startJob callback. Receives
    * a setState that's NOT jobId-bound (the loop hasn't started yet, and the
    * caller is the one assigning the new jobId via setState).
+   *
+   * No abort signal is provided — startJob is treated as fire-and-forget. If
+   * a caller needs cancellation for its initial POST, it owns an
+   * AbortController inside the callback.
    */
   start: (opts: StartOpts, ctx: StartCtx<State>) => Promise<void>
   /**
@@ -209,11 +212,10 @@ export function createJobStoreProvider<State, StartOpts>(
     }, [hydrated, jobId, inFlight])
 
     const startJob = useCallback(async (opts: StartOpts) => {
-      const ctl = new AbortController()
       const unboundSetState: JobStoreSetState<State> = (mapper) => {
         setStateRaw(mapper)
       }
-      await start(opts, { signal: ctl.signal, setState: unboundSetState })
+      await start(opts, { setState: unboundSetState })
     }, [])
 
     const reset = useCallback(() => {

--- a/apps/web/lib/createJobStoreProvider.tsx
+++ b/apps/web/lib/createJobStoreProvider.tsx
@@ -1,0 +1,248 @@
+"use client"
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react"
+
+/**
+ * Generic factory for `/api/...` job-backed React stores.
+ *
+ * Extracted from `jobStore.tsx` so the chat-flavored store (#125) can layer on
+ * the same lifecycle scaffolding — sessionStorage hydration, jobId-bound state
+ * updates, AbortController cleanup — without copy-pasting the polling loop.
+ *
+ * The factory does *not* know the protocol: it only owns the React lifecycle.
+ * The caller's ``start`` and ``watch`` callbacks decide how to talk to the
+ * backend (HTTP POST + polling for /run, SSE for chat).
+ */
+
+export type JobStoreSetState<State> = (mapper: (prev: State) => State) => void
+
+export type StartCtx<State> = {
+  signal: AbortSignal
+  setState: JobStoreSetState<State>
+}
+
+export type WatchCtx<State> = {
+  signal: AbortSignal
+  /**
+   * setState wrapper that no-ops when the caller's `jobId` no longer matches
+   * the state's current jobId — protects against late dispatches from a
+   * watch loop that has already been superseded by a newer job.
+   */
+  setState: JobStoreSetState<State>
+}
+
+export type JobStoreConfig<State, StartOpts> = {
+  /** sessionStorage key. Bump (e.g. ``...v2``) if the persisted shape changes incompatibly. */
+  storageKey: string
+  initialState: State
+  /** Identity of the current job — used to bind watch dispatches and key the watch effect. */
+  getJobId: (s: State) => string | null
+  /** Whether the state needs the watch lifecycle running. */
+  isInFlight: (s: State) => boolean
+  /**
+   * Whether to persist the current state. Default: persist when a jobId or
+   * surfacing-worthy fields exist (caller-defined). When this returns false,
+   * the persisted entry is removed instead of overwritten.
+   */
+  isPersistable: (s: State) => boolean
+  /**
+   * Whether a hydrated snapshot is unresumable and should be dropped on load
+   * (e.g. status=pending without a jobId — nothing to poll). Defaults to
+   * "in-flight with no jobId".
+   */
+  isUnresumable?: (s: State) => boolean
+  /**
+   * Transform state right before it's serialized to sessionStorage. Use to
+   * strip UI-only fields (e.g. transient flags) that must not survive a reload.
+   * Defaults to identity.
+   */
+  serializeForStorage?: (s: State) => State
+  /**
+   * Kicks the job off. Called from the consumer's startJob callback. Receives
+   * a setState that's NOT jobId-bound (the loop hasn't started yet, and the
+   * caller is the one assigning the new jobId via setState).
+   */
+  start: (opts: StartOpts, ctx: StartCtx<State>) => Promise<void>
+  /**
+   * Runs while a job is in-flight. Caller owns the protocol (polling / SSE /
+   * whatever). The provided setState is auto-guarded by the jobId the watch
+   * was started with, so a stale callback can't clobber a newer job.
+   *
+   * Honor ``ctx.signal``: the factory aborts on jobId change, status leaving
+   * in-flight, or unmount.
+   */
+  watch: (jobId: string, ctx: WatchCtx<State>) => Promise<void>
+}
+
+export type JobStoreContextValue<State, StartOpts> = State & {
+  /** True while the job is in flight (mirror of ``isInFlight(state)``). */
+  isBackgrounded: boolean
+  startJob: (opts: StartOpts) => Promise<void>
+  reset: () => void
+}
+
+function loadPersisted<State>(
+  storageKey: string,
+  initialState: State,
+  isUnresumable: (s: State) => boolean,
+): State {
+  if (typeof window === "undefined") return initialState
+  try {
+    const raw = window.sessionStorage.getItem(storageKey)
+    if (!raw) return initialState
+    const parsed = JSON.parse(raw) as Partial<State>
+    const next = { ...initialState, ...parsed } as State
+    if (isUnresumable(next)) return initialState
+    return next
+  } catch {
+    return initialState
+  }
+}
+
+function persistTo<State>(storageKey: string, state: State): void {
+  if (typeof window === "undefined") return
+  try {
+    window.sessionStorage.setItem(storageKey, JSON.stringify(state))
+  } catch {
+    // quota / unavailable — state remains in memory for the tab
+  }
+}
+
+function clearPersistedFrom(storageKey: string): void {
+  if (typeof window === "undefined") return
+  try {
+    window.sessionStorage.removeItem(storageKey)
+  } catch {
+    // ignore
+  }
+}
+
+export type CreatedJobStore<State, StartOpts> = {
+  Provider: (props: { children: ReactNode }) => JSX.Element
+  useStore: () => JobStoreContextValue<State, StartOpts>
+}
+
+export function createJobStoreProvider<State, StartOpts>(
+  config: JobStoreConfig<State, StartOpts>,
+): CreatedJobStore<State, StartOpts> {
+  const {
+    storageKey,
+    initialState,
+    getJobId,
+    isInFlight,
+    isPersistable,
+    isUnresumable = (s) => isInFlight(s) && getJobId(s) === null,
+    serializeForStorage = (s) => s,
+    start,
+    watch,
+  } = config
+
+  type Value = JobStoreContextValue<State, StartOpts>
+  const Context = createContext<Value | null>(null)
+
+  function Provider({ children }: { children: ReactNode }): JSX.Element {
+    // Render initialState on first paint so SSR and the first client render
+    // agree (sessionStorage is unavailable on the server). The hydrate effect
+    // promotes state to whatever was persisted in this tab.
+    const [state, setStateRaw] = useState<State>(initialState)
+    const [hydrated, setHydrated] = useState(false)
+
+    useEffect(() => {
+      setStateRaw(loadPersisted(storageKey, initialState, isUnresumable))
+      setHydrated(true)
+    }, [])
+
+    useEffect(() => {
+      if (!hydrated) return
+      if (isPersistable(state)) {
+        persistTo(storageKey, serializeForStorage(state))
+      } else {
+        clearPersistedFrom(storageKey)
+      }
+    }, [state, hydrated])
+
+    const jobId = getJobId(state)
+    const inFlight = isInFlight(state)
+
+    // Watch lifecycle: runs while an in-flight job with a jobId is present.
+    // Aborted/cleaned up on jobId change, status leaving in-flight, or unmount.
+    useEffect(() => {
+      if (!hydrated) return
+      if (!jobId) return
+      if (!inFlight) return
+
+      const ctl = new AbortController()
+      let stopped = false
+
+      const stop = () => {
+        stopped = true
+        ctl.abort()
+      }
+
+      const boundSetState: JobStoreSetState<State> = (mapper) => {
+        if (stopped) return
+        setStateRaw((prev) => {
+          // jobId changed since this watch started → drop the late dispatch.
+          if (getJobId(prev) !== jobId) return prev
+          return mapper(prev)
+        })
+      }
+
+      ;(async () => {
+        try {
+          await watch(jobId, { signal: ctl.signal, setState: boundSetState })
+        } catch {
+          // The watch callback owns its own error handling via setState. A
+          // raw throw here usually means an abort race — swallow it so the
+          // unmount cleanup path stays quiet.
+        }
+      })()
+
+      return stop
+    }, [hydrated, jobId, inFlight])
+
+    const startJob = useCallback(async (opts: StartOpts) => {
+      const ctl = new AbortController()
+      const unboundSetState: JobStoreSetState<State> = (mapper) => {
+        setStateRaw(mapper)
+      }
+      await start(opts, { signal: ctl.signal, setState: unboundSetState })
+    }, [])
+
+    const reset = useCallback(() => {
+      setStateRaw(initialState)
+      clearPersistedFrom(storageKey)
+    }, [])
+
+    const value = useMemo<Value>(
+      () => ({
+        ...state,
+        isBackgrounded: inFlight,
+        startJob,
+        reset,
+      }),
+      [state, inFlight, startJob, reset],
+    )
+
+    return <Context.Provider value={value}>{children}</Context.Provider>
+  }
+
+  function useStore(): Value {
+    const ctx = useContext(Context)
+    if (!ctx) {
+      throw new Error(
+        "useStore must be used inside the Provider returned by createJobStoreProvider",
+      )
+    }
+    return ctx
+  }
+
+  return { Provider, useStore }
+}

--- a/apps/web/lib/jobStore.tsx
+++ b/apps/web/lib/jobStore.tsx
@@ -1,13 +1,7 @@
 "use client"
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-  type ReactNode,
-} from "react"
+import type { ReactNode } from "react"
+
+import { createJobStoreProvider } from "./createJobStoreProvider"
 
 export type JobStatus = "idle" | "pending" | "running" | "done" | "failed"
 
@@ -44,7 +38,7 @@ const initialState: JobState = {
   sessionExpired: false,
 }
 
-const isInFlight = (s: JobStatus) => s === "pending" || s === "running"
+const isInFlightStatus = (s: JobStatus) => s === "pending" || s === "running"
 const isTerminal = (s: JobStatus) => s === "done" || s === "failed"
 
 type ApiJobDetail = {
@@ -56,196 +50,25 @@ type ApiJobDetail = {
   error?: string | null
 }
 
-function loadPersisted(): JobState {
-  if (typeof window === "undefined") return initialState
-  try {
-    const raw = window.sessionStorage.getItem(STORAGE_KEY)
-    if (!raw) return initialState
-    const parsed = JSON.parse(raw) as Partial<JobState>
-    const next = { ...initialState, ...parsed, sessionExpired: false }
-    // Drop unresumable snapshots: an in-flight status with no jobId can only
-    // come from the brief window between startJob() flipping status to
-    // "pending" and the POST returning. Polling has nothing to resume on.
-    if (!next.jobId && isInFlight(next.status)) return initialState
-    return next
-  } catch {
-    return initialState
-  }
-}
+const { Provider, useStore } = createJobStoreProvider<JobState, StartOpts>({
+  storageKey: STORAGE_KEY,
+  initialState,
+  getJobId: (s) => s.jobId,
+  isInFlight: (s) => isInFlightStatus(s.status),
+  // sessionExpired is UI-only; never persist it. Persist when there's anything
+  // worth resuming: a jobId or a surfaced error message.
+  isPersistable: (s) => Boolean(s.jobId) || Boolean(s.error),
+  serializeForStorage: (s) => ({ ...s, sessionExpired: false }),
 
-function persist(state: JobState) {
-  if (typeof window === "undefined") return
-  try {
-    // sessionExpired is UI-only; never persist it
-    const toStore = { ...state, sessionExpired: false }
-    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(toStore))
-  } catch {
-    // quota / unavailable — state remains in memory for the tab
-  }
-}
-
-function clearPersisted() {
-  if (typeof window === "undefined") return
-  try {
-    window.sessionStorage.removeItem(STORAGE_KEY)
-  } catch {
-    // ignore
-  }
-}
-
-const JobStateContext = createContext<JobStateContextValue | null>(null)
-
-export function JobStateProvider({ children }: { children: ReactNode }) {
-  // Render initialState on first paint so SSR and the first client render
-  // agree (sessionStorage is unavailable on the server). The hydrate effect
-  // below promotes state to whatever was persisted in this tab.
-  const [state, setState] = useState<JobState>(initialState)
-  const [hydrated, setHydrated] = useState(false)
-
-  useEffect(() => {
-    setState(loadPersisted())
-    setHydrated(true)
-  }, [])
-
-  useEffect(() => {
-    if (!hydrated) return
-    // Don't persist if there's nothing recoverable: no jobId AND no error to
-    // surface. This covers idle and the transient "pending without jobId"
-    // window during startJob() before the POST returns.
-    if (!state.jobId && !state.error) {
-      clearPersisted()
-    } else {
-      persist(state)
-    }
-  }, [state, hydrated])
-
-  const inFlight = isInFlight(state.status)
-
-  // Polling loop. Runs while an in-flight job is present; aborted/cleaned up
-  // on jobId change, status leaving in-flight, or unmount. Mount with a
-  // persisted in-flight job resumes polling per the acceptance criteria.
-  useEffect(() => {
-    if (!hydrated) return
-    if (!state.jobId) return
-    if (!inFlight) return
-
-    const jobId = state.jobId
-    const ctl = new AbortController()
-    const pollStartedAt = Date.now()
-    let stopped = false
-
-    const stop = () => {
-      stopped = true
-      ctl.abort()
-    }
-
-    ;(async () => {
-      while (!stopped) {
-        await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS))
-        if (stopped) return
-        if (Date.now() - pollStartedAt > POLL_TIMEOUT_MS) {
-          setState((prev) =>
-            prev.jobId === jobId
-              ? {
-                  ...prev,
-                  status: "failed",
-                  error: "Timed out waiting for the job to finish",
-                }
-              : prev,
-          )
-          return
-        }
-        try {
-          const res = await fetch(`/api/run/${jobId}`, {
-            cache: "no-store",
-            signal: ctl.signal,
-          })
-          if (stopped) return
-          if (res.status === 401) {
-            setState((prev) =>
-              prev.jobId === jobId
-                ? { ...prev, sessionExpired: true }
-                : prev,
-            )
-            return
-          }
-          if (res.status === 404) {
-            // Backend no longer knows this job (process restart, eviction).
-            // Per AC: clear state cleanly with an informative message.
-            setState((prev) =>
-              prev.jobId === jobId
-                ? {
-                    ...initialState,
-                    error:
-                      "The previous background job is no longer available — please run it again.",
-                  }
-                : prev,
-            )
-            return
-          }
-          if (!res.ok) {
-            setState((prev) =>
-              prev.jobId === jobId
-                ? {
-                    ...prev,
-                    status: "failed",
-                    error: `GET /api/run/${jobId} failed (HTTP ${res.status})`,
-                  }
-                : prev,
-            )
-            return
-          }
-          const detail = (await res.json()) as ApiJobDetail
-          if (stopped) return
-          setState((prev) =>
-            prev.jobId === jobId
-              ? {
-                  ...prev,
-                  status: detail.status,
-                  startedAt: detail.started_at ?? prev.startedAt,
-                  finishedAt: detail.finished_at ?? prev.finishedAt,
-                  // dry_run is set on the POST response; preserve it across GETs that omit it
-                  dryRun: detail.dry_run ?? prev.dryRun,
-                  error:
-                    detail.status === "failed"
-                      ? detail.error ?? "Job failed without an error message"
-                      : prev.error,
-                }
-                : prev,
-          )
-          if (isTerminal(detail.status)) return
-        } catch (e) {
-          if (stopped) return
-          setState((prev) =>
-            prev.jobId === jobId
-              ? {
-                  ...prev,
-                  status: "failed",
-                  error: e instanceof Error ? e.message : "Network error",
-                }
-              : prev,
-          )
-          return
-        }
-      }
-    })()
-
-    return stop
-  }, [hydrated, state.jobId, inFlight])
-
-  const startJob = useCallback(async ({ dryRun }: StartOpts) => {
-    setState({
-      ...initialState,
-      status: "pending",
-      dryRun,
-    })
+  start: async ({ dryRun }, { setState }) => {
+    setState(() => ({ ...initialState, status: "pending", dryRun }))
     try {
       const res = await fetch(`/api/run${dryRun ? "?dry_run=true" : ""}`, {
         method: "POST",
         cache: "no-store",
       })
       if (res.status === 401) {
-        setState({ ...initialState, sessionExpired: true })
+        setState(() => ({ ...initialState, sessionExpired: true }))
         return
       }
       if (!res.ok) {
@@ -273,34 +96,81 @@ export function JobStateProvider({ children }: { children: ReactNode }) {
         error: e instanceof Error ? e.message : "Network error",
       }))
     }
-  }, [])
+  },
 
-  const reset = useCallback(() => {
-    setState(initialState)
-    clearPersisted()
-  }, [])
+  watch: async (jobId, { signal, setState }) => {
+    const pollStartedAt = Date.now()
+    while (!signal.aborted) {
+      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS))
+      if (signal.aborted) return
+      if (Date.now() - pollStartedAt > POLL_TIMEOUT_MS) {
+        setState((prev) => ({
+          ...prev,
+          status: "failed",
+          error: "Timed out waiting for the job to finish",
+        }))
+        return
+      }
+      try {
+        const res = await fetch(`/api/run/${jobId}`, {
+          cache: "no-store",
+          signal,
+        })
+        if (signal.aborted) return
+        if (res.status === 401) {
+          setState((prev) => ({ ...prev, sessionExpired: true }))
+          return
+        }
+        if (res.status === 404) {
+          // Backend no longer knows this job (process restart, eviction).
+          // Per AC: clear state cleanly with an informative message.
+          setState(() => ({
+            ...initialState,
+            error:
+              "The previous background job is no longer available — please run it again.",
+          }))
+          return
+        }
+        if (!res.ok) {
+          setState((prev) => ({
+            ...prev,
+            status: "failed",
+            error: `GET /api/run/${jobId} failed (HTTP ${res.status})`,
+          }))
+          return
+        }
+        const detail = (await res.json()) as ApiJobDetail
+        if (signal.aborted) return
+        setState((prev) => ({
+          ...prev,
+          status: detail.status,
+          startedAt: detail.started_at ?? prev.startedAt,
+          finishedAt: detail.finished_at ?? prev.finishedAt,
+          // dry_run is set on the POST response; preserve it across GETs that omit it
+          dryRun: detail.dry_run ?? prev.dryRun,
+          error:
+            detail.status === "failed"
+              ? detail.error ?? "Job failed without an error message"
+              : prev.error,
+        }))
+        if (isTerminal(detail.status)) return
+      } catch (e) {
+        if (signal.aborted) return
+        setState((prev) => ({
+          ...prev,
+          status: "failed",
+          error: e instanceof Error ? e.message : "Network error",
+        }))
+        return
+      }
+    }
+  },
+})
 
-  const value = useMemo<JobStateContextValue>(
-    () => ({
-      ...state,
-      isBackgrounded: inFlight,
-      startJob,
-      reset,
-    }),
-    [state, inFlight, startJob, reset],
-  )
-
-  return (
-    <JobStateContext.Provider value={value}>
-      {children}
-    </JobStateContext.Provider>
-  )
+export function JobStateProvider({ children }: { children: ReactNode }) {
+  return <Provider>{children}</Provider>
 }
 
 export function useJobState(): JobStateContextValue {
-  const ctx = useContext(JobStateContext)
-  if (!ctx) {
-    throw new Error("useJobState must be used inside <JobStateProvider>")
-  }
-  return ctx
+  return useStore()
 }

--- a/apps/web/tests/create-job-store-provider.test.tsx
+++ b/apps/web/tests/create-job-store-provider.test.tsx
@@ -1,0 +1,315 @@
+import { act, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { createJobStoreProvider, type WatchCtx } from "@/lib/createJobStoreProvider"
+
+// Minimal non-/run consumer: a fake "chat-like" store with a different state
+// shape. Exercises the factory's lifecycle scaffolding (sessionStorage hydrate,
+// watch loop, jobId-bound dispatches, reset) without depending on /run.
+
+type FakeStatus = "idle" | "running" | "done" | "failed"
+
+type FakeState = {
+  jobId: string | null
+  status: FakeStatus
+  events: string[]
+  error: string | null
+}
+
+const STORAGE_KEY = "test:fake-store:v1"
+
+const initialState: FakeState = {
+  jobId: null,
+  status: "idle",
+  events: [],
+  error: null,
+}
+
+function makeStore(opts: {
+  watch: (
+    jobId: string,
+    ctx: { signal: AbortSignal; setState: (m: (s: FakeState) => FakeState) => void },
+  ) => Promise<void>
+  start?: (
+    jobId: string,
+    ctx: { signal: AbortSignal; setState: (m: (s: FakeState) => FakeState) => void },
+  ) => Promise<void>
+}) {
+  return createJobStoreProvider<FakeState, { jobId: string }>({
+    storageKey: STORAGE_KEY,
+    initialState,
+    getJobId: (s) => s.jobId,
+    isInFlight: (s) => s.status === "running",
+    isPersistable: (s) => Boolean(s.jobId) || Boolean(s.error),
+    start: async ({ jobId }, ctx) => {
+      ctx.setState(() => ({ ...initialState, jobId, status: "running" }))
+      if (opts.start) await opts.start(jobId, ctx)
+    },
+    watch: opts.watch,
+  })
+}
+
+function Probe({ useStore }: { useStore: () => FakeState & { startJob: (o: { jobId: string }) => Promise<void>; reset: () => void; isBackgrounded: boolean } }) {
+  const s = useStore()
+  return (
+    <div>
+      <div data-testid="jobId">{s.jobId ?? ""}</div>
+      <div data-testid="status">{s.status}</div>
+      <div data-testid="events">{s.events.join(",")}</div>
+      <div data-testid="error">{s.error ?? ""}</div>
+      <div data-testid="bg">{s.isBackgrounded ? "yes" : "no"}</div>
+      <button data-testid="start" onClick={() => s.startJob({ jobId: "new-1" })}>start</button>
+      <button data-testid="reset" onClick={s.reset}>reset</button>
+    </div>
+  )
+}
+
+describe("createJobStoreProvider — generic lifecycle", () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+  afterEach(() => {
+    sessionStorage.clear()
+    vi.useRealTimers()
+  })
+
+  it("hydrates a persisted in-flight snapshot and triggers the watch loop", async () => {
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ jobId: "resume-1", status: "running", events: ["a"], error: null }),
+    )
+    const watch = vi.fn(async (_jobId: string, { setState }: WatchCtx<FakeState>) => {
+      setState((prev) => ({ ...prev, events: [...prev.events, "b"], status: "done" }))
+    })
+    const { Provider, useStore } = makeStore({ watch })
+
+    render(
+      <Provider>
+        <Probe useStore={useStore} />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status")).toHaveTextContent("done")
+    })
+    expect(watch).toHaveBeenCalledTimes(1)
+    expect(watch.mock.calls[0][0]).toBe("resume-1")
+    expect(screen.getByTestId("events")).toHaveTextContent("a,b")
+  })
+
+  it("does not run watch for a hydrated terminal snapshot", async () => {
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ jobId: "done-1", status: "done", events: ["x"], error: null }),
+    )
+    const watch = vi.fn(async () => {})
+    const { Provider, useStore } = makeStore({ watch })
+
+    render(
+      <Provider>
+        <Probe useStore={useStore} />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status")).toHaveTextContent("done")
+    })
+    await new Promise((r) => setTimeout(r, 20))
+    expect(watch).not.toHaveBeenCalled()
+  })
+
+  it("drops an unresumable snapshot (in-flight with no jobId) on hydrate", async () => {
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ jobId: null, status: "running", events: [], error: null }),
+    )
+    const watch = vi.fn(async () => {})
+    const { Provider, useStore } = makeStore({ watch })
+
+    render(
+      <Provider>
+        <Probe useStore={useStore} />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status")).toHaveTextContent("idle")
+    })
+    expect(screen.getByTestId("jobId")).toHaveTextContent("")
+    expect(watch).not.toHaveBeenCalled()
+  })
+
+  it("ignores late watch dispatches after the jobId has changed", async () => {
+    let releaseFirstWatch: (() => void) | null = null
+    const firstWatchStarted = new Promise<void>((resolve) => {
+      releaseFirstWatch = resolve
+    })
+
+    const watch = vi.fn(async (jobId: string, { signal, setState }: WatchCtx<FakeState>) => {
+      if (jobId === "resume-1") {
+        // Wait until we've swapped to a new jobId, then try to write — the
+        // factory's bound setState must drop this update.
+        await firstWatchStarted
+        if (signal.aborted) return
+        setState((prev) => ({ ...prev, events: [...prev.events, "stale!"] }))
+        return
+      }
+      setState((prev) => ({ ...prev, status: "done", events: [...prev.events, "fresh"] }))
+    })
+
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ jobId: "resume-1", status: "running", events: [], error: null }),
+    )
+    const { Provider, useStore } = makeStore({ watch })
+
+    render(
+      <Provider>
+        <Probe useStore={useStore} />
+      </Provider>,
+    )
+
+    await waitFor(() => expect(watch).toHaveBeenCalledTimes(1))
+
+    // Swap to a new jobId via startJob; this aborts the first watch and starts
+    // a new one. After the new one runs, release the first so it tries (and
+    // should fail) to write back.
+    await act(async () => {
+      screen.getByTestId("start").click()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status")).toHaveTextContent("done")
+    })
+    await act(async () => {
+      releaseFirstWatch?.()
+      // Give the first watch a chance to dispatch.
+      await new Promise((r) => setTimeout(r, 10))
+    })
+
+    // "stale!" must NOT appear — the bound setState dropped it.
+    expect(screen.getByTestId("events")).toHaveTextContent("fresh")
+    expect(screen.getByTestId("events")).not.toHaveTextContent("stale!")
+  })
+
+  it("clears persisted state on reset()", async () => {
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ jobId: "live-1", status: "done", events: ["a"], error: null }),
+    )
+    const watch = vi.fn(async () => {})
+    const { Provider, useStore } = makeStore({ watch })
+
+    render(
+      <Provider>
+        <Probe useStore={useStore} />
+      </Provider>,
+    )
+
+    await waitFor(() => expect(screen.getByTestId("jobId")).toHaveTextContent("live-1"))
+
+    await act(async () => {
+      screen.getByTestId("reset").click()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status")).toHaveTextContent("idle")
+    })
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it("applies serializeForStorage so UI-only fields don't survive a reload", async () => {
+    // A minimal store that surfaces an in-memory `transient` flag but strips
+    // it before persisting — mirrors the `sessionExpired` contract on /run.
+    type S = { jobId: string | null; transient: boolean; persistedNote: string }
+    const KEY = "test:serialize:v1"
+    const init: S = { jobId: null, transient: false, persistedNote: "" }
+    sessionStorage.clear()
+    const { Provider, useStore } = createJobStoreProvider<S, void>({
+      storageKey: KEY,
+      initialState: init,
+      getJobId: (s) => s.jobId,
+      isInFlight: () => false,
+      isPersistable: (s) => Boolean(s.jobId) || Boolean(s.persistedNote),
+      serializeForStorage: (s) => ({ ...s, transient: false }),
+      start: async (_opts, { setState }) => {
+        setState(() => ({ jobId: "kept", transient: true, persistedNote: "saved" }))
+      },
+      watch: async () => {},
+    })
+
+    function P() {
+      const s = useStore()
+      return (
+        <div>
+          <button data-testid="go" onClick={() => s.startJob()}>go</button>
+          <div data-testid="transient">{String(s.transient)}</div>
+        </div>
+      )
+    }
+
+    render(
+      <Provider>
+        <P />
+      </Provider>,
+    )
+    await act(async () => {
+      screen.getByTestId("go").click()
+    })
+
+    // In-memory: transient flag survives.
+    await waitFor(() => {
+      expect(screen.getByTestId("transient")).toHaveTextContent("true")
+    })
+    // On-disk: transient was stripped to false.
+    const raw = sessionStorage.getItem(KEY)
+    expect(raw).not.toBeNull()
+    const stored = JSON.parse(raw as string)
+    expect(stored.jobId).toBe("kept")
+    expect(stored.persistedNote).toBe("saved")
+    expect(stored.transient).toBe(false)
+    sessionStorage.clear()
+  })
+
+  it("aborts the watch when the provider unmounts mid-flight", async () => {
+    let abortedFlag = false
+    const watch = vi.fn(async (_jobId: string, { signal }: WatchCtx<FakeState>) => {
+      await new Promise<void>((resolve) => {
+        signal.addEventListener("abort", () => {
+          abortedFlag = true
+          resolve()
+        })
+      })
+    })
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ jobId: "live", status: "running", events: [], error: null }),
+    )
+    const { Provider, useStore } = makeStore({ watch })
+
+    const { unmount } = render(
+      <Provider>
+        <Probe useStore={useStore} />
+      </Provider>,
+    )
+
+    await waitFor(() => expect(watch).toHaveBeenCalledTimes(1))
+    unmount()
+    await waitFor(() => expect(abortedFlag).toBe(true))
+  })
+
+  it("useStore throws when used outside Provider", () => {
+    const { useStore } = makeStore({ watch: async () => {} })
+    function Bad() {
+      useStore()
+      return null
+    }
+    // Suppress React's expected error log for the failing render.
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {})
+    try {
+      expect(() => render(<Bad />)).toThrow(/createJobStoreProvider/)
+    } finally {
+      spy.mockRestore()
+    }
+  })
+})

--- a/apps/web/tests/create-job-store-provider.test.tsx
+++ b/apps/web/tests/create-job-store-provider.test.tsx
@@ -32,7 +32,7 @@ function makeStore(opts: {
   ) => Promise<void>
   start?: (
     jobId: string,
-    ctx: { signal: AbortSignal; setState: (m: (s: FakeState) => FakeState) => void },
+    ctx: { setState: (m: (s: FakeState) => FakeState) => void },
   ) => Promise<void>
 }) {
   return createJobStoreProvider<FakeState, { jobId: string }>({


### PR DESCRIPTION
## Summary
- Pulled `jobStore.tsx`'s polling useEffect + sessionStorage scaffolding into a generic `createJobStoreProvider<State, StartOpts>` factory in `apps/web/lib/createJobStoreProvider.tsx`.
- `jobStore.tsx` (308→89 LOC) is now a thin /run-specific config; existing exports unchanged.
- Chat store (#125) can layer on the same factory; AC #2 covered by 8 new factory unit tests using a fake non-/run consumer.

## Test plan
- [x] `npm run test` — 94 passed (6 existing job-store + 8 new factory)
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean

Closes #124.