### PR TITLE
feat(web): Up/Down arrow history recall in chat textarea

### DIFF
--- a/apps/web/components/chat/ChatComposer.tsx
+++ b/apps/web/components/chat/ChatComposer.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { useRef } from "react"
+import { useRef, type KeyboardEvent } from "react"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
@@ -15,6 +15,9 @@ type Props = {
   onToggleMic: (prefix: string) => void
   onSend: () => void
   onCancel: () => void
+  // Optional Up/Down/Esc history recall (Issue #117). When provided, runs
+  // after the IME + Enter guards so Enter-to-send still wins.
+  onHistoryKeyDown?: (e: KeyboardEvent<HTMLTextAreaElement>) => void
 }
 
 export function ChatComposer({
@@ -26,6 +29,7 @@ export function ChatComposer({
   onToggleMic,
   onSend,
   onCancel,
+  onHistoryKeyDown,
 }: Props) {
   // Tracks IME composition so Enter doesn't submit while picking kanji.
   const composingRef = useRef(false)
@@ -45,15 +49,15 @@ export function ChatComposer({
               composingRef.current = false
             }}
             onKeyDown={(e) => {
-              if (
-                e.key === "Enter" &&
-                !e.shiftKey &&
-                !composingRef.current &&
-                !e.nativeEvent.isComposing
-              ) {
+              // IME guard covers both Enter-to-send and history recall — Up/Down
+              // during kanji selection must move the suggestion cursor, not nav.
+              if (composingRef.current || e.nativeEvent.isComposing) return
+              if (e.key === "Enter" && !e.shiftKey) {
                 e.preventDefault()
                 onSend()
+                return
               }
+              onHistoryKeyDown?.(e)
             }}
             placeholder="Ask about today's briefing…"
             rows={2}

--- a/apps/web/components/screens/ChatForm.tsx
+++ b/apps/web/components/screens/ChatForm.tsx
@@ -1,11 +1,12 @@
 "use client"
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import { ChatComposer } from "@/components/chat/ChatComposer"
 import { ChatMessageList } from "@/components/chat/ChatMessageList"
 import { SessionExpiredCard } from "@/components/SessionExpiredCard"
 import { useChatState } from "@/lib/chatStore"
 import { useAbortableMount } from "@/lib/hooks/useAbortableMount"
+import { useChatHistoryNavigation } from "@/lib/hooks/useChatHistoryNavigation"
 import { useDraftPersistence } from "@/lib/hooks/useDraftPersistence"
 import { useNotionCredentials } from "@/lib/hooks/useNotionCredentials"
 import { useNotionSave } from "@/lib/hooks/useNotionSave"
@@ -54,6 +55,16 @@ export function ChatForm() {
 
   // Suppress setState and cancel in-flight work after unmount.
   const { mountedRef, abortRef } = useAbortableMount()
+  // Shell-style Up/Down history of prior user questions (Issue #117).
+  const userHistory = useMemo(
+    () => messages.filter((m) => m.role === "user").map((m) => m.content),
+    [messages],
+  )
+  const onHistoryKeyDown = useChatHistoryNavigation({
+    history: userHistory,
+    setInput,
+    busy,
+  })
   // The question currently in flight — restored into the textarea on cancel
   // so the user can edit and resend without retyping.
   const pendingQuestionRef = useRef("")
@@ -264,6 +275,7 @@ export function ChatForm() {
         onToggleMic={toggleMic}
         onSend={() => void send()}
         onCancel={cancel}
+        onHistoryKeyDown={onHistoryKeyDown}
       />
     </div>
   )

--- a/apps/web/lib/hooks/useChatHistoryNavigation.ts
+++ b/apps/web/lib/hooks/useChatHistoryNavigation.ts
@@ -1,0 +1,90 @@
+"use client"
+import { useCallback, useEffect, useRef, type KeyboardEvent } from "react"
+
+/**
+ * Shell-prompt-style history recall for the chat textarea.
+ *
+ * Up/Down walk back / forward through the user's prior questions. The first
+ * Up press snapshots whatever was in the textarea so Down-past-newest (or Esc)
+ * can restore it. Mid-navigation edits are *not* preserved across further
+ * keystrokes — matching readline/zsh: typing while navigating commits to that
+ * draft, then the next Up overwrites it.
+ *
+ * Caller is responsible for filtering out IME composition before delegating
+ * (so Enter-to-send and arrow-history share the same guard at the call site).
+ */
+export function useChatHistoryNavigation({
+  history,
+  setInput,
+  busy,
+}: {
+  /** User-question history, oldest → newest. */
+  history: string[]
+  setInput: (v: string) => void
+  /** Streaming flag — Esc is reserved for cancel while busy (Issue #98). */
+  busy: boolean
+}): (e: KeyboardEvent<HTMLTextAreaElement>) => void {
+  // -1 = not navigating. Otherwise an index into ``history``.
+  const indexRef = useRef(-1)
+  const savedDraftRef = useRef("")
+
+  // After a successful send, the new user message lands in ``history`` and
+  // input clears. Reset so the next Up starts a fresh cycle rather than
+  // walking from the stale index left behind by a half-navigated state.
+  useEffect(() => {
+    indexRef.current = -1
+    savedDraftRef.current = ""
+  }, [history.length])
+
+  return useCallback(
+    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      const ta = e.currentTarget
+
+      if (e.key === "ArrowUp") {
+        if (history.length === 0) return
+        // Multi-line caret guard: when the caret isn't on the first line of
+        // a multi-line draft, Up moves the caret naturally — don't hijack.
+        const beforeCaret = ta.value.slice(0, ta.selectionStart)
+        if (beforeCaret.includes("\n")) return
+        e.preventDefault()
+        if (indexRef.current === -1) {
+          savedDraftRef.current = ta.value
+          indexRef.current = history.length - 1
+        } else if (indexRef.current > 0) {
+          indexRef.current -= 1
+        }
+        setInput(history[indexRef.current])
+        return
+      }
+
+      if (e.key === "ArrowDown") {
+        if (indexRef.current === -1) return
+        const afterCaret = ta.value.slice(ta.selectionEnd)
+        if (afterCaret.includes("\n")) return
+        e.preventDefault()
+        if (indexRef.current < history.length - 1) {
+          indexRef.current += 1
+          setInput(history[indexRef.current])
+        } else {
+          // Past newest → restore the pre-nav draft and exit history mode.
+          setInput(savedDraftRef.current)
+          indexRef.current = -1
+          savedDraftRef.current = ""
+        }
+        return
+      }
+
+      if (e.key === "Escape") {
+        // Esc while streaming is the cancel hotkey (ChatForm's window-level
+        // handler owns that). Letting it bubble keeps cancel taking precedence.
+        if (busy) return
+        if (indexRef.current === -1) return
+        e.preventDefault()
+        setInput(savedDraftRef.current)
+        indexRef.current = -1
+        savedDraftRef.current = ""
+      }
+    },
+    [history, setInput, busy],
+  )
+}

--- a/apps/web/tests/chat-form.test.tsx
+++ b/apps/web/tests/chat-form.test.tsx
@@ -727,4 +727,173 @@ describe("ChatForm", () => {
       )
     })
   })
+
+  // ----- Up/Down history recall (Issue #117) ---------------------------
+
+  const CHAT_HISTORY_KEY = "ai-agent:chat-history:v1"
+
+  // Seed the chat store directly via sessionStorage so each test can start
+  // with a controlled history without going through real POST→stream
+  // roundtrips for every entry.
+  function seedHistory(questions: string[]): void {
+    const messages = questions.flatMap((q) => [
+      { role: "user" as const, content: q },
+      { role: "assistant" as const, content: "answer for " + q },
+    ])
+    window.sessionStorage.setItem(CHAT_HISTORY_KEY, JSON.stringify(messages))
+  }
+
+  function getInput(): HTMLTextAreaElement {
+    return screen.getByTestId("chat-input") as HTMLTextAreaElement
+  }
+
+  it("Up in an empty textarea recalls the most recent user question", async () => {
+    seedHistory(["first", "second", "third"])
+    renderChatForm()
+    const input = await screen.findByTestId("chat-input")
+    await waitFor(() => expect(input).toBeInTheDocument())
+
+    fireEvent.keyDown(input, { key: "ArrowUp" })
+    await waitFor(() => expect(input).toHaveValue("third"))
+  })
+
+  it("subsequent Up keystrokes walk further back through history", async () => {
+    seedHistory(["first", "second", "third"])
+    renderChatForm()
+    const input = getInput()
+
+    fireEvent.keyDown(input, { key: "ArrowUp" })
+    await waitFor(() => expect(input).toHaveValue("third"))
+    fireEvent.keyDown(input, { key: "ArrowUp" })
+    await waitFor(() => expect(input).toHaveValue("second"))
+    fireEvent.keyDown(input, { key: "ArrowUp" })
+    await waitFor(() => expect(input).toHaveValue("first"))
+    // Up at the oldest is a no-op (preventDefault keeps caret stable but
+    // value doesn't regress further).
+    fireEvent.keyDown(input, { key: "ArrowUp" })
+    await new Promise((r) => setTimeout(r, 10))
+    expect(input).toHaveValue("first")
+  })
+
+  it("Down walks forward and Down past newest restores the saved draft", async () => {
+    seedHistory(["first", "second"])
+    const user = userEvent.setup()
+    renderChatForm()
+    const input = getInput()
+    // User had a draft in progress before nav.
+    await user.type(input, "draft")
+
+    fireEvent.keyDown(input, { key: "ArrowUp" })
+    await waitFor(() => expect(input).toHaveValue("second"))
+    fireEvent.keyDown(input, { key: "ArrowUp" })
+    await waitFor(() => expect(input).toHaveValue("first"))
+    fireEvent.keyDown(input, { key: "ArrowDown" })
+    await waitFor(() => expect(input).toHaveValue("second"))
+    // Past the newest → original draft restored, nav state reset.
+    fireEvent.keyDown(input, { key: "ArrowDown" })
+    await waitFor(() => expect(input).toHaveValue("draft"))
+    // A subsequent Down without a prior Up is a no-op.
+    fireEvent.keyDown(input, { key: "ArrowDown" })
+    await new Promise((r) => setTimeout(r, 10))
+    expect(input).toHaveValue("draft")
+  })
+
+  it("Esc while navigating restores the draft without aborting any stream", async () => {
+    seedHistory(["older", "newer"])
+    const user = userEvent.setup()
+    renderChatForm()
+    const input = getInput()
+    await user.type(input, "in progress")
+
+    fireEvent.keyDown(input, { key: "ArrowUp" })
+    await waitFor(() => expect(input).toHaveValue("newer"))
+    fireEvent.keyDown(input, { key: "Escape" })
+    await waitFor(() => expect(input).toHaveValue("in progress"))
+    // After Esc resets nav, a fresh Up should re-snapshot (current "in
+    // progress") and walk to newest again.
+    fireEvent.keyDown(input, { key: "ArrowUp" })
+    await waitFor(() => expect(input).toHaveValue("newer"))
+    fireEvent.keyDown(input, { key: "ArrowDown" })
+    await waitFor(() => expect(input).toHaveValue("in progress"))
+  })
+
+  it("Up while IME composing does not navigate history", async () => {
+    seedHistory(["older"])
+    renderChatForm()
+    const input = getInput()
+
+    fireEvent.compositionStart(input)
+    fireEvent.keyDown(input, { key: "ArrowUp", isComposing: true })
+    await new Promise((r) => setTimeout(r, 10))
+    expect(input).toHaveValue("")
+    fireEvent.compositionEnd(input)
+    // After composition ends, Up works again.
+    fireEvent.keyDown(input, { key: "ArrowUp" })
+    await waitFor(() => expect(input).toHaveValue("older"))
+  })
+
+  it("Up with caret not on the first line of a multi-line draft does NOT recall", async () => {
+    seedHistory(["older"])
+    const user = userEvent.setup()
+    renderChatForm()
+    const input = getInput()
+    // Multi-line draft via Shift+Enter (avoids triggering send).
+    await user.type(input, "line1{Shift>}{Enter}{/Shift}line2")
+    expect(input.value).toBe("line1\nline2")
+
+    // Caret in the middle of line2 — Up should naturally move it to line1,
+    // not hijack to history recall.
+    input.selectionStart = 8
+    input.selectionEnd = 8
+    fireEvent.keyDown(input, { key: "ArrowUp" })
+    await new Promise((r) => setTimeout(r, 10))
+    expect(input).toHaveValue("line1\nline2")
+
+    // Caret on the first line → Up DOES recall, replacing the draft.
+    input.selectionStart = 2
+    input.selectionEnd = 2
+    fireEvent.keyDown(input, { key: "ArrowUp" })
+    await waitFor(() => expect(input).toHaveValue("older"))
+  })
+
+  it("Down with caret not on the last line of a multi-line draft does NOT exit recall", async () => {
+    seedHistory(["older"])
+    const user = userEvent.setup()
+    renderChatForm()
+    const input = getInput()
+
+    // Enter nav, then build a multi-line draft mid-nav (simulates edits).
+    fireEvent.keyDown(input, { key: "ArrowUp" })
+    await waitFor(() => expect(input).toHaveValue("older"))
+    await user.type(input, "{Shift>}{Enter}{/Shift}second")
+    expect(input.value).toBe("older\nsecond")
+
+    // Caret on the first line — Down should move it to line 2, not bail nav.
+    input.selectionStart = 2
+    input.selectionEnd = 2
+    fireEvent.keyDown(input, { key: "ArrowDown" })
+    await new Promise((r) => setTimeout(r, 10))
+    expect(input).toHaveValue("older\nsecond")
+  })
+
+  it("nav state resets after a successful send", async () => {
+    seedHistory(["seed"])
+    chatRoundtrip(() => sseResponse([{ data: "ok" }]))
+    const user = userEvent.setup()
+    renderChatForm()
+    const input = getInput()
+
+    fireEvent.keyDown(input, { key: "ArrowUp" })
+    await waitFor(() => expect(input).toHaveValue("seed"))
+    // Send the recalled question.
+    await user.click(screen.getByTestId("send-button"))
+    await waitFor(() => {
+      const all = screen.getAllByTestId("chat-msg-assistant")
+      expect(all[all.length - 1]).toHaveTextContent("ok")
+    })
+    // After send, input clears AND nav resets — the next Up should start
+    // from the newest entry again (which is now the just-sent question).
+    fireEvent.keyDown(input, { key: "ArrowUp" })
+    await waitFor(() => expect(input).toHaveValue("seed"))
+  })
 })


### PR DESCRIPTION
## Summary
- New ``useChatHistoryNavigation`` hook + wiring on ``ChatComposer`` so Up/Down walks through prior user questions like a shell prompt; Esc restores the saved draft.
- Multi-line caret guard (Up/Down on inner lines moves the caret normally), IME guard, and Esc-defers-to-cancel-while-streaming all covered.
- History state resets after a successful send (``history.length`` increment).

## Test plan
- [x] ``npm run test`` — 102 passed (8 new chat-form cases covering recall / Down restore / IME / multi-line caret guard / Esc / send-resets-nav)
- [x] ``npx tsc --noEmit`` — clean
- [x] ``npm run lint`` — clean
- [x] ``npm run build`` — clean
- [ ] Browser smoke on ``/chat`` — quick manual check recommended (I haven't spun the full stack)

Closes #117.