### PR TITLE
feat(web): chat uses job-backed store with SSE resume + e2e

### DIFF
--- a/apps/web/app/(main)/layout.tsx
+++ b/apps/web/app/(main)/layout.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation"
 
 import { apiFetch } from "@/lib/api"
 import { Sidebar } from "@/components/Sidebar"
+import { ChatJobStateProvider } from "@/lib/chatJobStore"
 import { ChatStateProvider } from "@/lib/chatStore"
 import { JobStateProvider } from "@/lib/jobStore"
 
@@ -28,10 +29,12 @@ export default async function MainLayout({
   return (
     <JobStateProvider>
       <ChatStateProvider>
-        <div className="flex min-h-screen">
-          <Sidebar />
-          <main className="flex-1 p-8">{children}</main>
-        </div>
+        <ChatJobStateProvider>
+          <div className="flex min-h-screen">
+            <Sidebar />
+            <main className="flex-1 p-8">{children}</main>
+          </div>
+        </ChatJobStateProvider>
       </ChatStateProvider>
     </JobStateProvider>
   )

--- a/apps/web/components/screens/ChatForm.tsx
+++ b/apps/web/components/screens/ChatForm.tsx
@@ -4,8 +4,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { ChatComposer } from "@/components/chat/ChatComposer"
 import { ChatMessageList } from "@/components/chat/ChatMessageList"
 import { SessionExpiredCard } from "@/components/SessionExpiredCard"
-import { useChatState } from "@/lib/chatStore"
-import { useAbortableMount } from "@/lib/hooks/useAbortableMount"
+import { useChatJobState } from "@/lib/chatJobStore"
+import { useChatState, type ChatMessage } from "@/lib/chatStore"
 import { useChatHistoryNavigation } from "@/lib/hooks/useChatHistoryNavigation"
 import { useDraftPersistence } from "@/lib/hooks/useDraftPersistence"
 import { useNotionCredentials } from "@/lib/hooks/useNotionCredentials"
@@ -13,230 +13,138 @@ import { useNotionSave } from "@/lib/hooks/useNotionSave"
 import { useSpeechRecognition } from "@/lib/hooks/useSpeechRecognition"
 import { formatLocalDate } from "@/lib/utils"
 
-type SSEEvent = { type: string; data: string }
-
 function today(): string {
   return formatLocalDate()
 }
 
-// Parse buffered SSE text. Events are terminated by a blank line ("\n\n");
-// multi-line `data:` fields are joined with "\n" per the SSE spec.
-function parseSSE(buffer: string): { events: SSEEvent[]; rest: string } {
-  const events: SSEEvent[] = []
-  let rest = buffer
-  let idx
-  while ((idx = rest.indexOf("\n\n")) !== -1) {
-    const raw = rest.slice(0, idx)
-    rest = rest.slice(idx + 2)
-    let type = "message"
-    const data: string[] = []
-    for (const line of raw.split("\n")) {
-      if (line.startsWith("event: ")) type = line.slice(7)
-      else if (line.startsWith("data: ")) data.push(line.slice(6))
-    }
-    events.push({ type, data: data.join("\n") })
-  }
-  return { events, rest }
-}
-
 export function ChatForm() {
-  const { messages, setMessages } = useChatState()
+  const { messages: committedMessages, setMessages } = useChatState()
+  const chatJob = useChatJobState()
   const { draft: input, setDraft: setInput } = useDraftPersistence({
     storageKey: "ai-agent:chat-draft:v1",
   })
-  const [busy, setBusy] = useState(false)
-  const [sessionExpired, setSessionExpired] = useState(false)
   const [retrying, setRetrying] = useState(false)
   const { notionReady } = useNotionCredentials()
   const { supportsMic, listening, toggle: toggleMic } = useSpeechRecognition({
     onTranscript: setInput,
   })
-  const { notionState, saveToNotion } = useNotionSave({ messages })
+  // Notion save targets committed turns only — never the in-flight one.
+  const { notionState, saveToNotion } = useNotionSave({
+    messages: committedMessages,
+  })
 
-  // Suppress setState and cancel in-flight work after unmount.
-  const { mountedRef, abortRef } = useAbortableMount()
-  // Shell-style Up/Down history of prior user questions (Issue #117).
+  // Latch to enforce "retry at most once per user send" across status flips.
+  // Reset each time the user invokes send() so the next turn gets its own
+  // budget. NOT persisted: a reload mid-retry just spends a fresh budget,
+  // which we consider acceptable since stale_session is rare.
+  const retriedRef = useRef(false)
+
+  // Up/Down history of prior user questions (Issue #117). The chatStore
+  // history is the durable source of truth.
   const userHistory = useMemo(
-    () => messages.filter((m) => m.role === "user").map((m) => m.content),
-    [messages],
+    () =>
+      committedMessages.filter((m) => m.role === "user").map((m) => m.content),
+    [committedMessages],
   )
+  const busy = chatJob.isBackgrounded
   const onHistoryKeyDown = useChatHistoryNavigation({
     history: userHistory,
     setInput,
     busy,
   })
-  // The question currently in flight — restored into the textarea on cancel
-  // so the user can edit and resend without retyping.
-  const pendingQuestionRef = useRef("")
 
-  // Drive one chat turn: POST kicks off a backend job (returns 202 + job_id),
-  // then GET /api/chat/{job_id}/stream tails the SSE buffer to completion.
-  // Returns "stale" iff the backend emitted the `stale_session` event — the
-  // caller retries exactly once.
-  const stream = useCallback(
-    async (
-      question: string,
-      ctl: AbortController,
-    ): Promise<"ok" | "stale" | "401"> => {
-      const post = await fetch("/api/chat", {
-        method: "POST",
-        cache: "no-store",
-        signal: ctl.signal,
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ date: today(), question }),
-      })
-      if (post.status === 401) return "401"
-      if (!post.ok) {
-        const text = await post.text().catch(() => "")
-        throw new Error(`POST /api/chat failed (HTTP ${post.status}): ${text}`)
-      }
-      const { job_id: jobId } = (await post.json()) as { job_id?: string }
-      if (!jobId) throw new Error("POST /api/chat returned no job_id")
-
-      const res = await fetch(`/api/chat/${jobId}/stream`, {
-        method: "GET",
-        cache: "no-store",
-        signal: ctl.signal,
-      })
-      if (res.status === 401) return "401"
-      if (!res.ok || !res.body) {
-        const text = await res.text().catch(() => "")
-        throw new Error(
-          `GET /api/chat/${jobId}/stream failed (HTTP ${res.status}): ${text}`,
-        )
-      }
-      const reader = res.body.getReader()
-      const decoder = new TextDecoder()
-      let buffer = ""
-      let stale = false
-      while (true) {
-        const { value, done } = await reader.read()
-        if (done) break
-        buffer += decoder.decode(value, { stream: true })
-        const { events, rest } = parseSSE(buffer)
-        buffer = rest
-        for (const ev of events) {
-          if (ctl.signal.aborted || !mountedRef.current) return "ok"
-          if (ev.type === "message") {
-            setMessages((prev) => {
-              const copy = [...prev]
-              const last = copy[copy.length - 1]
-              if (last && last.role === "assistant") {
-                copy[copy.length - 1] = {
-                  ...last,
-                  content: last.content + (last.content ? "\n" : "") + ev.data,
-                }
-              }
-              return copy
-            })
-          } else if (ev.type === "stale_session") {
-            stale = true
-          } else if (ev.type === "error") {
-            setMessages((prev) => {
-              const copy = [...prev]
-              const last = copy[copy.length - 1]
-              if (last && last.role === "assistant") {
-                copy[copy.length - 1] = {
-                  ...last,
-                  error: ev.data || "stream error",
-                }
-              }
-              return copy
-            })
-          }
-        }
-      }
-      return stale ? "stale" : "ok"
-    },
-    [mountedRef, setMessages],
+  // The user/assistant pair currently being streamed (or null when idle).
+  // Appended onto the committed list so ChatMessageList can render the
+  // in-flight turn without knowing the store split.
+  const inFlightTurn = useMemo<ChatMessage[] | null>(() => {
+    if (!chatJob.jobId && chatJob.status !== "pending") return null
+    if (!chatJob.question) return null
+    return [
+      { role: "user", content: chatJob.question },
+      {
+        role: "assistant",
+        content: chatJob.assistantContent,
+        error: chatJob.error,
+      },
+    ]
+  }, [
+    chatJob.jobId,
+    chatJob.status,
+    chatJob.question,
+    chatJob.assistantContent,
+    chatJob.error,
+  ])
+  const displayMessages = useMemo(
+    () =>
+      inFlightTurn ? [...committedMessages, ...inFlightTurn] : committedMessages,
+    [committedMessages, inFlightTurn],
   )
 
-  const send = useCallback(async () => {
+  const send = useCallback(() => {
     const question = input.trim()
     if (!question || busy) return
-
-    abortRef.current?.abort()
-    const ctl = new AbortController()
-    abortRef.current = ctl
-    pendingQuestionRef.current = question
-
     setInput("")
-    setBusy(true)
     setRetrying(false)
-    setSessionExpired(false)
-    setMessages((prev) => [
-      ...prev,
-      { role: "user", content: question },
-      { role: "assistant", content: "" },
-    ])
+    retriedRef.current = false
+    void chatJob.startJob({ question, date: today() })
+  }, [busy, chatJob, input, setInput])
 
-    try {
-      let result = await stream(question, ctl)
-      if (result === "401") {
-        setSessionExpired(true)
-        return
-      }
-      if (result === "stale") {
-        // Backend wiped .sessions/<date>; a single retry creates a fresh
-        // session and proceeds. Clear any partial output before re-streaming.
-        if (!mountedRef.current) return
-        setRetrying(true)
-        setMessages((prev) => {
-          const copy = [...prev]
-          const last = copy[copy.length - 1]
-          if (last && last.role === "assistant") {
-            copy[copy.length - 1] = { ...last, content: "", error: null }
-          }
-          return copy
-        })
-        result = await stream(question, ctl)
-        if (result === "401") {
-          setSessionExpired(true)
-          return
-        }
-      }
-    } catch (e) {
-      if (ctl.signal.aborted || !mountedRef.current) return
-      setMessages((prev) => {
-        const copy = [...prev]
-        const last = copy[copy.length - 1]
-        if (last && last.role === "assistant") {
-          copy[copy.length - 1] = {
-            ...last,
-            error: e instanceof Error ? e.message : "Network error",
-          }
-        }
-        return copy
-      })
-    } finally {
-      if (mountedRef.current) {
-        setBusy(false)
-        setRetrying(false)
-      }
-    }
-  }, [abortRef, busy, input, mountedRef, setInput, setMessages, stream])
-
-  // Abort the in-flight stream, mark the last assistant message as cancelled
-  // (distinct visual from an error), and restore the original question into
-  // the textarea so the user can edit and resend. `busy` flips back to false
-  // via send()'s finally{} once the abort propagates through the reader.
+  // Cancel: terminate the backend job, commit the partial answer as a
+  // cancelled turn to chat history, restore the question into the textarea
+  // for re-edit. We don't await DELETE — the user-facing UX should switch
+  // immediately, the backend cleanup is best-effort.
   const cancel = useCallback(() => {
-    const ctl = abortRef.current
-    if (!ctl || !busy) return
-    ctl.abort()
-    // Esc fires at window scope, so a late keystroke could land after unmount —
-    // skip the state writes if so. abort() above is safe either way.
-    if (!mountedRef.current) return
-    setInput(pendingQuestionRef.current)
-    setMessages((prev) => {
-      const copy = [...prev]
-      const last = copy[copy.length - 1]
-      if (last && last.role === "assistant") {
-        copy[copy.length - 1] = { ...last, cancelled: true, error: null }
-      }
-      return copy
-    })
-  }, [abortRef, busy, mountedRef, setInput, setMessages])
+    if (!busy) return
+    const jobId = chatJob.jobId
+    const question = chatJob.question
+    const partial = chatJob.assistantContent
+    if (jobId) {
+      void fetch(`/api/chat/${jobId}`, { method: "DELETE", cache: "no-store" })
+    }
+    if (question) {
+      setMessages((prev) => [
+        ...prev,
+        { role: "user", content: question },
+        { role: "assistant", content: partial, cancelled: true },
+      ])
+      setInput(question)
+    }
+    chatJob.reset()
+  }, [busy, chatJob, setInput, setMessages])
+
+  // Watch the job for terminal transitions: retry once on stale_session,
+  // otherwise commit the in-flight turn to chat history and reset the store.
+  // The store handles session expiry (renders the SessionExpiredCard guard
+  // below) so this effect skips that path.
+  useEffect(() => {
+    if (chatJob.sessionExpired) return
+    if (chatJob.status !== "done" && chatJob.status !== "failed") return
+    if (!chatJob.question) return
+
+    if (chatJob.staleSession && !retriedRef.current) {
+      retriedRef.current = true
+      const { question, date } = chatJob
+      setRetrying(true)
+      chatJob.reset()
+      void chatJob.startJob({ question, date }).finally(() => {
+        setRetrying(false)
+      })
+      return
+    }
+
+    const userMsg: ChatMessage = { role: "user", content: chatJob.question }
+    const assistantMsg: ChatMessage = {
+      role: "assistant",
+      content: chatJob.assistantContent,
+      error: chatJob.error,
+    }
+    setMessages((prev) => [...prev, userMsg, assistantMsg])
+    chatJob.reset()
+    // chatJob is read inside but excluded from deps — its identity flips on
+    // every render via the wrapping useMemo, and we only want this effect to
+    // fire on terminal status transitions.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chatJob.status, chatJob.sessionExpired])
 
   // Window-level Esc handler — only active while streaming so it doesn't
   // intercept Esc in other contexts (modals, popovers).
@@ -252,14 +160,14 @@ export function ChatForm() {
     return () => window.removeEventListener("keydown", onKeyDown)
   }, [busy, cancel])
 
-  if (sessionExpired) {
+  if (chatJob.sessionExpired) {
     return <SessionExpiredCard />
   }
 
   return (
     <div className="space-y-4">
       <ChatMessageList
-        messages={messages}
+        messages={displayMessages}
         busy={busy}
         retrying={retrying}
         notionReady={notionReady}
@@ -273,7 +181,7 @@ export function ChatForm() {
         supportsMic={supportsMic}
         listening={listening}
         onToggleMic={toggleMic}
-        onSend={() => void send()}
+        onSend={send}
         onCancel={cancel}
         onHistoryKeyDown={onHistoryKeyDown}
       />

--- a/apps/web/e2e/onboarding-and-run.spec.ts
+++ b/apps/web/e2e/onboarding-and-run.spec.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "@playwright/test"
 
+// The two tests below share backend state (onboarded=true is persisted into
+// state.json by test 1, used by test 2). Run serially so the order is fixed
+// and one test's failure aborts the rest instead of cascading.
+test.describe.configure({ mode: "serial" })
+
 test("first-time user can complete onboarding and reach the sidebar", async ({ page }) => {
   await page.goto("/")
 
@@ -30,4 +35,71 @@ test("first-time user can complete onboarding and reach the sidebar", async ({ p
   // to "/portfolio", which mounts the sidebar.
   await page.getByRole("button", { name: "Finish" }).click()
   await expect(page.getByTestId("nav-portfolio")).toBeVisible({ timeout: 15_000 })
+})
+
+test("chat: an in-flight job survives a page reload via sessionStorage resume (Issue #125)", async ({
+  page,
+  context,
+}) => {
+  // Route the chat backend at the browser→Next-proxy boundary so we don't
+  // need a real briefing file or claude CLI. The first GET against the
+  // stream hangs until reload aborts it; the second (post-reload) replay
+  // delivers the full answer — modelling what the FastAPI tail loop does.
+  let streamHits = 0
+  await context.route("**/api/chat", async (route) => {
+    if (route.request().method() !== "POST") {
+      return route.fallback()
+    }
+    await route.fulfill({
+      status: 202,
+      contentType: "application/json",
+      body: JSON.stringify({ job_id: "e2e-resume", status: "pending" }),
+    })
+  })
+  await context.route("**/api/chat/e2e-resume/stream", async (route) => {
+    streamHits++
+    if (streamHits === 1) {
+      // Hold the response open. Reload aborts the request, so we don't
+      // need to resolve this promise — Playwright reaps the route on
+      // page navigation.
+      await new Promise<void>(() => {})
+      return
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: "data: Resumed answer.\n\n",
+    })
+  })
+
+  // Test 1 above already ran the onboarding wizard, so MainLayout's
+  // server-side onboarded check passes and the /chat route renders.
+  await page.goto("/chat")
+  await page.getByTestId("chat-input").fill("what's new?")
+  await page.getByTestId("send-button").click()
+
+  // The running snapshot must be in sessionStorage before reload —
+  // that's what carries the jobId across the page lifecycle.
+  await page.waitForFunction(
+    () => {
+      const raw = window.sessionStorage.getItem("ai-agent:chat-job:v1")
+      if (!raw) return false
+      const parsed = JSON.parse(raw) as { jobId?: string; status?: string }
+      return parsed.jobId === "e2e-resume" && parsed.status === "running"
+    },
+    { timeout: 5_000 },
+  )
+
+  await page.reload()
+
+  // After remount, the hydrated jobId triggers a fresh GET against the
+  // stream and the replay fills in the assistant message. The user's
+  // original question rehydrates from the persisted snapshot.
+  await expect(page.getByTestId("chat-msg-user")).toContainText(
+    "what's new?",
+  )
+  await expect(page.getByTestId("chat-msg-assistant")).toContainText(
+    "Resumed answer.",
+  )
+  expect(streamHits).toBeGreaterThanOrEqual(2)
 })

--- a/apps/web/lib/chatJobStore.tsx
+++ b/apps/web/lib/chatJobStore.tsx
@@ -42,8 +42,10 @@ export type ChatJobStateContextValue = ChatJobState & {
   reset: () => void
 }
 
-// Bumped if the persisted shape changes incompatibly.
-const STORAGE_KEY = "ai-agent:chat-job:v1"
+// Bumped if the persisted shape changes incompatibly. Exported so tests
+// and hand-rolled debugging tools read the same key — duplicating it
+// would silently break after a version bump.
+export const CHAT_JOB_STORAGE_KEY = "ai-agent:chat-job:v1"
 
 const initialState: ChatJobState = {
   jobId: null,
@@ -84,7 +86,7 @@ const { Provider, useStore } = createJobStoreProvider<
   ChatJobState,
   ChatJobStartOpts
 >({
-  storageKey: STORAGE_KEY,
+  storageKey: CHAT_JOB_STORAGE_KEY,
   initialState,
   getJobId: (s) => s.jobId,
   isInFlight: (s) => isInFlightStatus(s.status),

--- a/apps/web/lib/chatJobStore.tsx
+++ b/apps/web/lib/chatJobStore.tsx
@@ -1,0 +1,264 @@
+"use client"
+import type { ReactNode } from "react"
+
+import { createJobStoreProvider } from "./createJobStoreProvider"
+
+/**
+ * Chat-flavored job-backed store. Owns the *currently in-flight* chat turn
+ * (question + accumulating assistant content) so a tab switch / page reload
+ * while streaming can resume via ``GET /api/chat/{job_id}/stream`` (Issue
+ * #125 / #126).
+ *
+ * Completed turns are NOT held here — they get committed into
+ * ``chatStore.messages`` once the job reaches a terminal status. Keeping the
+ * two concerns split means the chat history persistence (FIFO cap, multi-tab
+ * survival) stays untouched, and rehydrating an in-flight job doesn't risk
+ * duplicating an already-committed turn into history.
+ */
+
+export type ChatJobStatus = "idle" | "pending" | "running" | "done" | "failed"
+
+export type ChatJobState = {
+  jobId: string | null
+  status: ChatJobStatus
+  /** Question the user asked. Persisted so the user message can be re-rendered after reload. */
+  question: string
+  /** YYYY-MM-DD briefing context (re-sent on stale_session retry). */
+  date: string
+  /** Accumulating assistant content. NOT persisted — rebuilt from the GET stream's replay. */
+  assistantContent: string
+  error: string | null
+  /** UI-only: surfaced via the SessionExpiredCard. */
+  sessionExpired: boolean
+  /** UI-only: signal to ChatForm to retry the POST once with the same question. */
+  staleSession: boolean
+}
+
+export type ChatJobStartOpts = { question: string; date: string }
+
+export type ChatJobStateContextValue = ChatJobState & {
+  isBackgrounded: boolean
+  startJob: (opts: ChatJobStartOpts) => Promise<void>
+  reset: () => void
+}
+
+// Bumped if the persisted shape changes incompatibly.
+const STORAGE_KEY = "ai-agent:chat-job:v1"
+
+const initialState: ChatJobState = {
+  jobId: null,
+  status: "idle",
+  question: "",
+  date: "",
+  assistantContent: "",
+  error: null,
+  sessionExpired: false,
+  staleSession: false,
+}
+
+const isInFlightStatus = (s: ChatJobStatus) =>
+  s === "pending" || s === "running"
+
+type SSEEvent = { type: string; data: string }
+
+// Streaming SSE parser: events end at "\n\n"; multi-line ``data:`` fields join with "\n".
+function parseSSE(buffer: string): { events: SSEEvent[]; rest: string } {
+  const events: SSEEvent[] = []
+  let rest = buffer
+  let idx
+  while ((idx = rest.indexOf("\n\n")) !== -1) {
+    const raw = rest.slice(0, idx)
+    rest = rest.slice(idx + 2)
+    let type = "message"
+    const data: string[] = []
+    for (const line of raw.split("\n")) {
+      if (line.startsWith("event: ")) type = line.slice(7)
+      else if (line.startsWith("data: ")) data.push(line.slice(6))
+    }
+    events.push({ type, data: data.join("\n") })
+  }
+  return { events, rest }
+}
+
+const { Provider, useStore } = createJobStoreProvider<
+  ChatJobState,
+  ChatJobStartOpts
+>({
+  storageKey: STORAGE_KEY,
+  initialState,
+  getJobId: (s) => s.jobId,
+  isInFlight: (s) => isInFlightStatus(s.status),
+  // Only persist while in flight with a real jobId — completed turns live in
+  // ``chatStore.messages`` instead. Persisting a finished snapshot here would
+  // resurrect it on the next mount and duplicate the turn.
+  isPersistable: (s) => Boolean(s.jobId) && isInFlightStatus(s.status),
+  serializeForStorage: (s) => ({
+    ...s,
+    // sessionExpired / staleSession / assistantContent are all transient or
+    // recoverable from the backend's replay. Strip them so a reload doesn't
+    // resurrect stale UI state, and so we don't have to dedupe the SSE
+    // replay against a partially-built buffer.
+    assistantContent: "",
+    sessionExpired: false,
+    staleSession: false,
+  }),
+
+  start: async ({ question, date }, { setState }) => {
+    setState(() => ({
+      ...initialState,
+      status: "pending",
+      question,
+      date,
+    }))
+    try {
+      const post = await fetch("/api/chat", {
+        method: "POST",
+        cache: "no-store",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ date, question }),
+      })
+      if (post.status === 401) {
+        setState(() => ({ ...initialState, sessionExpired: true }))
+        return
+      }
+      if (!post.ok) {
+        const text = await post.text().catch(() => "")
+        setState((prev) => ({
+          ...prev,
+          status: "failed",
+          error: `POST /api/chat failed (HTTP ${post.status}): ${text}`,
+        }))
+        return
+      }
+      const body = (await post.json()) as { job_id?: string }
+      if (!body.job_id) {
+        setState((prev) => ({
+          ...prev,
+          status: "failed",
+          error: "POST /api/chat returned no job_id",
+        }))
+        return
+      }
+      setState((prev) => ({
+        ...prev,
+        jobId: body.job_id ?? null,
+        status: "running",
+      }))
+    } catch (e) {
+      setState((prev) => ({
+        ...prev,
+        status: "failed",
+        error: e instanceof Error ? e.message : "Network error",
+      }))
+    }
+  },
+
+  watch: async (jobId, { signal, setState }) => {
+    // The backend replays every buffered event on (re)connect, so the
+    // assistant content we already have on this render could collide with the
+    // replay. Reset to "" at the start and rebuild — slightly visible on
+    // resume but correctness wins over a flash-free animation.
+    setState((prev) => ({ ...prev, assistantContent: "" }))
+
+    let res: Response
+    try {
+      res = await fetch(`/api/chat/${jobId}/stream`, {
+        method: "GET",
+        cache: "no-store",
+        signal,
+      })
+    } catch (e) {
+      if (signal.aborted) return
+      setState((prev) => ({
+        ...prev,
+        status: "failed",
+        error: e instanceof Error ? e.message : "Network error",
+      }))
+      return
+    }
+    if (signal.aborted) return
+    if (res.status === 401) {
+      setState((prev) => ({ ...prev, sessionExpired: true, status: "failed" }))
+      return
+    }
+    if (res.status === 404) {
+      // Backend no longer knows this job (process restart, eviction). Clear
+      // cleanly with an informative message; ChatForm will commit nothing.
+      setState(() => ({
+        ...initialState,
+        status: "failed",
+        error:
+          "The previous chat job is no longer available — please ask again.",
+      }))
+      return
+    }
+    if (!res.ok || !res.body) {
+      const text = await res.text().catch(() => "")
+      setState((prev) => ({
+        ...prev,
+        status: "failed",
+        error: `GET /api/chat/${jobId}/stream failed (HTTP ${res.status}): ${text}`,
+      }))
+      return
+    }
+
+    const reader = res.body.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ""
+    try {
+      while (true) {
+        const { value, done } = await reader.read()
+        if (done) break
+        if (signal.aborted) return
+        buffer += decoder.decode(value, { stream: true })
+        const { events, rest } = parseSSE(buffer)
+        buffer = rest
+        for (const ev of events) {
+          if (signal.aborted) return
+          if (ev.type === "message") {
+            setState((prev) => ({
+              ...prev,
+              assistantContent:
+                prev.assistantContent +
+                (prev.assistantContent ? "\n" : "") +
+                ev.data,
+            }))
+          } else if (ev.type === "stale_session") {
+            // Backend wiped .sessions/<date>; ChatForm sees this flag on
+            // terminal and re-issues the POST once with the same question.
+            setState((prev) => ({ ...prev, staleSession: true }))
+          } else if (ev.type === "error") {
+            setState((prev) => ({
+              ...prev,
+              error: ev.data || "stream error",
+            }))
+          }
+        }
+      }
+    } catch (e) {
+      if (signal.aborted) return
+      setState((prev) => ({
+        ...prev,
+        status: "failed",
+        error: e instanceof Error ? e.message : "Stream read error",
+      }))
+      return
+    }
+
+    if (signal.aborted) return
+    setState((prev) => ({
+      ...prev,
+      // ``error`` set above by an ``event: error`` frame promotes the terminal
+      // status to "failed"; otherwise the stream ended cleanly.
+      status: prev.error ? "failed" : "done",
+    }))
+  },
+})
+
+export function ChatJobStateProvider({ children }: { children: ReactNode }) {
+  return <Provider>{children}</Provider>
+}
+
+export function useChatJobState(): ChatJobStateContextValue {
+  return useStore()
+}

--- a/apps/web/tests/chat-form.test.tsx
+++ b/apps/web/tests/chat-form.test.tsx
@@ -4,7 +4,10 @@ import { StrictMode } from "react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { ChatForm } from "@/components/screens/ChatForm"
-import { ChatJobStateProvider } from "@/lib/chatJobStore"
+import {
+  CHAT_JOB_STORAGE_KEY,
+  ChatJobStateProvider,
+} from "@/lib/chatJobStore"
 import { ChatStateProvider } from "@/lib/chatStore"
 
 function renderChatForm() {
@@ -736,9 +739,8 @@ describe("ChatForm", () => {
   // ----- Resume in-flight job on mount (Issue #125) --------------------
 
   it("hydrates an in-flight job from sessionStorage and resumes the stream", async () => {
-    const CHAT_JOB_KEY = "ai-agent:chat-job:v1"
     window.sessionStorage.setItem(
-      CHAT_JOB_KEY,
+      CHAT_JOB_STORAGE_KEY,
       JSON.stringify({
         jobId: "resume-2",
         status: "running",
@@ -775,7 +777,7 @@ describe("ChatForm", () => {
     // double-list the turn on next mount. The sessionStorage entry should
     // also be cleared once the job terminates.
     await waitFor(() => {
-      expect(window.sessionStorage.getItem(CHAT_JOB_KEY)).toBeNull()
+      expect(window.sessionStorage.getItem(CHAT_JOB_STORAGE_KEY)).toBeNull()
     })
     // Only one user message (the in-flight one) — the hydrated tab didn't
     // commit a second copy.

--- a/apps/web/tests/chat-form.test.tsx
+++ b/apps/web/tests/chat-form.test.tsx
@@ -4,12 +4,15 @@ import { StrictMode } from "react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { ChatForm } from "@/components/screens/ChatForm"
+import { ChatJobStateProvider } from "@/lib/chatJobStore"
 import { ChatStateProvider } from "@/lib/chatStore"
 
 function renderChatForm() {
   return render(
     <ChatStateProvider>
-      <ChatForm />
+      <ChatJobStateProvider>
+        <ChatForm />
+      </ChatJobStateProvider>
     </ChatStateProvider>,
   )
 }
@@ -18,7 +21,9 @@ function renderChatFormStrict() {
   return render(
     <StrictMode>
       <ChatStateProvider>
-        <ChatForm />
+        <ChatJobStateProvider>
+          <ChatForm />
+        </ChatJobStateProvider>
       </ChatStateProvider>
     </StrictMode>,
   )
@@ -726,6 +731,55 @@ describe("ChatForm", () => {
         "second answer",
       )
     })
+  })
+
+  // ----- Resume in-flight job on mount (Issue #125) --------------------
+
+  it("hydrates an in-flight job from sessionStorage and resumes the stream", async () => {
+    const CHAT_JOB_KEY = "ai-agent:chat-job:v1"
+    window.sessionStorage.setItem(
+      CHAT_JOB_KEY,
+      JSON.stringify({
+        jobId: "resume-2",
+        status: "running",
+        question: "今日の株価は？",
+        date: "2026-06-06",
+        assistantContent: "",
+        error: null,
+        sessionExpired: false,
+        staleSession: false,
+      }),
+    )
+    on("/api/chat/resume-2/stream", () =>
+      sseResponse([{ data: "Resumed answer." }]),
+    )
+
+    renderChatForm()
+
+    // The persisted user question shows up immediately as the in-flight
+    // turn, alongside whatever committed history was already there.
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-msg-user")).toHaveTextContent(
+        "今日の株価は？",
+      )
+    })
+    // The watch loop resumes the GET stream against the persisted job_id
+    // and fills the assistant message from the replay.
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-msg-assistant")).toHaveTextContent(
+        "Resumed answer.",
+      )
+    })
+    // The originating tab is the one that committed the turn — this
+    // (hydrated) tab must NOT also append it to chatStore, otherwise we'd
+    // double-list the turn on next mount. The sessionStorage entry should
+    // also be cleared once the job terminates.
+    await waitFor(() => {
+      expect(window.sessionStorage.getItem(CHAT_JOB_KEY)).toBeNull()
+    })
+    // Only one user message (the in-flight one) — the hydrated tab didn't
+    // commit a second copy.
+    expect(screen.getAllByTestId("chat-msg-user")).toHaveLength(1)
   })
 
   // ----- Up/Down history recall (Issue #117) ---------------------------

--- a/apps/web/tests/chat-job-store.test.tsx
+++ b/apps/web/tests/chat-job-store.test.tsx
@@ -1,0 +1,270 @@
+import { act, render, renderHook, screen, waitFor } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  ChatJobStateProvider,
+  useChatJobState,
+} from "@/lib/chatJobStore"
+
+const STORAGE_KEY = "ai-agent:chat-job:v1"
+
+type Handler = (init?: RequestInit) => Promise<Response> | Response
+
+function sseStream(parts: { event?: string; data: string }[]): Response {
+  const encoder = new TextEncoder()
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const p of parts) {
+        let chunk = ""
+        if (p.event) chunk += `event: ${p.event}\n`
+        for (const line of p.data.split("\n")) chunk += `data: ${line}\n`
+        chunk += "\n"
+        controller.enqueue(encoder.encode(chunk))
+      }
+      controller.close()
+    },
+  })
+  return new Response(stream, { status: 200 })
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  })
+}
+
+describe("chatJobStore", () => {
+  const fetchMock = vi.fn()
+  let queues: Record<string, Handler[]>
+
+  function on(url: string, handler: Handler) {
+    if (!queues[url]) queues[url] = []
+    queues[url].push(handler)
+  }
+
+  beforeEach(() => {
+    queues = {}
+    fetchMock.mockReset()
+    fetchMock.mockImplementation(async (url: string | URL, init?: RequestInit) => {
+      const u = typeof url === "string" ? url : url.toString()
+      const queue = queues[u]
+      if (queue && queue.length > 0) {
+        const next = queue.shift()!
+        return await next(init)
+      }
+      throw new Error(`Unmocked fetch in chatJobStore test: ${u}`)
+    })
+    vi.stubGlobal("fetch", fetchMock)
+    window.sessionStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    window.sessionStorage.clear()
+  })
+
+  function wrapper({ children }: { children: ReactNode }) {
+    return <ChatJobStateProvider>{children}</ChatJobStateProvider>
+  }
+
+  it("startJob POSTs and transitions through pending → running on a 202", async () => {
+    on("/api/chat", () => jsonResponse({ job_id: "abc", status: "pending" }, 202))
+    on("/api/chat/abc/stream", () =>
+      sseStream([{ data: "hello" }, { data: "world" }]),
+    )
+
+    const { result } = renderHook(() => useChatJobState(), { wrapper })
+    expect(result.current.status).toBe("idle")
+
+    await act(async () => {
+      await result.current.startJob({ question: "Q?", date: "2026-06-06" })
+    })
+    // After the POST resolves the watch loop runs and consumes the SSE.
+    await waitFor(() => expect(result.current.status).toBe("done"))
+    expect(result.current.jobId).toBe("abc")
+    expect(result.current.question).toBe("Q?")
+    expect(result.current.assistantContent).toBe("hello\nworld")
+    expect(result.current.error).toBeNull()
+  })
+
+  it("persists only while in-flight; clears on terminal", async () => {
+    let release: (() => void) | null = null
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    on("/api/chat", () => jsonResponse({ job_id: "live", status: "pending" }, 202))
+    on("/api/chat/live/stream", async () => {
+      // Hold the stream open until the test releases it.
+      await gate
+      return sseStream([{ data: "answer" }])
+    })
+
+    const { result } = renderHook(() => useChatJobState(), { wrapper })
+    await act(async () => {
+      await result.current.startJob({ question: "Q", date: "2026-06-06" })
+    })
+    // While running, the snapshot must be in sessionStorage.
+    await waitFor(() => {
+      expect(result.current.status).toBe("running")
+    })
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeTruthy()
+
+    // Let the stream complete.
+    await act(async () => {
+      release!()
+    })
+    await waitFor(() => expect(result.current.status).toBe("done"))
+    // On terminal, the entry must be wiped — completed turns live in
+    // chatStore.messages, not here. Resurrecting would dup the turn.
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it("serializeForStorage strips UI-only and unrebuildable fields", async () => {
+    // Force an in-flight state with all the strippable flags set, then read
+    // what hit sessionStorage to verify they were removed.
+    on("/api/chat", () => jsonResponse({ job_id: "x", status: "pending" }, 202))
+    on("/api/chat/x/stream", () =>
+      // event: stale_session sets staleSession; partial content accumulates.
+      sseStream([{ data: "partial" }, { event: "stale_session", data: "expired" }]),
+    )
+
+    const { result } = renderHook(() => useChatJobState(), { wrapper })
+    await act(async () => {
+      await result.current.startJob({ question: "Q", date: "2026-06-06" })
+    })
+    // After the stream closes, status flips to done — but the strippable
+    // fields land on prev-state mid-stream. Snapshot sessionStorage AS the
+    // running stream applies setState (which we approximate by reading
+    // immediately after the test arrives at the running state).
+    await waitFor(() => expect(result.current.status).toBe("done"))
+    // After terminal the entry is cleared; check that the previous in-flight
+    // writes never persisted partial content / staleSession.
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull()
+
+    // Now seed a hand-rolled in-flight entry with the strippable fields set
+    // and verify the loader is tolerant (factory doesn't fail on extras).
+    window.sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        jobId: "rehy",
+        status: "running",
+        question: "Q",
+        date: "2026-06-06",
+        assistantContent: "should be dropped",
+        sessionExpired: true,
+        staleSession: true,
+        error: null,
+      }),
+    )
+    // A second mount should pick it up but content stays "" until the watch
+    // (re-)fills it from the backend replay. The stream call below is what
+    // verifies the rebuild after rehydrate.
+    on("/api/chat/rehy/stream", () => sseStream([{ data: "rebuilt" }]))
+    const second = renderHook(() => useChatJobState(), { wrapper })
+    await waitFor(() => expect(second.result.current.jobId).toBe("rehy"))
+    // Content rebuilds from the stream — not the persisted "should be
+    // dropped" placeholder.
+    await waitFor(() =>
+      expect(second.result.current.assistantContent).toBe("rebuilt"),
+    )
+  })
+
+  it("rehydrates a persisted in-flight snapshot and resumes the GET stream", async () => {
+    window.sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        jobId: "resume-1",
+        status: "running",
+        question: "what's new?",
+        date: "2026-06-06",
+        assistantContent: "",
+        error: null,
+        sessionExpired: false,
+        staleSession: false,
+      }),
+    )
+    on("/api/chat/resume-1/stream", () =>
+      sseStream([{ data: "resumed" }, { data: "tail" }]),
+    )
+
+    function Probe() {
+      const s = useChatJobState()
+      return (
+        <div>
+          <span data-testid="jobid">{s.jobId ?? ""}</span>
+          <span data-testid="question">{s.question}</span>
+          <span data-testid="content">{s.assistantContent}</span>
+          <span data-testid="status">{s.status}</span>
+        </div>
+      )
+    }
+
+    render(
+      <ChatJobStateProvider>
+        <Probe />
+      </ChatJobStateProvider>,
+    )
+
+    // Hydration: jobId + question are restored from sessionStorage before
+    // the stream finishes.
+    await waitFor(() =>
+      expect(screen.getByTestId("jobid")).toHaveTextContent("resume-1"),
+    )
+    expect(screen.getByTestId("question")).toHaveTextContent("what's new?")
+    // The watch effect runs the GET against the persisted job_id and
+    // rebuilds assistantContent from the backend replay.
+    await waitFor(() =>
+      expect(screen.getByTestId("content")).toHaveTextContent("resumed"),
+    )
+    expect(screen.getByTestId("content")).toHaveTextContent("tail")
+    await waitFor(() =>
+      expect(screen.getByTestId("status")).toHaveTextContent("done"),
+    )
+  })
+
+  it("surfaces 401 on POST as sessionExpired without persisting", async () => {
+    on("/api/chat", () => new Response("", { status: 401 }))
+    const { result } = renderHook(() => useChatJobState(), { wrapper })
+    await act(async () => {
+      await result.current.startJob({ question: "Q", date: "2026-06-06" })
+    })
+    expect(result.current.sessionExpired).toBe(true)
+    expect(result.current.jobId).toBeNull()
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it("clears state cleanly on 404 from the resume GET", async () => {
+    window.sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        jobId: "gone",
+        status: "running",
+        question: "Q",
+        date: "2026-06-06",
+        assistantContent: "",
+        error: null,
+        sessionExpired: false,
+        staleSession: false,
+      }),
+    )
+    on("/api/chat/gone/stream", () => new Response("not found", { status: 404 }))
+
+    function Probe() {
+      const s = useChatJobState()
+      return <div data-testid="status">{s.status}-{s.error ?? ""}</div>
+    }
+
+    render(
+      <ChatJobStateProvider>
+        <Probe />
+      </ChatJobStateProvider>,
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId("status")).toHaveTextContent("failed")
+    })
+    expect(screen.getByTestId("status")).toHaveTextContent("no longer available")
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+})

--- a/apps/web/tests/chat-job-store.test.tsx
+++ b/apps/web/tests/chat-job-store.test.tsx
@@ -3,11 +3,10 @@ import type { ReactNode } from "react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import {
+  CHAT_JOB_STORAGE_KEY as STORAGE_KEY,
   ChatJobStateProvider,
   useChatJobState,
 } from "@/lib/chatJobStore"
-
-const STORAGE_KEY = "ai-agent:chat-job:v1"
 
 type Handler = (init?: RequestInit) => Promise<Response> | Response
 
@@ -233,6 +232,33 @@ describe("chatJobStore", () => {
     expect(result.current.sessionExpired).toBe(true)
     expect(result.current.jobId).toBeNull()
     expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it("surfaces 401 on the resume GET as sessionExpired", async () => {
+    // Backend tokens can expire mid-stream — different from the POST 401
+    // path (covered above) because the in-flight snapshot is in
+    // sessionStorage by the time auth dies. Make sure the resume GET
+    // 401 also lifts the SessionExpiredCard guard.
+    window.sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        jobId: "auth-gone",
+        status: "running",
+        question: "Q",
+        date: "2026-06-06",
+        assistantContent: "",
+        error: null,
+        sessionExpired: false,
+        staleSession: false,
+      }),
+    )
+    on("/api/chat/auth-gone/stream", () => new Response("", { status: 401 }))
+
+    const { result } = renderHook(() => useChatJobState(), { wrapper })
+    await waitFor(() => {
+      expect(result.current.sessionExpired).toBe(true)
+    })
+    expect(result.current.status).toBe("failed")
   })
 
   it("clears state cleanly on 404 from the resume GET", async () => {


### PR DESCRIPTION
## Summary
- Replace inline streaming in `ChatForm` with a `chatJobStore` (built on `createJobStoreProvider`) so an in-flight Q&A survives a page reload — sessionStorage persists `jobId` + `question`, and the watch loop re-opens `GET /api/chat/{job_id}/stream` on mount to rebuild `assistantContent` from the backend's replay.
- Persist only while in flight; on terminal status the turn gets committed to `chatStore.messages` (durable history) and the in-flight snapshot is cleared so the next mount doesn't duplicate it.
- Preserves all existing chat behaviors: Cancel (Issue #98), Esc-to-cancel, IME suppression, history recall (Issue #117), Notion save, session-expired card.

Closes #125

## Test plan
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 109/109 pass (new `chatJobStore` suite + Issue #125 resume scenario in `chat-form.test.tsx`)
- [x] `npx playwright test` — 2/2 pass (onboarding-and-run 2.7s; new chat resume e2e 1.4s)
- [x] Manual smoke: open chat, send a question, reload mid-stream → answer continues

🤖 Generated with [Claude Code](https://claude.com/claude-code)