### PR TITLE
test(web): add Playwright e2e for chat cancel flow

### DIFF
--- a/apps/web/e2e/onboarding-and-run.spec.ts
+++ b/apps/web/e2e/onboarding-and-run.spec.ts
@@ -103,3 +103,65 @@ test("chat: an in-flight job survives a page reload via sessionStorage resume (I
   )
   expect(streamHits).toBeGreaterThanOrEqual(2)
 })
+
+test("chat: Cancel mid-stream terminates the job and restores the question (Issue #99)", async ({
+  page,
+  context,
+}) => {
+  // Mock the job POST, hold the stream open until the user cancels,
+  // and capture the DELETE so we can assert the backend cancel call
+  // actually fires with the right job id.
+  let deleteHits = 0
+  let deletedJobId: string | null = null
+  await context.route("**/api/chat", async (route) => {
+    if (route.request().method() !== "POST") {
+      return route.fallback()
+    }
+    await route.fulfill({
+      status: 202,
+      contentType: "application/json",
+      body: JSON.stringify({ job_id: "e2e-cancel", status: "pending" }),
+    })
+  })
+  await context.route("**/api/chat/e2e-cancel/stream", async () => {
+    // Hold the stream open without ever sending a body. The watch loop
+    // sits at status="running" (busy=true → Cancel button visible),
+    // and the user click below aborts the fetch via the store's
+    // AbortController. Playwright cleans the handler up on navigation
+    // / context teardown; this promise intentionally never resolves.
+    // (Sending a one-shot body via route.fulfill would close the
+    // response, which flips status to "done" before cancel can fire.)
+    await new Promise<void>(() => {})
+  })
+  await context.route("**/api/chat/e2e-cancel", async (route) => {
+    if (route.request().method() !== "DELETE") {
+      return route.fallback()
+    }
+    deleteHits++
+    deletedJobId = "e2e-cancel"
+    await route.fulfill({ status: 204, body: "" })
+  })
+
+  await page.goto("/chat")
+  await page.getByTestId("chat-input").fill("draft to cancel")
+  await page.getByTestId("send-button").click()
+
+  // The Cancel button replaces Send once the POST returns 202 and the
+  // store flips into "running". The assistant bubble is mounted (the
+  // bouncing-dots indicator renders while busy) but content stays
+  // empty because the stream never emits.
+  await expect(page.getByTestId("cancel-button")).toBeVisible()
+  await expect(page.getByTestId("chat-msg-user")).toContainText(
+    "draft to cancel",
+  )
+
+  await page.getByTestId("cancel-button").click()
+
+  // Cancel turn is committed with the partial answer + Cancelled marker,
+  // textarea is repopulated for re-edit, Send is back.
+  await expect(page.getByTestId("chat-cancelled")).toBeVisible()
+  await expect(page.getByTestId("chat-input")).toHaveValue("draft to cancel")
+  await expect(page.getByTestId("send-button")).toBeVisible()
+  expect(deletedJobId).toBe("e2e-cancel")
+  expect(deleteHits).toBe(1)
+})

--- a/apps/web/e2e/onboarding-and-run.spec.ts
+++ b/apps/web/e2e/onboarding-and-run.spec.ts
@@ -110,9 +110,9 @@ test("chat: Cancel mid-stream terminates the job and restores the question (Issu
 }) => {
   // Mock the job POST, hold the stream open until the user cancels,
   // and capture the DELETE so we can assert the backend cancel call
-  // actually fires with the right job id.
+  // actually fires. The stream route is scoped to this job id, so any
+  // DELETE that lands here is by definition for "e2e-cancel".
   let deleteHits = 0
-  let deletedJobId: string | null = null
   await context.route("**/api/chat", async (route) => {
     if (route.request().method() !== "POST") {
       return route.fallback()
@@ -127,8 +127,9 @@ test("chat: Cancel mid-stream terminates the job and restores the question (Issu
     // Hold the stream open without ever sending a body. The watch loop
     // sits at status="running" (busy=true → Cancel button visible),
     // and the user click below aborts the fetch via the store's
-    // AbortController. Playwright cleans the handler up on navigation
-    // / context teardown; this promise intentionally never resolves.
+    // AbortController. The unroute in the finally block below releases
+    // the handler before the context tears down so the pending promise
+    // can't leak into a later test.
     // (Sending a one-shot body via route.fulfill would close the
     // response, which flips status to "done" before cancel can fire.)
     await new Promise<void>(() => {})
@@ -138,30 +139,32 @@ test("chat: Cancel mid-stream terminates the job and restores the question (Issu
       return route.fallback()
     }
     deleteHits++
-    deletedJobId = "e2e-cancel"
     await route.fulfill({ status: 204, body: "" })
   })
 
-  await page.goto("/chat")
-  await page.getByTestId("chat-input").fill("draft to cancel")
-  await page.getByTestId("send-button").click()
+  try {
+    await page.goto("/chat")
+    await page.getByTestId("chat-input").fill("draft to cancel")
+    await page.getByTestId("send-button").click()
 
-  // The Cancel button replaces Send once the POST returns 202 and the
-  // store flips into "running". The assistant bubble is mounted (the
-  // bouncing-dots indicator renders while busy) but content stays
-  // empty because the stream never emits.
-  await expect(page.getByTestId("cancel-button")).toBeVisible()
-  await expect(page.getByTestId("chat-msg-user")).toContainText(
-    "draft to cancel",
-  )
+    // The Cancel button replaces Send once the POST returns 202 and the
+    // store flips into "running". The assistant bubble is mounted (the
+    // bouncing-dots indicator renders while busy) but content stays
+    // empty because the stream never emits.
+    await expect(page.getByTestId("cancel-button")).toBeVisible()
+    await expect(page.getByTestId("chat-msg-user")).toContainText(
+      "draft to cancel",
+    )
 
-  await page.getByTestId("cancel-button").click()
+    await page.getByTestId("cancel-button").click()
 
-  // Cancel turn is committed with the partial answer + Cancelled marker,
-  // textarea is repopulated for re-edit, Send is back.
-  await expect(page.getByTestId("chat-cancelled")).toBeVisible()
-  await expect(page.getByTestId("chat-input")).toHaveValue("draft to cancel")
-  await expect(page.getByTestId("send-button")).toBeVisible()
-  expect(deletedJobId).toBe("e2e-cancel")
-  expect(deleteHits).toBe(1)
+    // Cancel turn is committed with the partial answer + Cancelled marker,
+    // textarea is repopulated for re-edit, Send is back.
+    await expect(page.getByTestId("chat-cancelled")).toBeVisible()
+    await expect(page.getByTestId("chat-input")).toHaveValue("draft to cancel")
+    await expect(page.getByTestId("send-button")).toBeVisible()
+    expect(deleteHits).toBe(1)
+  } finally {
+    await context.unrouteAll({ behavior: "ignoreErrors" })
+  }
 })

--- a/apps/web/e2e/onboarding-and-run.spec.ts
+++ b/apps/web/e2e/onboarding-and-run.spec.ts
@@ -163,6 +163,7 @@ test("chat: Cancel mid-stream terminates the job and restores the question (Issu
     await expect(page.getByTestId("chat-cancelled")).toBeVisible()
     await expect(page.getByTestId("chat-input")).toHaveValue("draft to cancel")
     await expect(page.getByTestId("send-button")).toBeVisible()
+    await expect(page.getByTestId("chat-error")).toHaveCount(0)
     expect(deleteHits).toBe(1)
   } finally {
     await context.unrouteAll({ behavior: "ignoreErrors" })


### PR DESCRIPTION
## Summary
- Adds a Playwright e2e covering the chat cancel flow: POST returns a job_id, GET stream is held open, Cancel button click fires DELETE, the cancelled turn is committed, the textarea is restored.
- The pytest \`_stream\` cancel criterion in the original Issue is no longer applicable after #126 jobification — \`_run_chat_job\` + \`DELETE /api/chat/{job_id}\` is the new shape, and equivalent coverage already lives in \`test_api_chat.py::test_delete_chat_*\`.

Closes #99

## Test plan
- [x] \`npm run lint\` — clean
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx playwright test\` — 3/3 pass (new cancel e2e 512ms)
- [x] \`pytest tests/test_api_chat.py\` — 35/35 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test coverage for canceling in-progress chat streams, ensuring the UI correctly displays cancellation state and restores draft text when a stream is cancelled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->