### PR TITLE
fix(local-llm): --briefing no longer requires the embed model (#145)

### DIFF
--- a/apps/python/src/local_llm/cli.py
+++ b/apps/python/src/local_llm/cli.py
@@ -159,7 +159,8 @@ def _cmd_briefing(cfg, *, post_to_notion: bool) -> int:
 
     try:
         olm = make_ollama_client(cfg)
-        ensure_models_available(olm, cfg.model, cfg.embed_model)
+        # briefing は generation のみ。embed_model 未 pull で弾かれないよう None で渡す。
+        ensure_models_available(olm, cfg.model, embed_model=None)
     except OllamaUnavailable as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1

--- a/apps/python/src/local_llm/clients.py
+++ b/apps/python/src/local_llm/clients.py
@@ -9,7 +9,13 @@ class OllamaUnavailable(RuntimeError):
     pass
 
 
-def ensure_models_available(client, model: str, embed_model: str) -> None:
+def ensure_models_available(client, model: str, embed_model: str | None) -> None:
+    """Verify the generation model (and optionally an embed model) is pulled.
+
+    `embed_model=None` is for the --briefing path which only generates and
+    does not touch the embed model; otherwise users without nomic-embed-text
+    pulled would be blocked from briefing for no reason (#145).
+    """
     try:
         info = client.list()
     except Exception as e:
@@ -38,7 +44,8 @@ def ensure_models_available(client, model: str, embed_model: str) -> None:
             return True
         return False
 
-    missing = [m for m in (model, embed_model) if not _present(m)]
+    required = [model] + ([embed_model] if embed_model is not None else [])
+    missing = [m for m in required if not _present(m)]
     if missing:
         cmds = "\n  ".join(f"ollama pull {m}" for m in missing)
         raise OllamaUnavailable(

--- a/apps/python/tests/local_llm/test_clients.py
+++ b/apps/python/tests/local_llm/test_clients.py
@@ -47,6 +47,18 @@ def test_ensure_models_available_missing_model():
     assert "qwen2.5:7b" in str(exc.value)
 
 
+def test_ensure_models_available_skips_embed_when_none():
+    # --briefing path only needs the generation model; embed_model=None should
+    # not trigger a "nomic-embed-text not found" failure.
+    ensure_models_available(StubClient(["qwen2.5:7b"]), "qwen2.5:7b", embed_model=None)
+
+
+def test_ensure_models_available_still_validates_generation_when_embed_none():
+    with pytest.raises(OllamaUnavailable) as exc:
+        ensure_models_available(StubClient([]), "qwen2.5:7b", embed_model=None)
+    assert "qwen2.5:7b" in str(exc.value)
+
+
 def test_ensure_models_available_connection_failure():
     class Broken:
         def list(self):


### PR DESCRIPTION
## Summary
- `ensure_models_available(client, model, embed_model)` now accepts `embed_model=None`
- `_cmd_briefing` passes `None` so users without `nomic-embed-text` pulled can still run `--briefing`
- Two new tests cover the embed-skipped success case and the still-validated generation case

Fixes #145.

## Test plan
- [x] `pytest tests/local_llm/` — 29/29 pass (27 prior + 2 new)
- [x] Manual: `bin/local_llm.sh --briefing` works on a host where only `qwen2.5:7b` is pulled
- [x] `--index` / `--ask` paths still require both models (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Streamlined the briefing feature to reduce model dependencies, enabling generation-only operations without requiring additional optional components.

* **Tests**
  * Added test coverage validating that the briefing feature operates correctly with minimal model configurations and properly handles missing models when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->