### PR TITLE
feat(local-llm): switch embed model default to bge-m3 (#135)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,10 +239,12 @@ brew install ollama       # or follow https://ollama.com
 ollama serve &
 ollama pull qwen2.5:14b   # for --briefing: reliable tool calling (~8.5GB RAM with Q4)
 ollama pull qwen2.5:7b    # for --ask / --index: smaller, fits the RAG path
-ollama pull nomic-embed-text
+ollama pull bge-m3        # embedding model (#135): stronger JP + code retrieval than nomic-embed-text
 ```
 
 The default generation model is `qwen2.5:14b` for more stable instruction-following and citation quality in the `--briefing` path. If you only run `--ask` / `--index`, override with `LOCAL_LLM_MODEL=qwen2.5:7b`.
+
+> **Switching embed models requires a rebuild.** `bge-m3` (1024 dim) and the legacy `nomic-embed-text` (768 dim) produce incompatible vectors. If you change `LOCAL_LLM_EMBED_MODEL` (or are upgrading from a pre-#135 index), the CLI refuses with an `EmbedModelMismatch` error — rebuild with `bin/local_llm.sh --index --reset`.
 
 ### Usage
 

--- a/apps/python/src/local_llm/cli.py
+++ b/apps/python/src/local_llm/cli.py
@@ -34,6 +34,7 @@ from .briefing import (
     validate_urls,
 )
 from .clients import (
+    EmbedModelMismatch,
     OllamaUnavailable,
     ensure_models_available,
     make_chroma_collection,
@@ -86,7 +87,11 @@ def main(argv: list[str]) -> int:
 
 
 def _cmd_status(cfg) -> int:
-    coll = make_chroma_collection(cfg)
+    try:
+        coll = make_chroma_collection(cfg)
+    except EmbedModelMismatch as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
     count = coll.count() if hasattr(coll, "count") else 0
     print(f"chroma_path : {cfg.chroma_path}")
     print(f"model       : {cfg.model}")
@@ -107,11 +112,11 @@ def _cmd_index(cfg, *, reset: bool) -> int:
     try:
         olm = make_ollama_client(cfg)
         ensure_models_available(olm, cfg.model, cfg.embed_model)
-    except OllamaUnavailable as e:
+        coll = make_chroma_collection(cfg)
+    except (OllamaUnavailable, EmbedModelMismatch) as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
 
-    coll = make_chroma_collection(cfg)
     t0 = time.time()
     stats = Indexer(cfg, collection=coll, ollama_client=olm).run()
     dt = time.time() - t0
@@ -127,10 +132,10 @@ def _cmd_sources(cfg, question: str) -> int:
     try:
         olm = make_ollama_client(cfg)
         ensure_models_available(olm, cfg.model, cfg.embed_model)
-    except OllamaUnavailable as e:
+        coll = make_chroma_collection(cfg)
+    except (OllamaUnavailable, EmbedModelMismatch) as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
-    coll = make_chroma_collection(cfg)
     chunks = Retriever(cfg, collection=coll, ollama_client=olm).retrieve(question)
     if not chunks:
         print("該当する文脈が見つかりませんでした")
@@ -145,10 +150,10 @@ def _cmd_ask(cfg, question: str) -> int:
     try:
         olm = make_ollama_client(cfg)
         ensure_models_available(olm, cfg.model, cfg.embed_model)
-    except OllamaUnavailable as e:
+        coll = make_chroma_collection(cfg)
+    except (OllamaUnavailable, EmbedModelMismatch) as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
-    coll = make_chroma_collection(cfg)
     retr = Retriever(cfg, collection=coll, ollama_client=olm)
     chunks = retr.retrieve(question)
     if not chunks:

--- a/apps/python/src/local_llm/clients.py
+++ b/apps/python/src/local_llm/clients.py
@@ -70,6 +70,11 @@ def make_ollama_client(cfg: LocalLLMConfig):
     return ollama.Client(host=cfg.ollama_host)
 
 
+# Frozen historical value: the embed model that pre-#135 collections were
+# built with (when collections carried no embed_model metadata). Do NOT
+# update this when DEFAULT_EMBED_MODEL changes — it must remain the model
+# that legacy on-disk indexes actually used, or the mismatch check below
+# will silently miss a dimension change.
 _LEGACY_EMBED_MODEL = "nomic-embed-text"
 
 

--- a/apps/python/src/local_llm/clients.py
+++ b/apps/python/src/local_llm/clients.py
@@ -9,6 +9,18 @@ class OllamaUnavailable(RuntimeError):
     pass
 
 
+class EmbedModelMismatch(RuntimeError):
+    """Existing Chroma collection was built with a different embed model.
+
+    Raised by ``make_chroma_collection`` when the current `cfg.embed_model`
+    does not match the embed model recorded in the persisted collection's
+    metadata. Different embed models produce vectors of different
+    dimensions (e.g. bge-m3=1024 vs nomic-embed-text=768), and mixing them
+    in one collection raises a dim-mismatch error on the first upsert; we
+    detect it up-front and tell the operator to ``--reset``.
+    """
+
+
 def ensure_models_available(client, model: str, embed_model: str | None) -> None:
     """Verify the generation model (and optionally an embed model) is pulled.
 
@@ -58,8 +70,26 @@ def make_ollama_client(cfg: LocalLLMConfig):
     return ollama.Client(host=cfg.ollama_host)
 
 
+_LEGACY_EMBED_MODEL = "nomic-embed-text"
+
+
 def make_chroma_collection(cfg: LocalLLMConfig):
     import chromadb
     cfg.chroma_path.mkdir(parents=True, exist_ok=True)
     client = chromadb.PersistentClient(path=str(cfg.chroma_path))
-    return client.get_or_create_collection(COLLECTION_NAME)
+    coll = client.get_or_create_collection(
+        COLLECTION_NAME,
+        metadata={"embed_model": cfg.embed_model},
+    )
+    # Pre-#135 collections have no embed_model tag; they were built with the
+    # previous default (nomic-embed-text). Fall back to that so the mismatch
+    # check still catches a silent dimension change.
+    prev_model = (coll.metadata or {}).get("embed_model") or _LEGACY_EMBED_MODEL
+    if prev_model != cfg.embed_model:
+        raise EmbedModelMismatch(
+            f"Existing Chroma collection at {cfg.chroma_path} was built with "
+            f"embed_model={prev_model!r}, but current config requests "
+            f"{cfg.embed_model!r}. Embedding dimensions differ. Rebuild with:\n"
+            f"  bin/local_llm.sh --index --reset"
+        )
+    return coll

--- a/apps/python/src/local_llm/config.py
+++ b/apps/python/src/local_llm/config.py
@@ -11,7 +11,10 @@ DEFAULT_OLLAMA_HOST = "http://localhost:11434"
 # `--briefing` 経路で web_search を確実に呼ぶために必要。Q4 量子化で ~8.5GB RAM。
 # 小さいモデルに戻したい場合は env LOCAL_LLM_MODEL=qwen2.5:7b で override 可能。
 DEFAULT_MODEL = "qwen2.5:14b"
-DEFAULT_EMBED_MODEL = "nomic-embed-text"
+# bge-m3 (1024d) outperforms nomic-embed-text (768d) on Japanese + code retrieval
+# (#135). Switching changes embedding dimensions, so an existing .chroma_db built
+# with the previous default must be rebuilt: bin/local_llm.sh --index --reset.
+DEFAULT_EMBED_MODEL = "bge-m3"
 DEFAULT_TOP_K = 6
 DEFAULT_CHUNK_LINES = 40
 DEFAULT_CHUNK_OVERLAP = 8

--- a/apps/python/tests/local_llm/test_cli.py
+++ b/apps/python/tests/local_llm/test_cli.py
@@ -1,6 +1,7 @@
 import pytest
 
 from src.local_llm import cli
+from src.local_llm.clients import EmbedModelMismatch
 
 
 def test_cli_status_prints_summary(monkeypatch, tmp_path, capsys):
@@ -48,6 +49,39 @@ def test_cli_sources_prints_top_k(monkeypatch, tmp_path, capsys):
 def test_cli_requires_one_action(tmp_path):
     with pytest.raises(SystemExit):
         cli.main([])
+
+
+def _raise_mismatch(_cfg):
+    raise EmbedModelMismatch(
+        "embed_model='nomic-embed-text' vs 'bge-m3'. Rebuild with: "
+        "bin/local_llm.sh --index --reset"
+    )
+
+
+def test_cli_status_exits_on_embed_model_mismatch(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("LOCAL_LLM_CHROMA_PATH", str(tmp_path / "chroma"))
+    monkeypatch.setattr(cli, "make_chroma_collection", _raise_mismatch)
+
+    rc = cli.main(["--status", "--root", str(tmp_path)])
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "--index --reset" in captured.err
+    assert "nomic-embed-text" in captured.err
+    assert "bge-m3" in captured.err
+
+
+def test_cli_sources_exits_on_embed_model_mismatch(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("LOCAL_LLM_CHROMA_PATH", str(tmp_path / "chroma"))
+    monkeypatch.setattr(cli, "make_ollama_client", lambda cfg: object())
+    monkeypatch.setattr(cli, "ensure_models_available", lambda *a, **kw: None)
+    monkeypatch.setattr(cli, "make_chroma_collection", _raise_mismatch)
+
+    rc = cli.main(["--sources", "test", "--root", str(tmp_path)])
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "--index --reset" in captured.err
 
 
 def test_cli_notion_without_briefing_errors(tmp_path, capsys):

--- a/apps/python/tests/local_llm/test_cli.py
+++ b/apps/python/tests/local_llm/test_cli.py
@@ -84,6 +84,32 @@ def test_cli_sources_exits_on_embed_model_mismatch(monkeypatch, tmp_path, capsys
     assert "--index --reset" in captured.err
 
 
+def test_cli_index_exits_on_embed_model_mismatch(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("LOCAL_LLM_CHROMA_PATH", str(tmp_path / "chroma"))
+    monkeypatch.setattr(cli, "make_ollama_client", lambda cfg: object())
+    monkeypatch.setattr(cli, "ensure_models_available", lambda *a, **kw: None)
+    monkeypatch.setattr(cli, "make_chroma_collection", _raise_mismatch)
+
+    rc = cli.main(["--index", "--root", str(tmp_path)])
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "--index --reset" in captured.err
+
+
+def test_cli_ask_exits_on_embed_model_mismatch(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("LOCAL_LLM_CHROMA_PATH", str(tmp_path / "chroma"))
+    monkeypatch.setattr(cli, "make_ollama_client", lambda cfg: object())
+    monkeypatch.setattr(cli, "ensure_models_available", lambda *a, **kw: None)
+    monkeypatch.setattr(cli, "make_chroma_collection", _raise_mismatch)
+
+    rc = cli.main(["--ask", "test", "--root", str(tmp_path)])
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "--index --reset" in captured.err
+
+
 def test_cli_notion_without_briefing_errors(tmp_path, capsys):
     # --notion is meaningless without --briefing; argparse should reject it
     # rather than silently ignore.

--- a/apps/python/tests/local_llm/test_cli.py
+++ b/apps/python/tests/local_llm/test_cli.py
@@ -17,7 +17,7 @@ def test_cli_status_prints_summary(monkeypatch, tmp_path, capsys):
     assert rc == 0
     assert "42" in out
     assert "qwen2.5:14b" in out
-    assert "nomic-embed-text" in out
+    assert "bge-m3" in out
 
 
 def test_cli_sources_prints_top_k(monkeypatch, tmp_path, capsys):

--- a/apps/python/tests/local_llm/test_cli.py
+++ b/apps/python/tests/local_llm/test_cli.py
@@ -82,6 +82,8 @@ def test_cli_sources_exits_on_embed_model_mismatch(monkeypatch, tmp_path, capsys
     captured = capsys.readouterr()
     assert rc == 1
     assert "--index --reset" in captured.err
+    assert "nomic-embed-text" in captured.err
+    assert "bge-m3" in captured.err
 
 
 def test_cli_index_exits_on_embed_model_mismatch(monkeypatch, tmp_path, capsys):
@@ -95,6 +97,8 @@ def test_cli_index_exits_on_embed_model_mismatch(monkeypatch, tmp_path, capsys):
     captured = capsys.readouterr()
     assert rc == 1
     assert "--index --reset" in captured.err
+    assert "nomic-embed-text" in captured.err
+    assert "bge-m3" in captured.err
 
 
 def test_cli_ask_exits_on_embed_model_mismatch(monkeypatch, tmp_path, capsys):
@@ -108,6 +112,8 @@ def test_cli_ask_exits_on_embed_model_mismatch(monkeypatch, tmp_path, capsys):
     captured = capsys.readouterr()
     assert rc == 1
     assert "--index --reset" in captured.err
+    assert "nomic-embed-text" in captured.err
+    assert "bge-m3" in captured.err
 
 
 def test_cli_notion_without_briefing_errors(tmp_path, capsys):

--- a/apps/python/tests/local_llm/test_clients.py
+++ b/apps/python/tests/local_llm/test_clients.py
@@ -1,6 +1,12 @@
 import pytest
 
-from src.local_llm.clients import OllamaUnavailable, ensure_models_available
+from src.local_llm.clients import (
+    EmbedModelMismatch,
+    OllamaUnavailable,
+    ensure_models_available,
+    make_chroma_collection,
+)
+from src.local_llm.config import LocalLLMConfig
 
 
 class StubClient:
@@ -67,3 +73,64 @@ def test_ensure_models_available_connection_failure():
     with pytest.raises(OllamaUnavailable) as exc:
         ensure_models_available(Broken(), "qwen2.5:7b", "nomic-embed-text")
     assert "ollama serve" in str(exc.value)
+
+
+def _make_cfg(chroma_path, embed_model):
+    return LocalLLMConfig(
+        ollama_host="http://localhost:11434",
+        model="qwen2.5:14b",
+        embed_model=embed_model,
+        top_k=6,
+        repo_root=chroma_path.parent,
+        chroma_path=chroma_path,
+        chunk_lines=40,
+        chunk_overlap=8,
+    )
+
+
+def test_make_chroma_collection_tags_metadata_on_create(tmp_path):
+    cfg = _make_cfg(tmp_path / "chroma", "bge-m3")
+
+    coll = make_chroma_collection(cfg)
+
+    assert (coll.metadata or {}).get("embed_model") == "bge-m3"
+
+
+def test_make_chroma_collection_reuses_matching_collection(tmp_path):
+    chroma_path = tmp_path / "chroma"
+    cfg = _make_cfg(chroma_path, "bge-m3")
+
+    make_chroma_collection(cfg)
+    # Second call must succeed (same embed_model) and not raise.
+    coll = make_chroma_collection(cfg)
+    assert (coll.metadata or {}).get("embed_model") == "bge-m3"
+
+
+def test_make_chroma_collection_raises_on_embed_model_mismatch(tmp_path):
+    chroma_path = tmp_path / "chroma"
+    make_chroma_collection(_make_cfg(chroma_path, "bge-m3"))
+
+    cfg_after_switch = _make_cfg(chroma_path, "nomic-embed-text")
+    with pytest.raises(EmbedModelMismatch) as exc:
+        make_chroma_collection(cfg_after_switch)
+    assert "bge-m3" in str(exc.value)
+    assert "--reset" in str(exc.value)
+
+
+def test_make_chroma_collection_treats_pre_135_index_as_nomic(tmp_path, monkeypatch):
+    """Collections built before #135 carry no embed_model tag and must be
+    treated as nomic-embed-text so a silent switch to bge-m3 is caught.
+    """
+    import chromadb
+
+    from src.local_llm.config import COLLECTION_NAME
+
+    chroma_path = tmp_path / "chroma"
+    chroma_path.mkdir()
+    client = chromadb.PersistentClient(path=str(chroma_path))
+    client.create_collection(COLLECTION_NAME)  # no metadata, like a legacy index
+
+    cfg = _make_cfg(chroma_path, "bge-m3")
+    with pytest.raises(EmbedModelMismatch) as exc:
+        make_chroma_collection(cfg)
+    assert "nomic-embed-text" in str(exc.value)

--- a/apps/python/tests/local_llm/test_clients.py
+++ b/apps/python/tests/local_llm/test_clients.py
@@ -117,7 +117,7 @@ def test_make_chroma_collection_raises_on_embed_model_mismatch(tmp_path):
     assert "--reset" in str(exc.value)
 
 
-def test_make_chroma_collection_treats_pre_135_index_as_nomic(tmp_path, monkeypatch):
+def test_make_chroma_collection_treats_pre_135_index_as_nomic(tmp_path):
     """Collections built before #135 carry no embed_model tag and must be
     treated as nomic-embed-text so a silent switch to bge-m3 is caught.
     """

--- a/apps/python/tests/local_llm/test_clients.py
+++ b/apps/python/tests/local_llm/test_clients.py
@@ -134,3 +134,22 @@ def test_make_chroma_collection_treats_pre_135_index_as_nomic(tmp_path):
     with pytest.raises(EmbedModelMismatch) as exc:
         make_chroma_collection(cfg)
     assert "nomic-embed-text" in str(exc.value)
+
+
+def test_make_chroma_collection_reuses_legacy_index_when_embed_unchanged(tmp_path):
+    """Pre-#135 collections (no embed_model metadata) must remain usable when
+    the operator keeps nomic-embed-text — legacy is treated as nomic, not
+    rejected with EmbedModelMismatch.
+    """
+    import chromadb
+
+    from src.local_llm.config import COLLECTION_NAME
+
+    chroma_path = tmp_path / "chroma"
+    chroma_path.mkdir()
+    client = chromadb.PersistentClient(path=str(chroma_path))
+    client.create_collection(COLLECTION_NAME)  # no metadata, like a legacy index
+
+    cfg = _make_cfg(chroma_path, "nomic-embed-text")
+    # Must not raise; legacy index is treated as nomic-embed-text.
+    make_chroma_collection(cfg)

--- a/apps/python/tests/local_llm/test_config.py
+++ b/apps/python/tests/local_llm/test_config.py
@@ -19,7 +19,7 @@ def test_load_config_defaults(monkeypatch, tmp_path):
     assert isinstance(cfg, LocalLLMConfig)
     assert cfg.ollama_host == "http://localhost:11434"
     assert cfg.model == "qwen2.5:14b"
-    assert cfg.embed_model == "nomic-embed-text"
+    assert cfg.embed_model == "bge-m3"
     assert cfg.top_k == 6
     assert cfg.repo_root == tmp_path
     assert cfg.chunk_lines == 40
@@ -30,7 +30,7 @@ def test_load_config_defaults(monkeypatch, tmp_path):
 def test_load_config_env_overrides(monkeypatch, tmp_path):
     monkeypatch.setenv("OLLAMA_HOST", "http://example:11434")
     monkeypatch.setenv("LOCAL_LLM_MODEL", "qwen2.5:32b")
-    monkeypatch.setenv("LOCAL_LLM_EMBED_MODEL", "bge-m3")
+    monkeypatch.setenv("LOCAL_LLM_EMBED_MODEL", "nomic-embed-text")
     monkeypatch.setenv("LOCAL_LLM_TOP_K", "10")
     monkeypatch.setenv("LOCAL_LLM_CHROMA_PATH", str(tmp_path / "custom_chroma"))
 
@@ -38,6 +38,6 @@ def test_load_config_env_overrides(monkeypatch, tmp_path):
 
     assert cfg.ollama_host == "http://example:11434"
     assert cfg.model == "qwen2.5:32b"
-    assert cfg.embed_model == "bge-m3"
+    assert cfg.embed_model == "nomic-embed-text"
     assert cfg.top_k == 10
     assert cfg.chroma_path == tmp_path / "custom_chroma"


### PR DESCRIPTION
## Summary
- Default `LOCAL_LLM_EMBED_MODEL` changes from `nomic-embed-text` (768d) to `bge-m3` (1024d) for stronger JP+code retrieval.
- Chroma collections are now tagged with the embed model on create; mismatched runs fail fast with `EmbedModelMismatch` pointing to `--index --reset`.
- README updated to pull `bge-m3` and explains the rebuild requirement.

Closes #135.

## Before / after on the 3 baseline queries from #140

`bin/local_llm.sh --sources` top-6 (distance — source) on the same indexed repo.

### Q1: ブリーフィングは何のスケジュールでどう動く？
| Before (nomic) | After (bge-m3) |
|---|---|
| `notifier/discord.py:65-89` | `src/config.py:1-40` |
| `.claude/skills/architecting-defaults/SKILL.md:33-72` | `docs/.../local-briefing-design.md:65-104` |
| `docs/.../local-llm-bootstrap-design.md:161-176` | `src/generator/briefing.py:65-104` |
| `src/handler.py:33-72` | `src/handler.py:33-72` |
| `.claude/.../web-ui-phase1-design.md:33-72` | `src/chat_session.py:33-48` |
| `src/claude_runner.py:65-104` | `src/notifier/local_md.py:1-40` |

✅ bge-m3 surfaces briefing-specific files (`config.py` reads `briefing.json`, `generator/briefing.py`, `local-briefing-design.md`, `local_md.py` notifier); nomic mixed in noise (`discord.py`, skill docs, `claude_runner.py`).

### Q2: Web UI のチャットはどこからジョブを起こす？
| Before (nomic) | After (bge-m3) |
|---|---|
| `.claude/skills/architecting-defaults/SKILL.md:33-72` | `web/routers/chat.py:1-40` |
| `prompts/briefing.md:1-40` | `apps/web/e2e/onboarding-and-run.spec.ts:65-104` |
| `.claude/skills/tech-architect/SKILL.md:33-72` | `apps/web/lib/chatJobStore.tsx:1-40` |
| `docs/idea_xss-vulnerability-detection-agent.md:1-40` | `apps/web/components/screens/ChatForm.tsx:129-168` |
| `.claude/skills/architecting-defaults/SKILL.md:129-158` | `apps/web/lib/createJobStoreProvider.tsx:1-40` |
| `src/handler.py:33-72` | `apps/web/tests/chat-job-store.test.tsx:193-232` |

✅ Large win — bge-m3 returns the actual chat router + job-store + form components; nomic returned unrelated skill docs.

### Q3: `run_claude()` の auth_mode 切替の流れは？
| Before (nomic) | After (bge-m3) |
|---|---|
| `.claude/.../web-ui-phase1-design.md:225-264` | `.claude/.../web-ui-phase1-design.md:225-264` |
| `src/claude_runner.py:65-104` | `tests/test_chat.py:97-136` |
| `.claude/.../web-ui-phase1-plan-a-backend-foundation.md:1313-1352` | `.claude/.../web-ui-phase1-plan-a-backend-foundation.md:1313-1352` |
| `tests/test_claude_runner.py:289-328` | `docs/web-ui-setup.md:97-136` |
| `web/routers/auth_mode.py:1-36` | `tests/test_claude_runner.py:353-392` |
| `src/claude_runner.py:33-72` | `tests/test_claude_runner.py:385-424` |

⚠️ Minor regression — direct lexical hits (`claude_runner.py:65-104`, `auth_mode.py:1-36`) drop out of top-6 in favor of peripheral test files. As #141 noted, Q3 already worked under nomic because of literal keyword overlap; bge-m3 emphasizes semantic similarity which hurts here. Expect #136 (reranker) to recover this.

## Test plan
- [x] `pytest tests/local_llm/` — 69/69 pass (4 new in `test_clients.py` for create-tag / reuse / mismatch / legacy-index)
- [x] `pytest` (full suite) — 424/424 pass
- [x] `ollama pull bge-m3` + `bin/local_llm.sh --index --reset` succeeds against `~/work/ai-agent` (218 files / 1188 chunks)
- [x] `bin/local_llm.sh --status` shows `embed_model : bge-m3`
- [x] `LOCAL_LLM_EMBED_MODEL=nomic-embed-text bin/local_llm.sh --status` exits 1 with the rebuild instruction
- [x] All 3 baseline queries return results above (no crashes, top-6 documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Switch default local embedding model to bge-m3 and enforce compatibility between existing Chroma indexes and the configured embed model, surfacing clear CLI errors and rebuild guidance when they differ.

New Features:
- Introduce EmbedModelMismatch error to signal when a persisted Chroma collection was built with a different embed model than the current configuration.
- Tag Chroma collections with the embed_model name on creation so future runs can detect configuration changes.

Enhancements:
- Change the default LOCAL_LLM_EMBED_MODEL from nomic-embed-text to bge-m3 in the local LLM configuration.
- Update the CLI to handle embed model mismatches gracefully across status, index, sources, and ask commands, exiting with actionable error messages.
- Document the new bge-m3 default and the requirement to rebuild indexes when changing embed models in the README.

Tests:
- Add tests covering Chroma collection metadata tagging, reuse, and mismatch behavior, including handling of legacy collections without embed_model metadata.
- Add CLI tests ensuring each subcommand exits with an EmbedModelMismatch error and rebuild instructions when the stored embed model conflicts with the configured one.
- Update configuration tests to reflect the new default embed model and environment override behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default embedding model changed to bge-m3.
  * Added user-facing error handling and recovery guidance when an embedding-model conflict is detected with an existing local index.

* **Documentation**
  * Updated setup instructions and added a warning that switching embedding models requires rebuilding the local index.

* **Tests**
  * Expanded test coverage for embedding-model behavior and index compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->