### PR TITLE
fix(local-llm): explicit num_ctx/temperature for ollama chat (#150)

### DIFF
--- a/apps/python/src/local_llm/briefing.py
+++ b/apps/python/src/local_llm/briefing.py
@@ -375,7 +375,9 @@ def load_local_briefing_system_prompt() -> str:
 
 
 class _OllamaChatLike(Protocol):
-    def chat(self, *, model: str, messages: list[dict]) -> Any: ...
+    def chat(
+        self, *, model: str, messages: list[dict], options: dict | None = None
+    ) -> Any: ...
 
 
 def _msg_field(msg: Any, key: str, default: Any = None) -> Any:
@@ -384,26 +386,55 @@ def _msg_field(msg: Any, key: str, default: Any = None) -> Any:
     return getattr(msg, key, default)
 
 
+# 日本語混じりテキストの 1 token ≒ 2-3 文字。控えめに 2 で割って過大側に見積もり、
+# 取りこぼしより誤警告を許容する (#150)。
+_CHARS_PER_TOKEN_ESTIMATE = 2
+
+
 def generate_local_briefing(
     prompt: str,
     *,
     ollama_client: _OllamaChatLike,
     model: str,
     system_prompt: str | None = None,
+    options: dict | None = None,
 ) -> str:
     """Single-turn chat()。tool calling は廃止 (pre-fetch でコンテキストは注入済み)。
 
     `system_prompt` を渡したら role=system を先頭に積む。qwen2.5 系は system
     指示への追従が強いので「与えられた検索結果のみを使って書け」等の制約は
     ここに置く。
+
+    `options` は Ollama の生成オプション (num_ctx / temperature 等)。未指定だと
+    Ollama 既定の num_ctx (4096) でプロンプト末尾が黙って切り捨てられるため、
+    本番経路 (cli) は必ず cfg 由来の値を渡す (#150)。
     """
     messages: list[dict] = []
     if system_prompt:
         messages.append({"role": "system", "content": system_prompt})
     messages.append({"role": "user", "content": prompt})
 
+    total_chars = sum(len(m["content"]) for m in messages)
+    est_tokens = total_chars // _CHARS_PER_TOKEN_ESTIMATE
+    num_ctx = (options or {}).get("num_ctx")
+    if num_ctx and est_tokens > num_ctx:
+        logger.warning(
+            "[briefing] プロンプト概算 %d tokens (%d 文字) が num_ctx=%d を超過 — "
+            "末尾が切り捨てられる可能性",
+            est_tokens,
+            total_chars,
+            num_ctx,
+        )
+    else:
+        logger.info(
+            "[briefing] プロンプト概算 %d tokens (%d 文字) / num_ctx=%s",
+            est_tokens,
+            total_chars,
+            num_ctx if num_ctx else "(Ollama 既定)",
+        )
+
     logger.info("[briefing] ollama.chat — 単発生成 (tools 不使用)")
-    resp = ollama_client.chat(model=model, messages=messages)
+    resp = ollama_client.chat(model=model, messages=messages, options=options)
     msg = _msg_field(resp, "message")
     if msg is None:
         msg = resp

--- a/apps/python/src/local_llm/cli.py
+++ b/apps/python/src/local_llm/cli.py
@@ -220,6 +220,9 @@ def _cmd_briefing(cfg, *, post_to_notion: bool) -> int:
     # 4 段階のセクション分割生成。1 回 chat() で全 9 セクション書かせると
     # attention が散って保有銘柄テーブルで URL 捏造が頻発したため (#後続)、
     # 各段で渡す web_context をそのセクションに必要な分だけに絞る。
+    # Ollama 既定 num_ctx (4096) はセクションプロンプトでも溢れ得るため明示 (#150)。
+    gen_options = {"num_ctx": cfg.num_ctx, "temperature": cfg.temperature}
+
     def _gen(label: str, prompt: str) -> str:
         logger.info("[section] %s 生成開始", label)
         out = generate_local_briefing(
@@ -227,6 +230,7 @@ def _cmd_briefing(cfg, *, post_to_notion: bool) -> int:
             ollama_client=olm,
             model=cfg.model,
             system_prompt=system_prompt,
+            options=gen_options,
         )
         logger.info("[section] %s 生成完了 (%d 文字)", label, len(out))
         return out

--- a/apps/python/src/local_llm/config.py
+++ b/apps/python/src/local_llm/config.py
@@ -15,6 +15,11 @@ DEFAULT_MODEL = "qwen2.5:14b"
 # (#135). Switching changes embedding dimensions, so an existing .chroma_db built
 # with the previous default must be rebuilt: bin/local_llm.sh --index --reset.
 DEFAULT_EMBED_MODEL = "bge-m3"
+# Ollama 既定の num_ctx (4096) では pre-fetch 注入済みプロンプトの末尾が黙って
+# 切り捨てられる (#150)。qwen2.5:14b Q4 + 16K ctx は 24GB RAM で問題なく動く。
+DEFAULT_NUM_CTX = 16384
+# 事実の転記・要約タスクなので低温度で引用追従を優先する。
+DEFAULT_TEMPERATURE = 0.2
 DEFAULT_TOP_K = 6
 DEFAULT_CHUNK_LINES = 40
 DEFAULT_CHUNK_OVERLAP = 8
@@ -39,6 +44,8 @@ class LocalLLMConfig:
     ollama_host: str
     model: str
     embed_model: str
+    num_ctx: int
+    temperature: float
     top_k: int
     repo_root: Path
     chroma_path: Path
@@ -54,6 +61,8 @@ def load_config(repo_root: Path | None = None) -> LocalLLMConfig:
         ollama_host=os.environ.get("OLLAMA_HOST", DEFAULT_OLLAMA_HOST),
         model=os.environ.get("LOCAL_LLM_MODEL", DEFAULT_MODEL),
         embed_model=os.environ.get("LOCAL_LLM_EMBED_MODEL", DEFAULT_EMBED_MODEL),
+        num_ctx=int(os.environ.get("LOCAL_LLM_NUM_CTX", DEFAULT_NUM_CTX)),
+        temperature=float(os.environ.get("LOCAL_LLM_TEMPERATURE", DEFAULT_TEMPERATURE)),
         top_k=int(os.environ.get("LOCAL_LLM_TOP_K", DEFAULT_TOP_K)),
         repo_root=root,
         chroma_path=chroma_path,

--- a/apps/python/src/local_llm/config.py
+++ b/apps/python/src/local_llm/config.py
@@ -6,6 +6,10 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
+from src.logger import get_logger
+
+logger = get_logger(__name__)
+
 DEFAULT_OLLAMA_HOST = "http://localhost:11434"
 # qwen2.5:14b は qwen2.5:7b に比べて tool calling 追従が格段に良く、
 # `--briefing` 経路で web_search を確実に呼ぶために必要。Q4 量子化で ~8.5GB RAM。
@@ -53,6 +57,28 @@ class LocalLLMConfig:
     chunk_overlap: int
 
 
+def _env_number(name: str, default, cast):
+    """env を数値に変換する。不正値は warning を出して既定値にフォールバック。
+
+    バッチ (cron) 経路で typo った env のせいに起動ごと落とすより、既定値で
+    動かしてログに残す方が運用上安全 (Sourcery / CodeRabbit 指摘)。
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return cast(raw)
+    except ValueError:
+        logger.warning(
+            "env %s=%r を %s に変換できないため既定値 %r を使用",
+            name,
+            raw,
+            cast.__name__,
+            default,
+        )
+        return default
+
+
 def load_config(repo_root: Path | None = None) -> LocalLLMConfig:
     root = (repo_root or Path(os.environ.get("LOCAL_LLM_REPO_ROOT", DEFAULT_REPO_ROOT))).resolve()
     chroma_env = os.environ.get("LOCAL_LLM_CHROMA_PATH")
@@ -61,9 +87,9 @@ def load_config(repo_root: Path | None = None) -> LocalLLMConfig:
         ollama_host=os.environ.get("OLLAMA_HOST", DEFAULT_OLLAMA_HOST),
         model=os.environ.get("LOCAL_LLM_MODEL", DEFAULT_MODEL),
         embed_model=os.environ.get("LOCAL_LLM_EMBED_MODEL", DEFAULT_EMBED_MODEL),
-        num_ctx=int(os.environ.get("LOCAL_LLM_NUM_CTX", DEFAULT_NUM_CTX)),
-        temperature=float(os.environ.get("LOCAL_LLM_TEMPERATURE", DEFAULT_TEMPERATURE)),
-        top_k=int(os.environ.get("LOCAL_LLM_TOP_K", DEFAULT_TOP_K)),
+        num_ctx=_env_number("LOCAL_LLM_NUM_CTX", DEFAULT_NUM_CTX, int),
+        temperature=_env_number("LOCAL_LLM_TEMPERATURE", DEFAULT_TEMPERATURE, float),
+        top_k=_env_number("LOCAL_LLM_TOP_K", DEFAULT_TOP_K, int),
         repo_root=root,
         chroma_path=chroma_path,
         chunk_lines=DEFAULT_CHUNK_LINES,

--- a/apps/python/tests/local_llm/test_briefing.py
+++ b/apps/python/tests/local_llm/test_briefing.py
@@ -436,16 +436,30 @@ def test_generate_local_briefing_passes_options_to_chat():
     assert olm.calls[0]["options"] == {"num_ctx": 16384, "temperature": 0.2}
 
 
+def test_generate_local_briefing_defaults_to_no_options(caplog):
+    olm = _ScriptedOllama(reply={"message": {"content": "body"}})
+    with caplog.at_level(logging.INFO, logger="src.local_llm.briefing"):
+        generate_local_briefing("PROMPT", ollama_client=olm, model="m")
+    # options 未指定の既存呼び出しは chat() に None を渡す (後方互換)
+    assert olm.calls[0]["options"] is None
+    # num_ctx 不明時は警告ではなく info で「Ollama 既定」と記録する
+    assert not any(r.levelname == "WARNING" for r in caplog.records)
+    assert any("(Ollama 既定)" in r.getMessage() for r in caplog.records)
+
+
 def test_generate_local_briefing_warns_when_prompt_exceeds_num_ctx(caplog):
     olm = _ScriptedOllama(reply={"message": {"content": "body"}})
-    with caplog.at_level("WARNING"):
+    with caplog.at_level(logging.WARNING, logger="src.local_llm.briefing"):
         generate_local_briefing(
             "x" * 100,
             ollama_client=olm,
             model="m",
             options={"num_ctx": 10},
         )
-    assert any("num_ctx=10 を超過" in r.message for r in caplog.records)
+    assert any(
+        r.levelname == "WARNING" and "num_ctx=10" in r.getMessage()
+        for r in caplog.records
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/apps/python/tests/local_llm/test_briefing.py
+++ b/apps/python/tests/local_llm/test_briefing.py
@@ -390,8 +390,10 @@ class _ScriptedOllama:
         self._reply = reply
         self.calls: list[dict] = []
 
-    def chat(self, *, model, messages):
-        self.calls.append({"model": model, "messages": list(messages)})
+    def chat(self, *, model, messages, options=None):
+        self.calls.append(
+            {"model": model, "messages": list(messages), "options": options}
+        )
         return self._reply
 
 
@@ -421,6 +423,29 @@ def test_generate_local_briefing_omits_system_when_not_provided():
     )
     assert out == "body"
     assert olm.calls[0]["messages"] == [{"role": "user", "content": "PROMPT"}]
+
+
+def test_generate_local_briefing_passes_options_to_chat():
+    olm = _ScriptedOllama(reply={"message": {"content": "body"}})
+    generate_local_briefing(
+        "PROMPT",
+        ollama_client=olm,
+        model="m",
+        options={"num_ctx": 16384, "temperature": 0.2},
+    )
+    assert olm.calls[0]["options"] == {"num_ctx": 16384, "temperature": 0.2}
+
+
+def test_generate_local_briefing_warns_when_prompt_exceeds_num_ctx(caplog):
+    olm = _ScriptedOllama(reply={"message": {"content": "body"}})
+    with caplog.at_level("WARNING"):
+        generate_local_briefing(
+            "x" * 100,
+            ollama_client=olm,
+            model="m",
+            options={"num_ctx": 10},
+        )
+    assert any("num_ctx=10 を超過" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------
@@ -600,9 +625,9 @@ class _FakeRunCLI:
             cli, "load_local_briefing_system_prompt", lambda: "SYS"
         )
 
-        def _fake_generate(prompt, *, ollama_client, model, system_prompt):
+        def _fake_generate(prompt, *, ollama_client, model, system_prompt, options=None):
             self.generate_calls.append(
-                {"prompt": prompt, "system_prompt": system_prompt}
+                {"prompt": prompt, "system_prompt": system_prompt, "options": options}
             )
             # CLI 側は 4 回 chat() を呼ぶ。テストごとに変えたい本文 (URL 捏造を
             # 仕込む等) は 1 段目 (topnews) に集約し、他はラベルだけ返す。
@@ -659,6 +684,11 @@ def test_cmd_briefing_prefetches_and_writes_local_file(monkeypatch, tmp_path):
     assert "保有銘柄テーブル" in prompts[3]
     # 全段に同じ system prompt が乗る
     assert all(c["system_prompt"] == "SYS" for c in fake.generate_calls)
+    # 全段に cfg 由来の生成オプションが乗る (#150 — Ollama 既定 num_ctx 回避)
+    for c in fake.generate_calls:
+        assert c["options"] is not None
+        assert c["options"]["num_ctx"] == 16384
+        assert c["options"]["temperature"] == 0.2
     # 参考記事セクションが Python 側で追加されている
     assert "## 参考記事" in content
     # portfolio セグメントはモデルが見出し・区切り行を省略したが、CLI 側の

--- a/apps/python/tests/local_llm/test_clients.py
+++ b/apps/python/tests/local_llm/test_clients.py
@@ -80,6 +80,8 @@ def _make_cfg(chroma_path, embed_model):
         ollama_host="http://localhost:11434",
         model="qwen2.5:14b",
         embed_model=embed_model,
+        num_ctx=16384,
+        temperature=0.2,
         top_k=6,
         repo_root=chroma_path.parent,
         chroma_path=chroma_path,

--- a/apps/python/tests/local_llm/test_config.py
+++ b/apps/python/tests/local_llm/test_config.py
@@ -9,6 +9,8 @@ def test_load_config_defaults(monkeypatch, tmp_path):
         "OLLAMA_HOST",
         "LOCAL_LLM_MODEL",
         "LOCAL_LLM_EMBED_MODEL",
+        "LOCAL_LLM_NUM_CTX",
+        "LOCAL_LLM_TEMPERATURE",
         "LOCAL_LLM_TOP_K",
         "LOCAL_LLM_CHROMA_PATH",
     ]:
@@ -20,6 +22,8 @@ def test_load_config_defaults(monkeypatch, tmp_path):
     assert cfg.ollama_host == "http://localhost:11434"
     assert cfg.model == "qwen2.5:14b"
     assert cfg.embed_model == "bge-m3"
+    assert cfg.num_ctx == 16384
+    assert cfg.temperature == 0.2
     assert cfg.top_k == 6
     assert cfg.repo_root == tmp_path
     assert cfg.chunk_lines == 40
@@ -31,6 +35,8 @@ def test_load_config_env_overrides(monkeypatch, tmp_path):
     monkeypatch.setenv("OLLAMA_HOST", "http://example:11434")
     monkeypatch.setenv("LOCAL_LLM_MODEL", "qwen2.5:32b")
     monkeypatch.setenv("LOCAL_LLM_EMBED_MODEL", "nomic-embed-text")
+    monkeypatch.setenv("LOCAL_LLM_NUM_CTX", "32768")
+    monkeypatch.setenv("LOCAL_LLM_TEMPERATURE", "0.7")
     monkeypatch.setenv("LOCAL_LLM_TOP_K", "10")
     monkeypatch.setenv("LOCAL_LLM_CHROMA_PATH", str(tmp_path / "custom_chroma"))
 
@@ -39,5 +45,7 @@ def test_load_config_env_overrides(monkeypatch, tmp_path):
     assert cfg.ollama_host == "http://example:11434"
     assert cfg.model == "qwen2.5:32b"
     assert cfg.embed_model == "nomic-embed-text"
+    assert cfg.num_ctx == 32768
+    assert cfg.temperature == 0.7
     assert cfg.top_k == 10
     assert cfg.chroma_path == tmp_path / "custom_chroma"

--- a/apps/python/tests/local_llm/test_config.py
+++ b/apps/python/tests/local_llm/test_config.py
@@ -49,3 +49,18 @@ def test_load_config_env_overrides(monkeypatch, tmp_path):
     assert cfg.temperature == 0.7
     assert cfg.top_k == 10
     assert cfg.chroma_path == tmp_path / "custom_chroma"
+
+
+def test_load_config_falls_back_on_malformed_numeric_env(monkeypatch, tmp_path, caplog):
+    monkeypatch.setenv("LOCAL_LLM_NUM_CTX", "abc")
+    monkeypatch.setenv("LOCAL_LLM_TEMPERATURE", "warm")
+
+    with caplog.at_level("WARNING", logger="src.local_llm.config"):
+        cfg = load_config(repo_root=tmp_path)
+
+    # 不正値はクラッシュせず既定値にフォールバックし、warning に残す
+    assert cfg.num_ctx == 16384
+    assert cfg.temperature == 0.2
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("LOCAL_LLM_NUM_CTX" in m for m in messages)
+    assert any("LOCAL_LLM_TEMPERATURE" in m for m in messages)


### PR DESCRIPTION
## Summary
- Add `LocalLLMConfig.num_ctx` / `.temperature` (defaults 16384 / 0.2, env overrides `LOCAL_LLM_NUM_CTX` / `LOCAL_LLM_TEMPERATURE`)
- Pass them as `options` to `ollama_client.chat()` from the briefing CLI — Ollama's default num_ctx (4096) was silently truncating the tail of pre-fetch-injected prompts
- Log estimated prompt tokens vs num_ctx (warns on overflow) so truncation is visible in logs
- Update test stubs (`chat(..., options=...)`) and add coverage: options pass-through, overflow warning, config defaults/env overrides

Closes #150

## Test plan
- [x] `pytest tests/local_llm/ -v` — 76 passed
- [x] full suite — 431 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add configurable generation options for local Ollama briefings and surface context window issues in logs.

New Features:
- Introduce num_ctx and temperature fields to LocalLLMConfig with environment-variable overrides and use them as generation options for Ollama chat requests.

Enhancements:
- Propagate configurable num_ctx and temperature options from the CLI to all local briefing generation calls to avoid relying on Ollama defaults.
- Log estimated prompt token usage against num_ctx, warning when the prompt is likely to exceed the context window.

Tests:
- Extend local LLM tests to cover configuration defaults and env overrides for num_ctx/temperature, options pass-through to Ollama chat, and warnings when prompts exceed num_ctx.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable LLM generation parameters: context window size (`num_ctx`) and temperature control, with environment variable support.
  * Added warning when prompt size estimates exceed the configured context window limit.

* **Chores**
  * Updated tests to validate new parameter handling and configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->