### PR TITLE
feat(local-llm): improve Brave Search query quality (#153)

### DIFF
--- a/apps/python/config/briefing.json.example
+++ b/apps/python/config/briefing.json.example
@@ -1,102 +1,266 @@
 {
   "portfolio": {
-    "tickers": ["PLTR", "NVDA", "CBRS"],
-    "themes": ["AI規制", "米中関係", "半導体", "関税・貿易戦争", "FRB金融政策", "脱炭素・エネルギー転換", "食料安全保障・農業テック", "サイバーセキュリティ", "バイオ・ゲノム編集"]
+    "tickers": [
+      "PLTR",
+      "NVDA",
+      "CBRS"
+    ],
+    "themes": [
+      "AI規制",
+      "米中関係",
+      "半導体",
+      "関税・貿易戦争",
+      "FRB金融政策",
+      "脱炭素・エネルギー転換",
+      "食料安全保障・農業テック",
+      "サイバーセキュリティ",
+      "バイオ・ゲノム編集"
+    ]
   },
   "watch_sectors": [
     {
       "sector": "AI・クラウド",
-      "tickers": ["NVDA", "MSFT", "GOOGL", "META", "AMZN", "ORCL", "CRM", "SNOW", "PLTR"],
+      "tickers": [
+        "NVDA",
+        "MSFT",
+        "GOOGL",
+        "META",
+        "AMZN",
+        "ORCL",
+        "CRM",
+        "SNOW",
+        "PLTR"
+      ],
       "notes": "AI設備投資サイクル・モデル競争・規制動向が株価ドライバー"
     },
     {
       "sector": "半導体・製造装置",
-      "tickers": ["NVDA", "AMD", "INTC", "QCOM", "ARM", "TSM", "ASML", "AMAT", "LRCX", "MU"],
+      "tickers": [
+        "NVDA",
+        "AMD",
+        "INTC",
+        "QCOM",
+        "ARM",
+        "TSM",
+        "ASML",
+        "AMAT",
+        "LRCX",
+        "MU"
+      ],
       "notes": "米中輸出規制・台湾リスク・データセンター向け需要が焦点。ASMLは欧州規制の影響大"
     },
     {
       "sector": "サイバーセキュリティ",
-      "tickers": ["CRWD", "PANW", "ZS", "FTNT", "S", "OKTA", "CYBR"],
+      "tickers": [
+        "CRWD",
+        "PANW",
+        "ZS",
+        "FTNT",
+        "S",
+        "OKTA",
+        "CYBR"
+      ],
       "notes": "ランサムウェア・国家支援型攻撃の増加で政府・企業需要が底堅い。AI活用による脅威検知が次の競争軸"
     },
     {
       "sector": "防衛・宇宙",
-      "tickers": ["LMT", "RTX", "NOC", "GD", "BA", "HII"],
+      "tickers": [
+        "LMT",
+        "RTX",
+        "NOC",
+        "GD",
+        "BA",
+        "HII"
+      ],
       "notes": "NATO防衛費増加・地政学緊張が追い風。継続的な増勢予算で長期受注残が積み上がる構図"
     },
     {
       "sector": "エネルギー（石油・ガス）",
-      "tickers": ["XOM", "CVX", "COP", "BP", "SHEL", "EOG", "SLB"],
+      "tickers": [
+        "XOM",
+        "CVX",
+        "COP",
+        "BP",
+        "SHEL",
+        "EOG",
+        "SLB"
+      ],
       "notes": "原油価格・OPEC+産量・中東リスクが直結。SLBは探掘サービスで景気敏感性高い"
     },
     {
       "sector": "再生可能エネルギー・電力",
-      "tickers": ["NEE", "ENPH", "FSLR", "BE", "GEV"],
+      "tickers": [
+        "NEE",
+        "ENPH",
+        "FSLR",
+        "BE",
+        "GEV"
+      ],
       "notes": "IRA補助金・金利動向・電力需要急増（データセンター）が変数。金利低下局面で追い風"
     },
     {
       "sector": "ヘルスケア・製薬",
-      "tickers": ["LLY", "UNH", "JNJ", "PFE", "MRK", "ABBV", "BMY", "AMGN", "GILD", "MRNA"],
+      "tickers": [
+        "LLY",
+        "UNH",
+        "JNJ",
+        "PFE",
+        "MRK",
+        "ABBV",
+        "BMY",
+        "AMGN",
+        "GILD",
+        "MRNA"
+      ],
       "notes": "GLP-1肥満治療薬（LLY）・薬価規制（IRA）・特許崖がセクター全体の焦点"
     },
     {
       "sector": "バイオテク・ゲノム編集",
-      "tickers": ["REGN", "VRTX", "BIIB", "ILMN", "CRSP", "EDIT", "NTLA", "BEAM"],
+      "tickers": [
+        "REGN",
+        "VRTX",
+        "BIIB",
+        "ILMN",
+        "CRSP",
+        "EDIT",
+        "NTLA",
+        "BEAM"
+      ],
       "notes": "CRISPR・mRNA・細胞療法が次世代パイプラインの柱。FDA承認タイミングが株価の急騰・急落トリガー"
     },
     {
       "sector": "農業・農業テック",
-      "tickers": ["DE", "MOS", "CF", "CTVA", "FMC", "ADM", "BG"],
+      "tickers": [
+        "DE",
+        "MOS",
+        "CF",
+        "CTVA",
+        "FMC",
+        "ADM",
+        "BG"
+      ],
       "notes": "食料安全保障・肥料価格（天然ガス連動）・気候変動対応が需要ドライバー。ウクライナ紛争による穀物供給不安が継続リスク"
     },
     {
       "sector": "金融・銀行",
-      "tickers": ["JPM", "BAC", "GS", "MS", "C", "WFC", "V", "MA", "BLK"],
+      "tickers": [
+        "JPM",
+        "BAC",
+        "GS",
+        "MS",
+        "C",
+        "WFC",
+        "V",
+        "MA",
+        "BLK"
+      ],
       "notes": "FRB利下げペース・信用コスト・規制緩和（バーゼルIII最終化）が業績に直結"
     },
     {
       "sector": "フィンテック・暗号資産",
-      "tickers": ["SQ", "PYPL", "COIN", "NU", "HOOD"],
+      "tickers": [
+        "SQ",
+        "PYPL",
+        "COIN",
+        "NU",
+        "HOOD"
+      ],
       "notes": "暗号資産規制・金利水準・決済競争が変数。COINはBTC価格との連動性が高い"
     },
     {
       "sector": "消費者・小売・EC",
-      "tickers": ["AMZN", "WMT", "COST", "TGT", "HD", "MCD", "SBUX", "NKE"],
+      "tickers": [
+        "AMZN",
+        "WMT",
+        "COST",
+        "TGT",
+        "HD",
+        "MCD",
+        "SBUX",
+        "NKE"
+      ],
       "notes": "消費者信頼感・関税（輸入コスト）・雇用統計が先行指標。HDは住宅ローン金利に敏感"
     },
     {
       "sector": "EV・自動車",
-      "tickers": ["TSLA", "GM", "F", "TM", "RIVN", "ON"],
+      "tickers": [
+        "TSLA",
+        "GM",
+        "F",
+        "TM",
+        "RIVN",
+        "ON"
+      ],
       "notes": "EV補助金見直し・中国EV関税・バッテリーコストが業績左右。TSLAはAI・ロボット期待も含む"
     },
     {
       "sector": "産業・重工業・機械",
-      "tickers": ["CAT", "HON", "GE", "ETN", "EMR", "ITW"],
+      "tickers": [
+        "CAT",
+        "HON",
+        "GE",
+        "ETN",
+        "EMR",
+        "ITW"
+      ],
       "notes": "インフラ投資・製造業PMI・設備投資サイクルが需要ドライバー。GEはエアロエンジンで超過需要"
     },
     {
       "sector": "ロボティクス・産業オートメーション",
-      "tickers": ["ABB", "ROK", "ISRG", "FANUC", "TER", "BRKS"],
+      "tickers": [
+        "ABB",
+        "ROK",
+        "ISRG",
+        "FANUC",
+        "TER",
+        "BRKS"
+      ],
       "notes": "人件費高騰・製造業の国内回帰（ニアショアリング）が自動化投資を加速。外科ロボット（ISRG）は医療費圧縮の切り札"
     },
     {
       "sector": "海運・物流",
-      "tickers": ["ZIM", "FDX", "UPS", "XPO", "CHRW", "EXPD"],
+      "tickers": [
+        "ZIM",
+        "FDX",
+        "UPS",
+        "XPO",
+        "CHRW",
+        "EXPD"
+      ],
       "notes": "紅海・ホルムズ海峡の地政学リスクが運賃に直結。eコマース需要と過剰船腹の需給バランスが焦点"
     },
     {
       "sector": "素材・資源・鉱業",
-      "tickers": ["FCX", "NEM", "AA", "NUE", "LIN"],
+      "tickers": [
+        "FCX",
+        "NEM",
+        "AA",
+        "NUE",
+        "LIN"
+      ],
       "notes": "中国需要・ドル高・脱炭素向け素材（銅：FCX）需要増が注目点。金（NEM）は地政学ヘッジ"
     },
     {
       "sector": "通信・メディア・エンタメ",
-      "tickers": ["DIS", "NFLX", "CMCSA", "T", "VZ", "TMUS"],
+      "tickers": [
+        "DIS",
+        "NFLX",
+        "CMCSA",
+        "T",
+        "VZ",
+        "TMUS"
+      ],
       "notes": "ストリーミング競争・5G設備投資・広告市場の回復度合いがカタリスト"
     },
     {
       "sector": "不動産・REIT",
-      "tickers": ["PLD", "AMT", "EQIX", "SPG", "O"],
+      "tickers": [
+        "PLD",
+        "AMT",
+        "EQIX",
+        "SPG",
+        "O"
+      ],
       "notes": "金利低下がバリュエーション直撃。データセンターREIT（EQIX）はAI需要で別格の強さ"
     }
   ],
@@ -104,8 +268,17 @@
     {
       "name": "SpaceX IPO",
       "trigger": "SECへのS-1正式申請",
-      "affected_sectors": ["防衛・宇宙", "テクノロジー", "AI・クラウド"],
-      "related_tickers": ["RKLB", "ASTS", "MNTS", "LUNR"],
+      "affected_sectors": [
+        "防衛・宇宙",
+        "テクノロジー",
+        "AI・クラウド"
+      ],
+      "related_tickers": [
+        "RKLB",
+        "ASTS",
+        "MNTS",
+        "LUNR"
+      ],
       "notes": "SpaceX上場時は宇宙セクター全体の再評価が起きやすい。競合のRKLB・ASTSへの影響（バリュエーション圧縮 or 注目集中）に注目。Starlink分離上場シナリオも要ウォッチ"
     }
   ],
@@ -113,39 +286,113 @@
     "conflicts": [
       {
         "name": "ロシア・ウクライナ戦争",
-        "affected_sectors": ["エネルギー", "防衛産業", "穀物・農業", "欧州株"],
-        "related_tickers": ["LMT", "RTX", "NOC", "XOM", "BP", "SHEL"],
-        "notes": "欧州のエネルギー依存・穀物供給不安が継続。NATO加盟国の防衛費増加でLMT/RTXに追い風"
+        "affected_sectors": [
+          "エネルギー",
+          "防衛産業",
+          "穀物・農業",
+          "欧州株"
+        ],
+        "related_tickers": [
+          "LMT",
+          "RTX",
+          "NOC",
+          "XOM",
+          "BP",
+          "SHEL"
+        ],
+        "notes": "欧州のエネルギー依存・穀物供給不安が継続。NATO加盟国の防衛費増加でLMT/RTXに追い風",
+        "query_en": "Russia Ukraine war"
       },
       {
         "name": "中東紛争（イスラエル・ガザ・イラン）",
-        "affected_sectors": ["エネルギー", "防衛産業", "海運・物流"],
-        "related_tickers": ["XOM", "CVX", "COP", "LMT", "NOC", "SLB"],
-        "notes": "ホルムズ海峡リスクが原油価格に直結。イラン核合意の行方次第で原油±10%の変動リスク"
+        "affected_sectors": [
+          "エネルギー",
+          "防衛産業",
+          "海運・物流"
+        ],
+        "related_tickers": [
+          "XOM",
+          "CVX",
+          "COP",
+          "LMT",
+          "NOC",
+          "SLB"
+        ],
+        "notes": "ホルムズ海峡リスクが原油価格に直結。イラン核合意の行方次第で原油±10%の変動リスク",
+        "query_en": "Israel Iran Middle East conflict"
       },
       {
         "name": "米中技術覇権争い・台湾リスク",
-        "affected_sectors": ["半導体", "AI・クラウド", "防衛産業", "EV・バッテリー"],
-        "related_tickers": ["NVDA", "TSM", "AMAT", "ASML", "PLTR", "AMD", "LRCX"],
-        "notes": "台湾有事シナリオはTSM・NVDAに直撃。輸出規制の強化・緩和がNVDA株価の短期ドライバー"
+        "affected_sectors": [
+          "半導体",
+          "AI・クラウド",
+          "防衛産業",
+          "EV・バッテリー"
+        ],
+        "related_tickers": [
+          "NVDA",
+          "TSM",
+          "AMAT",
+          "ASML",
+          "PLTR",
+          "AMD",
+          "LRCX"
+        ],
+        "notes": "台湾有事シナリオはTSM・NVDAに直撃。輸出規制の強化・緩和がNVDA株価の短期ドライバー",
+        "query_en": "US China chip export controls Taiwan"
       },
       {
         "name": "米国関税・貿易戦争（トランプ政権）",
-        "affected_sectors": ["製造業", "消費財", "半導体", "EV・自動車", "素材"],
-        "related_tickers": ["TSLA", "GM", "F", "AAPL", "NKE", "CAT", "FCX", "AA"],
-        "notes": "相互関税・中国製品への高関税がサプライチェーン再編を加速。ニアショアリング恩恵はCAT・ETN"
+        "affected_sectors": [
+          "製造業",
+          "消費財",
+          "半導体",
+          "EV・自動車",
+          "素材"
+        ],
+        "related_tickers": [
+          "TSLA",
+          "GM",
+          "F",
+          "AAPL",
+          "NKE",
+          "CAT",
+          "FCX",
+          "AA"
+        ],
+        "notes": "相互関税・中国製品への高関税がサプライチェーン再編を加速。ニアショアリング恩恵はCAT・ETN",
+        "query_en": "Trump tariffs trade war"
       },
       {
         "name": "インド・パキスタン緊張",
-        "affected_sectors": ["防衛産業", "エネルギー", "新興国株"],
-        "related_tickers": ["LMT", "RTX", "NOC", "XOM"],
-        "notes": "核保有国同士の衝突リスク。エスカレーション時はリスクオフでゴールド・原油上昇圧力"
+        "affected_sectors": [
+          "防衛産業",
+          "エネルギー",
+          "新興国株"
+        ],
+        "related_tickers": [
+          "LMT",
+          "RTX",
+          "NOC",
+          "XOM"
+        ],
+        "notes": "核保有国同士の衝突リスク。エスカレーション時はリスクオフでゴールド・原油上昇圧力",
+        "query_en": "India Pakistan tensions"
       },
       {
         "name": "北朝鮮・朝鮮半島リスク",
-        "affected_sectors": ["防衛産業", "半導体（韓国）"],
-        "related_tickers": ["LMT", "RTX", "NOC", "AMAT"],
-        "notes": "有事時はSamsungやSKハイニックスの供給網に打撃。DRAMスポット価格急騰リスク"
+        "affected_sectors": [
+          "防衛産業",
+          "半導体（韓国）"
+        ],
+        "related_tickers": [
+          "LMT",
+          "RTX",
+          "NOC",
+          "AMAT"
+        ],
+        "notes": "有事時はSamsungやSKハイニックスの供給網に打撃。DRAMスポット価格急騰リスク",
+        "query_en": "North Korea missile Korean peninsula"
       }
     ]
   }

--- a/apps/python/src/config.py
+++ b/apps/python/src/config.py
@@ -35,6 +35,9 @@ class Conflict(BaseModel):
     affected_sectors: list[str]
     related_tickers: list[str] = Field(default_factory=list)
     notes: str | None = None
+    # ローカル LLM 経路の pre-fetch 用英語検索クエリ (#153)。日本語トピック名の
+    # 検索は常設の索引ページを引きがちなので、設定があればこちらを優先する。
+    query_en: str | None = None
 
 
 class GeopoliticalConfig(BaseModel):

--- a/apps/python/src/local_llm/briefing.py
+++ b/apps/python/src/local_llm/briefing.py
@@ -31,6 +31,30 @@ PER_MACRO_RESULTS = 3
 PER_GEO_RESULTS = 2
 PER_EVENT_RESULTS = 2
 
+# Brave の鮮度フィルタ。日次ブリーフィングなので直近 1 週間に絞る (#153)。
+PREFETCH_FRESHNESS = "pw"
+# 索引ページフィルタで間引かれる分を見込んだ over-fetch の上乗せ件数。
+OVERFETCH_EXTRA = 3
+
+# ニュース本文ではない常設の銘柄索引/クオートページ。スニペットに当日の事実が
+# 含まれず、プロンプトを汚すだけなので注入前に間引く (#153)。
+_INDEX_PAGE_URL_PATTERNS = [
+    re.compile(p)
+    for p in (
+        r"finance\.yahoo\.com/quote/",
+        r"robinhood\.com/.*/stocks/",
+        r"google\.com/finance",
+        r"investing\.com/equities/",
+        r"stockanalysis\.com/stocks/",
+        r"seekingalpha\.com/symbol/",
+        r"amazon\.(com|co\.jp)/",
+    )
+]
+
+
+def _is_index_page(url: str) -> bool:
+    return any(p.search(url) for p in _INDEX_PAGE_URL_PATTERNS)
+
 
 @dataclass(frozen=True)
 class PrefetchedContext:
@@ -67,11 +91,23 @@ class PrefetchedContext:
 def _safe_search(
     client: BraveSearchClient, query: str, count: int
 ) -> list[SearchResult]:
+    """freshness=pw + 索引ページフィルタ付きの web_search (#153)。
+
+    フィルタで間引かれても count 件残るよう OVERFETCH_EXTRA 件多めに取り、
+    フィルタ後に count 件へ切り詰める。失敗は空リスト (他クエリは継続)。
+    """
     try:
-        return client.search(query, count=count)
+        hits = client.search(
+            query, count=count + OVERFETCH_EXTRA, freshness=PREFETCH_FRESHNESS
+        )
     except BraveSearchError as e:
         logger.warning("[prefetch] web_search failed for %r: %s", query, e)
         return []
+    kept = [r for r in hits if not _is_index_page(r.url)]
+    dropped = len(hits) - len(kept)
+    if dropped:
+        logger.info("[prefetch] %r: 索引ページ %d 件を除外", query, dropped)
+    return kept[:count]
 
 
 def prefetch_briefing_context(
@@ -106,9 +142,13 @@ def prefetch_briefing_context(
         name = getattr(conflict, "name", None) or ""
         if not name:
             continue
-        hits = _safe_search(search_client, f"{name} today", PER_GEO_RESULTS)
+        # 日本語トピック名のままだと常設のトピック索引ページや書籍ページが上位に
+        # 来る。briefing.json に query_en があれば英語ニュースクエリを使う (#153)。
+        query_en = getattr(conflict, "query_en", None) or ""
+        query = f"{query_en} latest news" if query_en else f"{name} today"
+        hits = _safe_search(search_client, query, PER_GEO_RESULTS)
         geo_by_topic[name] = hits
-        logger.info("[prefetch] geo topic=%r hits=%d", name, len(hits))
+        logger.info("[prefetch] geo topic=%r query=%r hits=%d", name, query, len(hits))
 
     events_by_name: dict[str, list[SearchResult]] = {}
     for event in getattr(cfg, "watch_events", None) or []:

--- a/apps/python/src/local_llm/briefing.py
+++ b/apps/python/src/local_llm/briefing.py
@@ -34,6 +34,8 @@ PER_EVENT_RESULTS = 2
 # Brave の鮮度フィルタ。日次ブリーフィングなので直近 1 週間に絞る (#153)。
 PREFETCH_FRESHNESS = "pw"
 # 索引ページフィルタで間引かれる分を見込んだ over-fetch の上乗せ件数。
+# Brave の count 上限は 10 (クライアント側で clamp)。現状の PER_* 最大は 3 なので
+# 3+3=6 で枠内だが、PER_* を増やす場合は 10 を超えないよう注意。
 OVERFETCH_EXTRA = 3
 
 # ニュース本文ではない常設の銘柄索引/クオートページ。スニペットに当日の事実が
@@ -47,7 +49,9 @@ _INDEX_PAGE_URL_PATTERNS = [
         r"investing\.com/equities/",
         r"stockanalysis\.com/stocks/",
         r"seekingalpha\.com/symbol/",
-        r"amazon\.(com|co\.jp)/",
+        # Amazon は商品詳細ページ (/dp/, /gp/product/ — 商品名スラッグ付きも可)
+        # のみ除外。記事系ページまで落とさないようドメイン全体は対象にしない。
+        r"amazon\.(com|co\.jp)/(.+/)?(gp/product|dp)/",
     )
 ]
 

--- a/apps/python/src/local_llm/search.py
+++ b/apps/python/src/local_llm/search.py
@@ -47,9 +47,18 @@ class BraveSearchClient:
         self._http = http_client
         self._timeout = timeout
 
-    def search(self, query: str, count: int = 5) -> list[SearchResult]:
+    def search(
+        self, query: str, count: int = 5, freshness: str | None = None
+    ) -> list[SearchResult]:
+        """`freshness` は Brave の鮮度フィルタ (pd=24h / pw=1週間 / pm=1ヶ月)。
+
+        日次ブリーフィングの pre-fetch はトピック索引ページ (SEO 上位の常設
+        ページ) を引きがちなので、呼び出し側は基本 "pw" を渡す (#153)。
+        """
         count = max(1, min(int(count), 10))
-        params = {"q": query, "count": count}
+        params: dict[str, Any] = {"q": query, "count": count}
+        if freshness:
+            params["freshness"] = freshness
         headers = {
             "Accept": "application/json",
             "X-Subscription-Token": self._api_key,

--- a/apps/python/tests/config/briefing.json
+++ b/apps/python/tests/config/briefing.json
@@ -25,7 +25,8 @@
         "name": "地政学リスク名",
         "affected_sectors": ["影響セクター1"],
         "related_tickers": ["TICKER1"],
-        "notes": "背景メモ（任意）"
+        "notes": "背景メモ（任意）",
+        "query_en": "english search query for local-LLM pre-fetch (optional)"
       }
     ]
   }

--- a/apps/python/tests/local_llm/test_briefing.py
+++ b/apps/python/tests/local_llm/test_briefing.py
@@ -207,7 +207,12 @@ def test_prefetch_filters_index_pages_and_trims_to_count():
     assert ctx.per_ticker["PLTR"] == news[:PER_TICKER_RESULTS]
     for r in index_pages:
         assert _is_index_page(r.url), r.url
+    # 商品名スラッグ付きの Amazon 商品ページ (local_2026-06-11 で実際に汚染した形)
+    assert _is_index_page("https://www.amazon.co.jp/%E5%8F%B0%E6%B9%BE%E6%9C%89%E4%BA%8B-987/dp/4582859879")
     assert not _is_index_page("https://news.example.com/article-1")
+    # Amazon の記事系ページ (商品詳細以外) は除外しない
+    assert not _is_index_page("https://www.aboutamazon.com/news/company-news/q1-results")
+    assert not _is_index_page("https://www.amazon.com/press-release/some-news")
 
 
 def test_prefetch_uses_english_geo_query_when_query_en_set():

--- a/apps/python/tests/local_llm/test_briefing.py
+++ b/apps/python/tests/local_llm/test_briefing.py
@@ -13,8 +13,13 @@ from src.config import (
 )
 from src.local_llm import cli
 from src.local_llm.briefing import (
+    OVERFETCH_EXTRA,
+    PER_GEO_RESULTS,
+    PER_MACRO_RESULTS,
+    PER_TICKER_RESULTS,
     PrefetchedContext,
     UrlValidation,
+    _is_index_page,
     build_section_geo_events_prompt,
     build_section_insight_prompt,
     build_section_portfolio_prompt,
@@ -65,8 +70,8 @@ class _StubSearch:
         self.responses = responses or {}
         self.calls: list[dict] = []
 
-    def search(self, query, count=5):
-        self.calls.append({"query": query, "count": count})
+    def search(self, query, count=5, freshness=None):
+        self.calls.append({"query": query, "count": count, "freshness": freshness})
         return self.responses.get(query, [])
 
 
@@ -120,7 +125,7 @@ def test_prefetch_handles_brave_errors_per_query(caplog):
         def __init__(self):
             self.calls: list[str] = []
 
-        def search(self, query, count=5):
+        def search(self, query, count=5, freshness=None):
             self.calls.append(query)
             if "PLTR" in query:
                 raise BraveSearchError("HTTP 429: rate limited")
@@ -152,6 +157,83 @@ def test_prefetch_skips_geo_when_no_conflicts_configured():
         if "today" in q and q != "stock market news 2026-06-09" and "stock news" not in q
     ]
     assert geo_or_event_queries == []
+
+
+def test_prefetch_requests_freshness_and_overfetch_on_every_query():
+    cfg = _minimal_cfg(
+        tickers=["PLTR"],
+        conflicts=[Conflict(name="米中", affected_sectors=["半導体"])],
+    )
+    search = _StubSearch()
+
+    prefetch_briefing_context(cfg, search_client=search, today="2026-06-09")
+
+    assert search.calls, "search が呼ばれていない"
+    # 直近 1 週間に絞り、索引ページフィルタの間引き分を over-fetch する (#153)
+    for call in search.calls:
+        assert call["freshness"] == "pw"
+    by_query = {c["query"]: c for c in search.calls}
+    assert by_query["stock market news 2026-06-09"]["count"] == (
+        PER_MACRO_RESULTS + OVERFETCH_EXTRA
+    )
+    assert by_query["PLTR stock news 2026-06-09"]["count"] == (
+        PER_TICKER_RESULTS + OVERFETCH_EXTRA
+    )
+    assert by_query["米中 today"]["count"] == PER_GEO_RESULTS + OVERFETCH_EXTRA
+
+
+def test_prefetch_filters_index_pages_and_trims_to_count():
+    cfg = _minimal_cfg(tickers=["PLTR"], conflicts=[])
+    news = [
+        SearchResult(f"News {i}", f"https://news.example.com/{i}", "d")
+        for i in range(PER_TICKER_RESULTS + 1)
+    ]
+    index_pages = [
+        SearchResult("Quote", "https://finance.yahoo.com/quote/PLTR/", "d"),
+        SearchResult("RH", "https://robinhood.com/us/en/stocks/PLTR/", "d"),
+        SearchResult("GF", "https://www.google.com/finance/beta/quote/PLTR:NASDAQ", "d"),
+        SearchResult("Inv", "https://www.investing.com/equities/palantir", "d"),
+        SearchResult("SA", "https://stockanalysis.com/stocks/pltr/", "d"),
+        SearchResult("SeekA", "https://seekingalpha.com/symbol/PLTR", "d"),
+        SearchResult("Book", "https://www.amazon.co.jp/dp/4582859879", "d"),
+    ]
+    search = _StubSearch(
+        responses={"PLTR stock news 2026-06-09": index_pages[:2] + news}
+    )
+
+    ctx = prefetch_briefing_context(cfg, search_client=search, today="2026-06-09")
+
+    # 索引ページは除外され、残りが PER_TICKER_RESULTS 件に切り詰められる
+    assert ctx.per_ticker["PLTR"] == news[:PER_TICKER_RESULTS]
+    for r in index_pages:
+        assert _is_index_page(r.url), r.url
+    assert not _is_index_page("https://news.example.com/article-1")
+
+
+def test_prefetch_uses_english_geo_query_when_query_en_set():
+    cfg = _minimal_cfg(
+        tickers=["PLTR"],
+        conflicts=[
+            Conflict(
+                name="ロシア・ウクライナ戦争",
+                affected_sectors=["エネルギー"],
+                query_en="Russia Ukraine war",
+            ),
+            Conflict(name="米中", affected_sectors=["半導体"]),
+        ],
+    )
+    geo_hit = SearchResult("RU war", "https://e.com/ru", "d")
+    search = _StubSearch(responses={"Russia Ukraine war latest news": [geo_hit]})
+
+    ctx = prefetch_briefing_context(cfg, search_client=search, today="2026-06-09")
+
+    queried = [c["query"] for c in search.calls]
+    # query_en があれば英語ニュースクエリ、なければ従来の日本語クエリ
+    assert "Russia Ukraine war latest news" in queried
+    assert "ロシア・ウクライナ戦争 today" not in queried
+    assert "米中 today" in queried
+    # 結果のキーは表示用に日本語トピック名のまま
+    assert ctx.geo_by_topic["ロシア・ウクライナ戦争"] == [geo_hit]
 
 
 def _full_ctx() -> PrefetchedContext:

--- a/apps/python/tests/local_llm/test_search.py
+++ b/apps/python/tests/local_llm/test_search.py
@@ -81,6 +81,22 @@ def test_search_clamps_count_into_1_to_10():
     assert http.calls[-1]["params"]["count"] == 1
 
 
+def test_search_passes_freshness_param_when_given():
+    http = _FakeHTTP(_FakeResp(200, {"web": {"results": []}}))
+    client = BraveSearchClient("k", http_client=http)
+
+    client.search("q", count=3, freshness="pw")
+    assert http.calls[-1]["params"]["freshness"] == "pw"
+
+
+def test_search_omits_freshness_param_by_default():
+    http = _FakeHTTP(_FakeResp(200, {"web": {"results": []}}))
+    client = BraveSearchClient("k", http_client=http)
+
+    client.search("q", count=3)
+    assert "freshness" not in http.calls[-1]["params"]
+
+
 def test_search_raises_on_non_200():
     http = _FakeHTTP(_FakeResp(429, text="rate limited"))
     client = BraveSearchClient("k", http_client=http)


### PR DESCRIPTION
## Summary
- Add `freshness` param to `BraveSearchClient.search()`; pre-fetch always passes `pw` (past week) so hits are news, not evergreen pages
- Filter index/quote pages (`finance.yahoo.com/quote/`, Robinhood, Google Finance, Investing.com, stockanalysis.com, Seeking Alpha symbol pages, Amazon) before prompt injection, with +3 over-fetch so PER_*_RESULTS usable hits remain
- New optional `query_en` on geopolitical conflicts: Japanese topic names like「ロシア・ウクライナ戦争」surface topic-hub/book pages, so when set the pre-fetch queries `"<query_en> latest news"` instead. `briefing.json.example` and `tests/config/briefing.json` updated in sync (operator's `briefing.json` can adopt it manually — optional field, backward compatible)
- Tests: freshness pass-through/omission, index-page filter + trim, over-fetch counts, English geo query selection

Closes #153

## Test plan
- [x] `pytest tests/local_llm/ -v`
- [x] full suite — 434 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve Brave Search-based prefetching for local LLM briefings to favor fresh, news-like results over evergreen index pages, especially for geopolitical topics.

New Features:
- Allow configuring an English search query per geopolitical conflict via the optional query_en field in briefing configuration, used for prefetching news.

Enhancements:
- Add an optional freshness parameter to BraveSearchClient.search and use a past-week filter for briefing prefetch queries.
- Over-fetch search results and filter out index/quote and non-news pages before prompt construction to keep only the desired number of news hits.
- Log applied geo queries and index-page filtering to make prefetch behavior more observable.

Tests:
- Extend local LLM briefing and search tests to cover freshness handling, index-page filtering and trimming, over-fetch behavior, and English geopolitical query selection.