### PR TITLE
feat(local-llm): fetch article bodies into briefing prompts (#151)

### DIFF
--- a/apps/python/requirements.in
+++ b/apps/python/requirements.in
@@ -20,3 +20,6 @@ ollama>=0.3
 # is compatible with protobuf 5+ (uv otherwise resolves to ancient 1.11.x).
 opentelemetry-proto>=1.30
 opentelemetry-exporter-otlp-proto-grpc>=1.30
+
+# Article body extraction for local-LLM briefing (#151)
+trafilatura>=1.12

--- a/apps/python/requirements.txt
+++ b/apps/python/requirements.txt
@@ -22,6 +22,8 @@ attrs==26.1.0
     #   aiohttp
     #   jsonschema
     #   referencing
+babel==2.18.0
+    # via courlan
 bcrypt==5.0.0
     # via chromadb
 beautifulsoup4==4.14.3
@@ -35,18 +37,26 @@ certifi==2026.2.25
     #   httpx
     #   kubernetes
     #   requests
+    #   trafilatura
 cffi==2.0.0
     # via curl-cffi
 charset-normalizer==3.4.7
-    # via requests
+    # via
+    #   htmldate
+    #   requests
+    #   trafilatura
 chromadb==1.5.9
     # via -r requirements.in
 click==8.4.1
     # via uvicorn
+courlan==1.4.0
+    # via trafilatura
 coverage==7.13.5
     # via pytest-cov
 curl-cffi==0.15.0
     # via yfinance
+dateparser==1.4.0
+    # via htmldate
 durationpy==0.10
     # via kubernetes
 fastapi==0.136.3
@@ -75,6 +85,8 @@ h11==0.16.0
     #   uvicorn
 hf-xet==1.5.0
     # via huggingface-hub
+htmldate==1.10.0
+    # via trafilatura
 httpcore==1.0.9
     # via httpx
 httptools==0.8.0
@@ -108,10 +120,20 @@ jsonschema==4.26.0
     # via chromadb
 jsonschema-specifications==2025.9.1
     # via jsonschema
+justext==3.0.2
+    # via trafilatura
 keyring==25.7.0
     # via -r requirements.in
 kubernetes==36.0.2
     # via chromadb
+lxml==6.1.1
+    # via
+    #   htmldate
+    #   justext
+    #   lxml-html-clean
+    #   trafilatura
+lxml-html-clean==0.4.5
+    # via lxml
 markdown-it-py==4.0.0
     # via rich
 mdurl==0.1.2
@@ -229,6 +251,8 @@ pytest-cov==7.1.0
     # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via
+    #   dateparser
+    #   htmldate
     #   kubernetes
     #   pandas
 python-dotenv==1.2.2
@@ -237,7 +261,9 @@ python-dotenv==1.2.2
     #   pydantic-settings
     #   uvicorn
 pytz==2026.1.post1
-    # via yfinance
+    # via
+    #   dateparser
+    #   yfinance
 pyyaml==6.0.3
     # via
     #   chromadb
@@ -248,6 +274,8 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
+regex==2026.5.9
+    # via dateparser
 requests==2.33.1
     # via
     #   -r requirements.in
@@ -277,12 +305,16 @@ starlette==1.2.0
     # via fastapi
 tenacity==9.1.4
     # via chromadb
+tld==0.13.2
+    # via courlan
 tokenizers==0.23.1
     # via chromadb
 tqdm==4.68.1
     # via
     #   chromadb
     #   huggingface-hub
+trafilatura==2.1.0
+    # via -r requirements.in
 typer==0.26.7
     # via
     #   chromadb
@@ -306,10 +338,15 @@ typing-inspection==0.4.2
     #   fastapi
     #   pydantic
     #   pydantic-settings
+tzlocal==5.3.1
+    # via dateparser
 urllib3==2.6.3
     # via
+    #   courlan
+    #   htmldate
     #   kubernetes
     #   requests
+    #   trafilatura
 uvicorn==0.48.0
     # via
     #   -r requirements.in

--- a/apps/python/src/local_llm/articles.py
+++ b/apps/python/src/local_llm/articles.py
@@ -1,0 +1,161 @@
+"""記事本文の取得と抽出 (#151)。
+
+pre-fetch のスニペット (タイトル + ≤200 字) だけでは 14B クラスのモデルは
+具体的事実を書けず、曖昧な作文や出典ズレが起きる。各トピック上位ヒットの
+URL を実際に fetch して trafilatura で本文抽出し、切り詰めてプロンプトに
+注入することで、タスクを「見出しからの創作」から「本文の要約」に変える。
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+import httpx
+
+from src.logger import get_logger
+
+from .briefing import PrefetchedContext
+from .search import SearchResult
+
+logger = get_logger(__name__)
+
+# 1 記事あたりの本文上限。8 銘柄 × 1 記事 × 1800 字 ≒ 7K tokens で、セクション
+# 分割プロンプト + num_ctx 16K (#150) に収まる予算。
+MAX_ARTICLE_CHARS = 1800
+# マクロは全セクションの土台になるので 2 件、その他はトピックごと上位 1 件。
+PER_MACRO_ARTICLES = 2
+PER_GROUP_ARTICLES = 1
+
+FETCH_TIMEOUT = 10.0
+# 一部のニュースサイトはデフォルト UA (python-httpx/...) を 403 で弾く。
+_FETCH_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+    )
+}
+
+
+def _fetch_article_text(
+    url: str, *, http_client: Any | None = None, max_chars: int = MAX_ARTICLE_CHARS
+) -> str:
+    """URL を fetch して本文をプレーンテキストで返す。失敗は空文字 (呼び出し側でスニペットにフォールバック)。"""
+    try:
+        if http_client is not None:
+            resp = http_client.get(url, headers=_FETCH_HEADERS)
+        else:
+            resp = httpx.get(
+                url,
+                headers=_FETCH_HEADERS,
+                timeout=FETCH_TIMEOUT,
+                follow_redirects=True,
+            )
+    except Exception as e:
+        logger.warning("[articles] fetch failed for %s: %s", url, e)
+        return ""
+    if resp.status_code != 200:
+        logger.warning("[articles] HTTP %d for %s", resp.status_code, url)
+        return ""
+
+    try:
+        import trafilatura
+
+        text = trafilatura.extract(resp.text) or ""
+    except Exception as e:
+        logger.warning("[articles] extract failed for %s: %s", url, e)
+        return ""
+
+    text = " ".join(text.split())  # 改行・連続空白を畳んで 1 行に
+    if len(text) > max_chars:
+        text = text[:max_chars] + "..."
+    return text
+
+
+def _enrich_results(
+    results: list[SearchResult],
+    n: int,
+    *,
+    http_client: Any | None,
+    max_chars: int,
+) -> list[SearchResult]:
+    out: list[SearchResult] = []
+    for i, r in enumerate(results):
+        if i < n and r.url:
+            text = _fetch_article_text(
+                r.url, http_client=http_client, max_chars=max_chars
+            )
+            out.append(replace(r, content=text) if text else r)
+        else:
+            out.append(r)
+    return out
+
+
+def enrich_with_article_text(
+    ctx: PrefetchedContext,
+    *,
+    http_client: Any | None = None,
+    per_macro: int = PER_MACRO_ARTICLES,
+    per_group: int = PER_GROUP_ARTICLES,
+    max_chars: int = MAX_ARTICLE_CHARS,
+) -> PrefetchedContext:
+    """各グループ上位ヒットの記事本文を取得して content に埋めた新 ctx を返す。
+
+    fetch/抽出に失敗したヒットはスニペットのまま残す (全体は止めない)。
+    `http_client` はテスト用注入ポイント (get(url, headers=...) を持つこと)。
+    """
+    enriched = PrefetchedContext(
+        macro=_enrich_results(
+            ctx.macro, per_macro, http_client=http_client, max_chars=max_chars
+        ),
+        per_ticker={
+            t: _enrich_results(
+                hits, per_group, http_client=http_client, max_chars=max_chars
+            )
+            for t, hits in ctx.per_ticker.items()
+        },
+        geo_by_topic={
+            topic: _enrich_results(
+                hits, per_group, http_client=http_client, max_chars=max_chars
+            )
+            for topic, hits in ctx.geo_by_topic.items()
+        },
+        events_by_name={
+            name: _enrich_results(
+                hits, per_group, http_client=http_client, max_chars=max_chars
+            )
+            for name, hits in ctx.events_by_name.items()
+        },
+    )
+    attempted, fetched = count_article_fetches(enriched, per_macro=per_macro, per_group=per_group)
+    logger.info("[articles] 本文取得 %d/%d 件成功", fetched, attempted)
+    return enriched
+
+
+def count_article_fetches(
+    ctx: PrefetchedContext,
+    *,
+    per_macro: int = PER_MACRO_ARTICLES,
+    per_group: int = PER_GROUP_ARTICLES,
+) -> tuple[int, int]:
+    """(試行件数, content が埋まった件数) を返す。caveat 行の透明性用。"""
+    attempted = 0
+    fetched = 0
+
+    def _count(results: list[SearchResult], n: int) -> None:
+        nonlocal attempted, fetched
+        for r in results[:n]:
+            if not r.url:
+                continue
+            attempted += 1
+            if r.content:
+                fetched += 1
+
+    _count(ctx.macro, per_macro)
+    for hits in ctx.per_ticker.values():
+        _count(hits, per_group)
+    for hits in ctx.geo_by_topic.values():
+        _count(hits, per_group)
+    for hits in ctx.events_by_name.values():
+        _count(hits, per_group)
+    return attempted, fetched

--- a/apps/python/src/local_llm/articles.py
+++ b/apps/python/src/local_llm/articles.py
@@ -8,8 +8,9 @@ URL を実際に fetch して trafilatura で本文抽出し、切り詰めて�
 
 from __future__ import annotations
 
+import dataclasses
 from dataclasses import replace
-from typing import Any
+from typing import Any, Protocol
 
 import httpx
 
@@ -19,6 +20,13 @@ from .briefing import PrefetchedContext
 from .search import SearchResult
 
 logger = get_logger(__name__)
+
+
+class _HttpGetLike(Protocol):
+    """テスト注入用の最小 HTTP インターフェース (httpx 互換の get のみ)。"""
+
+    def get(self, url: str, headers: dict | None = None) -> Any: ...
+
 
 # 1 記事あたりの本文上限。8 銘柄 × 1 記事 × 1800 字 ≒ 7K tokens で、セクション
 # 分割プロンプト + num_ctx 16K (#150) に収まる予算。
@@ -38,7 +46,7 @@ _FETCH_HEADERS = {
 
 
 def _fetch_article_text(
-    url: str, *, http_client: Any | None = None, max_chars: int = MAX_ARTICLE_CHARS
+    url: str, *, http_client: _HttpGetLike | None = None, max_chars: int = MAX_ARTICLE_CHARS
 ) -> str:
     """URL を fetch して本文をプレーンテキストで返す。失敗は空文字 (呼び出し側でスニペットにフォールバック)。"""
     try:
@@ -76,7 +84,7 @@ def _enrich_results(
     results: list[SearchResult],
     n: int,
     *,
-    http_client: Any | None,
+    http_client: _HttpGetLike | None,
     max_chars: int,
 ) -> list[SearchResult]:
     out: list[SearchResult] = []
@@ -94,7 +102,7 @@ def _enrich_results(
 def enrich_with_article_text(
     ctx: PrefetchedContext,
     *,
-    http_client: Any | None = None,
+    http_client: _HttpGetLike | None = None,
     per_macro: int = PER_MACRO_ARTICLES,
     per_group: int = PER_GROUP_ARTICLES,
     max_chars: int = MAX_ARTICLE_CHARS,
@@ -104,7 +112,10 @@ def enrich_with_article_text(
     fetch/抽出に失敗したヒットはスニペットのまま残す (全体は止めない)。
     `http_client` はテスト用注入ポイント (get(url, headers=...) を持つこと)。
     """
-    enriched = PrefetchedContext(
+    # PrefetchedContext にフィールドが増えても黙って欠落しないよう
+    # dataclasses.replace で再構築する (Sourcery 指摘)。
+    enriched = dataclasses.replace(
+        ctx,
         macro=_enrich_results(
             ctx.macro, per_macro, http_client=http_client, max_chars=max_chars
         ),

--- a/apps/python/src/local_llm/briefing.py
+++ b/apps/python/src/local_llm/briefing.py
@@ -138,6 +138,10 @@ def _format_results(results: list[SearchResult]) -> str:
         if len(desc) > 200:
             desc = desc[:200] + "..."
         out.append(f"  - [{r.title}]({r.url}) — {desc}")
+        # 本文抜粋 (#151)。enrich_with_article_text が埋めた上位ヒットのみ持つ。
+        # スニペットより具体的な事実 (数値・日付・固有名詞) の唯一の供給源。
+        if r.content:
+            out.append(f"    - 本文抜粋: {r.content}")
     return "\n".join(out)
 
 
@@ -494,12 +498,14 @@ def compose_briefing_md(
     search_enabled: bool = True,
     url_validation: UrlValidation | None = None,
     prefetch_summary: str | None = None,
+    article_summary: str | None = None,
 ) -> str:
     """Caveat ヘッダと本文を `---` で連結する。
 
     `url_validation` を渡すと caveat に「URL 検証: verified/total」を追記する。
-    `prefetch_summary` を渡すと「Brave hits: ...」の件数行を追記する。両方とも
-    `-` 出典セルの裏付けを取るための運用透明性。
+    `prefetch_summary` を渡すと「Brave hits: ...」の件数行を追記する。
+    `article_summary` を渡すと「記事本文: ...」の取得状況行を追記する (#151)。
+    いずれも `-` 出典セルや曖昧な記述の裏付けを取るための運用透明性。
     """
     search_line = (
         "> - Web 検索: Brave Search (pre-fetch)\n"
@@ -509,6 +515,9 @@ def compose_briefing_md(
     summary_line = ""
     if prefetch_summary:
         summary_line = f"> - Brave hits: {prefetch_summary}\n"
+    article_line = ""
+    if article_summary:
+        article_line = f"> - 記事本文: {article_summary}\n"
     validation_line = ""
     if url_validation is not None:
         validation_line = (
@@ -520,6 +529,7 @@ def compose_briefing_md(
         f"> - model: {model}\n"
         f"{search_line}"
         f"{summary_line}"
+        f"{article_line}"
         f"{validation_line}"
         f"> - generated_at: {generated_at.isoformat(timespec='seconds')}\n"
     )

--- a/apps/python/src/local_llm/cli.py
+++ b/apps/python/src/local_llm/cli.py
@@ -18,6 +18,7 @@ from src.notifier.notion import send_to_notion
 
 logger = get_logger(__name__)
 
+from .articles import count_article_fetches, enrich_with_article_text
 from .briefing import (
     build_section_geo_events_prompt,
     build_section_insight_prompt,
@@ -213,7 +214,14 @@ def _cmd_briefing(cfg, *, post_to_notion: bool) -> int:
     ctx = prefetch_briefing_context(
         briefing_cfg, search_client=search_client, today=today
     )
-    logger.info("Brave Search pre-fetch 完了 — プロンプトに注入")
+    logger.info("Brave Search pre-fetch 完了 — 上位ヒットの記事本文を取得")
+
+    # スニペットだけではモデルが具体的事実を書けないため、上位ヒットの本文を
+    # 抽出してプロンプトに注入する (#151)。失敗分はスニペットにフォールバック。
+    ctx = enrich_with_article_text(ctx)
+    attempted, fetched = count_article_fetches(ctx)
+    article_summary = f"{fetched}/{attempted} 件取得 (上位ヒットのみ・失敗はスニペットで代替)"
+    logger.info("記事本文取得完了 — プロンプトに注入")
 
     system_prompt = load_local_briefing_system_prompt()
 
@@ -285,6 +293,7 @@ def _cmd_briefing(cfg, *, post_to_notion: bool) -> int:
         generated_at=datetime.now(),
         url_validation=validation,
         prefetch_summary=summarize_prefetch_hits(ctx),
+        article_summary=article_summary,
     )
 
     BRIEFING_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)

--- a/apps/python/src/local_llm/search.py
+++ b/apps/python/src/local_llm/search.py
@@ -19,6 +19,10 @@ class SearchResult:
     title: str
     url: str
     description: str
+    # 記事本文の抜粋 (#151)。検索ヒット時は空で、articles.enrich_with_article_text
+    # が上位ヒットにだけ後から埋める。スニペット (description ≤200 字) だけでは
+    # モデルが具体的事実を書けないための追加コンテキスト。
+    content: str = ""
 
 
 class BraveSearchError(RuntimeError):

--- a/apps/python/tests/local_llm/test_articles.py
+++ b/apps/python/tests/local_llm/test_articles.py
@@ -1,0 +1,189 @@
+import logging
+
+from src.local_llm.articles import (
+    MAX_ARTICLE_CHARS,
+    _fetch_article_text,
+    count_article_fetches,
+    enrich_with_article_text,
+)
+from src.local_llm.briefing import PrefetchedContext, _format_results
+from src.local_llm.search import SearchResult
+
+_ARTICLE_HTML = """<html><head><title>PLTR News</title></head><body>
+<nav>Home | Markets | Tech</nav>
+<article>
+<h1>Palantir wins major defense contract</h1>
+<p>Palantir Technologies announced on Friday that it has secured a $480 million
+contract with the US Army to expand its Maven Smart System. The deal extends
+through 2029 and covers AI-enabled targeting workflows.</p>
+<p>Shares rose 3.2% in pre-market trading following the announcement. Analysts
+at Morgan Stanley maintained their overweight rating with a price target of $145.</p>
+</article>
+<footer>Copyright 2026</footer>
+</body></html>"""
+
+
+class _FakeResp:
+    def __init__(self, status_code: int = 200, text: str = ""):
+        self.status_code = status_code
+        self.text = text
+
+
+class _FakeHTTP:
+    """get(url, headers=...) を持つテスト用クライアント。URL ごとに応答を返す。"""
+
+    def __init__(self, responses: dict[str, _FakeResp] | None = None):
+        self.responses = responses or {}
+        self.calls: list[str] = []
+
+    def get(self, url, headers=None):
+        self.calls.append(url)
+        if url not in self.responses:
+            raise ConnectionError("no route")
+        return self.responses[url]
+
+
+# ---------------------------------------------------------------------------
+# _fetch_article_text
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_article_text_extracts_main_text_without_nav_footer():
+    http = _FakeHTTP({"https://e.com/a": _FakeResp(200, _ARTICLE_HTML)})
+
+    text = _fetch_article_text("https://e.com/a", http_client=http)
+
+    assert "$480 million" in text
+    assert "Maven Smart System" in text
+    # 本文以外 (nav / footer) は落ちる
+    assert "Copyright" not in text
+    assert "Home | Markets" not in text
+    # 改行は畳まれて 1 行になる (markdown リスト内に注入するため)
+    assert "\n" not in text
+
+
+def test_fetch_article_text_truncates_to_max_chars():
+    http = _FakeHTTP({"https://e.com/a": _FakeResp(200, _ARTICLE_HTML)})
+
+    text = _fetch_article_text("https://e.com/a", http_client=http, max_chars=50)
+
+    assert len(text) == 50 + len("...")
+    assert text.endswith("...")
+
+
+def test_fetch_article_text_returns_empty_on_connection_error(caplog):
+    http = _FakeHTTP()  # 全 URL で ConnectionError
+
+    with caplog.at_level(logging.WARNING, logger="src.local_llm.articles"):
+        text = _fetch_article_text("https://e.com/down", http_client=http)
+
+    assert text == ""
+    assert any("fetch failed" in r.message for r in caplog.records)
+
+
+def test_fetch_article_text_returns_empty_on_http_error(caplog):
+    http = _FakeHTTP({"https://e.com/403": _FakeResp(403, "forbidden")})
+
+    with caplog.at_level(logging.WARNING, logger="src.local_llm.articles"):
+        text = _fetch_article_text("https://e.com/403", http_client=http)
+
+    assert text == ""
+    assert any("HTTP 403" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# enrich_with_article_text
+# ---------------------------------------------------------------------------
+
+
+def _ctx() -> PrefetchedContext:
+    return PrefetchedContext(
+        macro=[
+            SearchResult("M1", "https://e.com/m1", "dm1"),
+            SearchResult("M2", "https://e.com/m2", "dm2"),
+            SearchResult("M3", "https://e.com/m3", "dm3"),
+        ],
+        per_ticker={
+            "PLTR": [
+                SearchResult("P1", "https://e.com/p1", "dp1"),
+                SearchResult("P2", "https://e.com/p2", "dp2"),
+            ],
+            "MSFT": [],
+        },
+        geo_by_topic={"米中": [SearchResult("G1", "https://e.com/g1", "dg1")]},
+        events_by_name={},
+    )
+
+
+def test_enrich_fills_content_only_for_top_hits():
+    ok = _FakeResp(200, _ARTICLE_HTML)
+    http = _FakeHTTP(
+        {
+            "https://e.com/m1": ok,
+            "https://e.com/m2": ok,
+            "https://e.com/p1": ok,
+            "https://e.com/g1": ok,
+        }
+    )
+
+    out = enrich_with_article_text(_ctx(), http_client=http, per_macro=2, per_group=1)
+
+    # macro は上位 2 件、ticker/geo は上位 1 件だけ fetch される
+    assert sorted(http.calls) == [
+        "https://e.com/g1",
+        "https://e.com/m1",
+        "https://e.com/m2",
+        "https://e.com/p1",
+    ]
+    assert "$480 million" in out.macro[0].content
+    assert "$480 million" in out.macro[1].content
+    assert out.macro[2].content == ""
+    assert "$480 million" in out.per_ticker["PLTR"][0].content
+    assert out.per_ticker["PLTR"][1].content == ""
+    assert "$480 million" in out.geo_by_topic["米中"][0].content
+    # 元の ctx は不変 (frozen dataclass の新インスタンスを返す)
+    assert _ctx().macro[0].content == ""
+
+
+def test_enrich_falls_back_to_snippet_on_fetch_failure():
+    http = _FakeHTTP({"https://e.com/m1": _FakeResp(200, _ARTICLE_HTML)})
+    # p1 / g1 / m2 は ConnectionError になる
+
+    out = enrich_with_article_text(_ctx(), http_client=http, per_macro=2, per_group=1)
+
+    assert "$480 million" in out.macro[0].content
+    # 失敗したヒットはスニペットのまま (content 空) で残り、全体は止まらない
+    assert out.macro[1].content == ""
+    assert out.per_ticker["PLTR"][0].content == ""
+    assert out.per_ticker["PLTR"][0].title == "P1"
+
+
+def test_count_article_fetches_reports_attempted_and_fetched():
+    http = _FakeHTTP({"https://e.com/m1": _FakeResp(200, _ARTICLE_HTML)})
+    out = enrich_with_article_text(_ctx(), http_client=http, per_macro=2, per_group=1)
+
+    attempted, fetched = count_article_fetches(out, per_macro=2, per_group=1)
+
+    # m1, m2, p1, g1 の 4 件試行、成功は m1 のみ
+    assert attempted == 4
+    assert fetched == 1
+
+
+# ---------------------------------------------------------------------------
+# プロンプト注入 (_format_results との結合)
+# ---------------------------------------------------------------------------
+
+
+def test_format_results_includes_article_content_when_present():
+    results = [
+        SearchResult("T1", "https://e.com/1", "snippet only"),
+        SearchResult("T2", "https://e.com/2", "with body", content="本文テキスト $480M"),
+    ]
+
+    block = _format_results(results)
+
+    assert "本文抜粋: 本文テキスト $480M" in block
+    # content が無いヒットには本文行が付かない
+    lines = block.splitlines()
+    assert lines[0].startswith("  - [T1]")
+    assert "本文抜粋" not in lines[0]

--- a/apps/python/tests/local_llm/test_articles.py
+++ b/apps/python/tests/local_llm/test_articles.py
@@ -111,7 +111,7 @@ def _ctx() -> PrefetchedContext:
             "MSFT": [],
         },
         geo_by_topic={"米中": [SearchResult("G1", "https://e.com/g1", "dg1")]},
-        events_by_name={},
+        events_by_name={"SpaceX IPO": [SearchResult("E1", "https://e.com/e1", "de1")]},
     )
 
 
@@ -123,13 +123,15 @@ def test_enrich_fills_content_only_for_top_hits():
             "https://e.com/m2": ok,
             "https://e.com/p1": ok,
             "https://e.com/g1": ok,
+            "https://e.com/e1": ok,
         }
     )
 
     out = enrich_with_article_text(_ctx(), http_client=http, per_macro=2, per_group=1)
 
-    # macro は上位 2 件、ticker/geo は上位 1 件だけ fetch される
+    # macro は上位 2 件、ticker/geo/event は上位 1 件だけ fetch される
     assert sorted(http.calls) == [
+        "https://e.com/e1",
         "https://e.com/g1",
         "https://e.com/m1",
         "https://e.com/m2",
@@ -141,6 +143,7 @@ def test_enrich_fills_content_only_for_top_hits():
     assert "$480 million" in out.per_ticker["PLTR"][0].content
     assert out.per_ticker["PLTR"][1].content == ""
     assert "$480 million" in out.geo_by_topic["米中"][0].content
+    assert "$480 million" in out.events_by_name["SpaceX IPO"][0].content
     # 元の ctx は不変 (frozen dataclass の新インスタンスを返す)
     assert _ctx().macro[0].content == ""
 
@@ -164,8 +167,8 @@ def test_count_article_fetches_reports_attempted_and_fetched():
 
     attempted, fetched = count_article_fetches(out, per_macro=2, per_group=1)
 
-    # m1, m2, p1, g1 の 4 件試行、成功は m1 のみ
-    assert attempted == 4
+    # m1, m2, p1, g1, e1 の 5 件試行、成功は m1 のみ
+    assert attempted == 5
     assert fetched == 1
 
 

--- a/apps/python/tests/local_llm/test_briefing.py
+++ b/apps/python/tests/local_llm/test_briefing.py
@@ -321,6 +321,16 @@ def test_compose_briefing_md_includes_prefetch_summary_line():
     assert "Brave hits: macro=3 / tickers=[PLTR:3, MSFT:0]" in md
 
 
+def test_compose_briefing_md_includes_article_summary_line():
+    md = compose_briefing_md(
+        body="b",
+        model="qwen2.5:14b",
+        generated_at=datetime(2026, 6, 9, 9, 15, 0),
+        article_summary="10/12 件取得",
+    )
+    assert "記事本文: 10/12 件取得" in md
+
+
 def test_ensure_portfolio_table_header_prepends_when_divider_missing():
     body = (
         "| PLTR | ↓0.9% | (確認できず) | - |\n"


### PR DESCRIPTION
## Summary
- New `src/local_llm/articles.py`: fetch top pre-fetch hits (macro: 2, per ticker/geo/event: 1) with httpx, extract main text via `trafilatura`, truncate to 1,800 chars, and fill `SearchResult.content`
- `_format_results` appends a `本文抜粋:` line when content is present — the model now summarizes article text instead of inventing facts from headlines
- Per-hit failure (connection error, non-200, extract failure) logs a warning and falls back to snippet-only; the run never aborts
- Caveat header gains `> - 記事本文: fetched/attempted 件取得` for transparency
- `trafilatura>=1.12` added to `requirements.in` (requirements.txt recompiled)

**Stacked on #154** (explicit num_ctx) — article bodies would overflow Ollama's 4096 default. Merge #154 first, then retarget this PR to `dev`.

Closes #151

## Test plan
- [x] `pytest tests/local_llm/ -v` — extraction, truncation, top-N-only enrichment, failure fallback, fetch counts, prompt injection
- [x] full suite — 440 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fetch article bodies for top local LLM search hits and inject extracted excerpts into the briefing prompt, while tracking and exposing fetch success metrics.

New Features:
- Add article fetching and main-text extraction from news URLs using trafilatura, enriching top search hits with article content for use in prompts.
- Include article content excerpts in formatted search result blocks when available so the model summarizes real text rather than just snippets.
- Extend briefing metadata to report article-body fetch statistics alongside Brave pre-fetch counts for operational transparency.

Enhancements:
- Integrate article-body enrichment into the briefing CLI flow with graceful fallback to snippets on fetch or extraction failures.
- Augment search result objects with an optional content field to carry extracted article text.

Build:
- Add trafilatura and its transitive dependencies to Python requirements to support robust HTML article extraction.

Tests:
- Add unit tests covering article fetching, extraction, truncation, enrichment behavior, error handling, fetch counting, and prompt formatting with article content.