### PR TITLE
feat(local-llm): filter stock-forecast/rating sites from prefetch

### DIFF
--- a/apps/python/src/local_llm/briefing.py
+++ b/apps/python/src/local_llm/briefing.py
@@ -52,6 +52,14 @@ _INDEX_PAGE_URL_PATTERNS = [
         # Amazon は商品詳細ページ (/dp/, /gp/product/ — 商品名スラッグ付きも可)
         # のみ除外。記事系ページまで落とさないようドメイン全体は対象にしない。
         r"amazon\.(com|co\.jp)/(.+/)?(gp/product|dp)/",
+        # 株価予想・アナリストレーティングの集約ページ (#158)。常設の目標株価/
+        # 予想ページで当日の事実を含まず、投資判断価値が低い。各サイトの記事系
+        # (/originals/, /news/ 等) は残すため、予想ページのパスに絞って除外する。
+        r"marketbeat\.com/stocks/",
+        r"simplywall\.st/stocks/",
+        r"tipranks\.com/stocks/",
+        r"wallstreetzen\.com/stocks/",
+        r"cnn\.com/markets/stocks/",
     )
 ]
 

--- a/apps/python/tests/local_llm/test_briefing.py
+++ b/apps/python/tests/local_llm/test_briefing.py
@@ -212,6 +212,29 @@ def test_prefetch_filters_index_pages_and_trims_to_count():
     assert not _is_index_page("https://www.amazon.com/press-release/some-news")
 
 
+def test_is_index_page_filters_forecast_and_rating_sites():
+    # 株価予想・アナリストレーティングの集約ページは当日のニュースではなく
+    # 常設の目標株価/予想ページ。投資判断価値が低く注入コンテキストを汚すため
+    # 除外する (#158)。パスを `/stocks/` 等に絞り、各サイトの記事系ページは残す。
+    forecast_pages = [
+        "https://www.marketbeat.com/stocks/NASDAQ/PLTR/price-target/",
+        "https://www.marketbeat.com/stocks/NASDAQ/PLTR/forecast/",
+        "https://simplywall.st/stocks/us/tech/nyse-pltr/palantir-technologies",
+        "https://www.tipranks.com/stocks/pltr/forecast",
+        "https://www.wallstreetzen.com/stocks/us/nasdaq/pltr/stock-forecast",
+        "https://www.cnn.com/markets/stocks/PLTR",
+    ]
+    for url in forecast_pages:
+        assert _is_index_page(url), url
+
+    # 同じサイトでも記事系ページ (/originals/, /news/) は一次情報を含むので残す
+    assert not _is_index_page("https://www.marketbeat.com/originals/some-news-article/")
+    assert not _is_index_page("https://www.tipranks.com/news/some-article")
+    # 一次情報メディアの記事は当然残す
+    assert not _is_index_page("https://www.reuters.com/markets/us/article-1")
+    assert not _is_index_page("https://www.cnbc.com/2026/06/13/some-news.html")
+
+
 def test_prefetch_uses_english_geo_query_when_query_en_set():
     cfg = _minimal_cfg(
         tickers=["PLTR"],


### PR DESCRIPTION
## Summary
Drop MarketBeat / SimplyWallSt / TipRanks / WallStreetZen / CNN markets stock pages from the Brave pre-fetch. Path-scoped to `/stocks/` so each site's news articles are kept.

## Test plan
- [x] `pytest` — 457 passed (new `test_is_index_page_filters_forecast_and_rating_sites`)

Closes #158

## Summary by Sourcery

Filter stock forecast and analyst rating pages from Brave prefetch while keeping news article pages.

Bug Fixes:
- Exclude MarketBeat, SimplyWallSt, TipRanks, WallStreetZen, and CNN stock forecast pages from index page prefetch to reduce low-value context pollution.

Tests:
- Add coverage ensuring forecast and rating URLs are treated as index pages while preserving article and primary news URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved filtering to exclude stock price forecast and rating aggregation pages from search result contexts, providing more relevant content in searches.

* **Tests**
  * Added test coverage for URL filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->