### PR TITLE
fix(local-llm): filter indmoney quote pages and trefis forecasts

### DIFF
--- a/apps/python/src/local_llm/briefing.py
+++ b/apps/python/src/local_llm/briefing.py
@@ -71,6 +71,10 @@ _INDEX_PAGE_URL_PATTERNS = [
         r"weissratings\.com",
         r"timothysykes\.com",
         r"stockstotrade\.com",
+        # クオート/ライブ株価の索引ページ & バリュエーション予想サイト (#176)。
+        # indmoney は銘柄のライブ株価ページ、trefis は予想/バリュエーション記事。
+        r"indmoney\.com/us-stocks/",
+        r"trefis\.com/stock/",
     )
 ]
 

--- a/apps/python/tests/local_llm/test_briefing.py
+++ b/apps/python/tests/local_llm/test_briefing.py
@@ -237,6 +237,9 @@ def test_is_index_page_filters_forecast_and_rating_sites():
         "https://weissratings.com/en/instant-news-alerts/dexcom-inc-dxcm-up-5-9",
         "https://www.timothysykes.com/news/leverage-shares-2x-long-cbrs-2026_06_10/",
         "https://stockstotrade.com/news/cerebras-systems-inc-cbrs-news-2026_06_08-3/",
+        # クオート/ライブ株価の索引ページ & バリュエーション予想サイト (#176)
+        "https://www.indmoney.com/us-stocks/alphabet-inc-class-a-shares-share-price-googl",
+        "https://www.trefis.com/stock/googl/articles/602686/does-google-stock-have-more-upside/2026-06-12",
     ]
     for url in forecast_pages:
         assert _is_index_page(url), url

--- a/apps/python/tests/local_llm/test_briefing.py
+++ b/apps/python/tests/local_llm/test_briefing.py
@@ -257,6 +257,9 @@ def test_is_index_page_filters_forecast_and_rating_sites():
     assert not _is_index_page(
         "https://247wallst.com/investing/2026/06/10/microsoft-stock-prediction/"
     )
+    # indmoney / trefis はパス限定 — クオート/予想ページ以外の記事は残す
+    assert not _is_index_page("https://www.indmoney.com/blog/how-to-invest-in-us-stocks")
+    assert not _is_index_page("https://www.trefis.com/insights/some-market-commentary")
 
 
 def test_prefetch_uses_english_geo_query_when_query_en_set():


### PR DESCRIPTION
## Summary
Surfaced in the 2026-06-14 verification run: add `indmoney.com` live-price quote pages and `trefis.com` valuation/forecast articles to the index-page filter (path-scoped: `indmoney.com/us-stocks/`, `trefis.com/stock/`). Primary-source articles are unaffected.

## Test plan
- [x] `pytest` — 465 passed (indmoney/trefis added to the index-page filter test; existing negative cases keep primary sources)

Closes #176

## Summary by Sourcery

Extend local LLM briefing index-page filtering to cover additional quote and valuation forecast sites.

Bug Fixes:
- Exclude indmoney live US stock quote pages and trefis stock forecast articles from primary-source indexing.

Tests:
- Expand index-page filter tests to cover indmoney and trefis URLs while preserving existing negative cases.