### PR TITLE
fix(local-llm): extend marketbeat block to full domain (#180)

### DIFF
--- a/apps/python/src/local_llm/briefing.py
+++ b/apps/python/src/local_llm/briefing.py
@@ -54,10 +54,10 @@ _INDEX_PAGE_URL_PATTERNS = [
         # Amazon は商品詳細ページ (/dp/, /gp/product/ — 商品名スラッグ付きも可)
         # のみ除外。記事系ページまで落とさないようドメイン全体は対象にしない。
         r"amazon\.(com|co\.jp)/(.+/)?(gp/product|dp)/",
-        # 株価予想・アナリストレーティングの集約ページ (#158)。常設の目標株価/
-        # 予想ページで当日の事実を含まず、投資判断価値が低い。各サイトの記事系
-        # (/originals/, /news/ 等) は残すため、予想ページのパスに絞って除外する。
-        r"marketbeat\.com/stocks/",
+        # 株価予想・アナリストレーティング・13F スパムを配信する集約サイト (#158, #180)。
+        # marketbeat は /stocks/ だけでなく /instant-alerts/ 等も 13F 量産スパムのため
+        # ドメイン全体を除外する。
+        r"marketbeat\.com",
         r"simplywall\.st/stocks/",
         r"tipranks\.com/stocks/",
         r"wallstreetzen\.com/stocks/",

--- a/apps/python/tests/local_llm/test_briefing.py
+++ b/apps/python/tests/local_llm/test_briefing.py
@@ -241,6 +241,7 @@ def test_is_index_page_filters_forecast_and_rating_sites():
         "https://www.indmoney.com/us-stocks/alphabet-inc-class-a-shares-share-price-googl",
         "https://www.trefis.com/stock/googl/articles/602686/does-google-stock-have-more-upside/2026-06-12",
         # 13F スパム・/instant-alerts/ は /stocks/ 限定フィルタを回避していたため全ドメイン除外 (#180)
+        "https://www.marketbeat.com/",
         "https://www.marketbeat.com/instant-alerts/filing-macquarie-group-ltd-raises-stock-holdings-in-palantir/",
         "https://www.marketbeat.com/originals/some-news-article/",
     ]

--- a/apps/python/tests/local_llm/test_briefing.py
+++ b/apps/python/tests/local_llm/test_briefing.py
@@ -240,12 +240,12 @@ def test_is_index_page_filters_forecast_and_rating_sites():
         # クオート/ライブ株価の索引ページ & バリュエーション予想サイト (#176)
         "https://www.indmoney.com/us-stocks/alphabet-inc-class-a-shares-share-price-googl",
         "https://www.trefis.com/stock/googl/articles/602686/does-google-stock-have-more-upside/2026-06-12",
+        # 13F スパム・/instant-alerts/ は /stocks/ 限定フィルタを回避していたため全ドメイン除外 (#180)
+        "https://www.marketbeat.com/instant-alerts/filing-macquarie-group-ltd-raises-stock-holdings-in-palantir/",
+        "https://www.marketbeat.com/originals/some-news-article/",
     ]
     for url in forecast_pages:
         assert _is_index_page(url), url
-
-    # 同じサイトでも記事系ページ (/originals/, /news/) は一次情報を含むので残す
-    assert not _is_index_page("https://www.marketbeat.com/originals/some-news-article/")
     assert not _is_index_page("https://www.tipranks.com/news/some-article")
     # 一次情報メディアの記事は当然残す
     assert not _is_index_page("https://www.reuters.com/markets/us/article-1")


### PR DESCRIPTION
## Summary
- Change `r"marketbeat\.com/stocks/"` → `r"marketbeat\.com"` in `_INDEX_PAGE_URL_PATTERNS`
- `/instant-alerts/filing-*` (13F spam) was slipping through the old path-scoped filter and polluting the PLTR pre-fetch context
- Test updated: `/instant-alerts/` and `/originals/` both added to expected-blocked list

## Test plan
- [x] `test_is_index_page_filters_forecast_and_rating_sites` passes with new URLs
- [x] Full `tests/local_llm/` suite: 107 passed

Closes #180

## Summary by Sourcery

Expand local LLM index-page filtering to block all MarketBeat content, including new 13F spam paths, and align tests with the broader domain-level exclusion.

Bug Fixes:
- Prevent MarketBeat 13F instant-alert pages from bypassing index-page filtering and polluting pre-fetch context.

Tests:
- Update forecast and rating index-page tests to expect MarketBeat instant-alert and originals URLs to be classified as index pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced MarketBeat URL filtering to exclude the entire domain from index page processing, rather than limiting exclusion only to specific stock paths. This change ensures more consistent and comprehensive filtering of all MarketBeat content types—including instant alerts, articles, and featured sections—when they are retrieved through content prefetching mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->