### PR TITLE
fix(local-llm): drop malformed URLs from pre-fetch (#181)

### DIFF
--- a/apps/python/src/local_llm/briefing.py
+++ b/apps/python/src/local_llm/briefing.py
@@ -83,6 +83,11 @@ def _is_index_page(url: str) -> bool:
     return any(p.search(url) for p in _INDEX_PAGE_URL_PATTERNS)
 
 
+def _is_valid_url(url: str) -> bool:
+    """スペースを含む不正 URL を弾く。Markdown リンク崩壊 → <URL未検証> 防止 (#181)。"""
+    return " " not in url
+
+
 @dataclass(frozen=True)
 class PrefetchedContext:
     """Pre-fetched web_search のまとめ。プロンプトへの注入用。
@@ -130,10 +135,10 @@ def _safe_search(
     except BraveSearchError as e:
         logger.warning("[prefetch] web_search failed for %r: %s", query, e)
         return []
-    kept = [r for r in hits if not _is_index_page(r.url)]
+    kept = [r for r in hits if not _is_index_page(r.url) and _is_valid_url(r.url)]
     dropped = len(hits) - len(kept)
     if dropped:
-        logger.info("[prefetch] %r: 索引ページ %d 件を除外", query, dropped)
+        logger.info("[prefetch] %r: 索引ページ/不正URL %d 件を除外", query, dropped)
     return kept[:count]
 
 

--- a/apps/python/src/local_llm/briefing.py
+++ b/apps/python/src/local_llm/briefing.py
@@ -83,8 +83,8 @@ def _is_index_page(url: str) -> bool:
     return any(p.search(url) for p in _INDEX_PAGE_URL_PATTERNS)
 
 
-def _is_valid_url(url: str) -> bool:
-    """スペースを含む不正 URL を弾く。Markdown リンク崩壊 → <URL未検証> 防止 (#181)。"""
+def _url_has_no_spaces(url: str) -> bool:
+    """URL にスペースが含まれないか確認（空白チェックのみ）。Markdown リンク崩壊防止 (#181)。"""
     return " " not in url
 
 
@@ -135,10 +135,19 @@ def _safe_search(
     except BraveSearchError as e:
         logger.warning("[prefetch] web_search failed for %r: %s", query, e)
         return []
-    kept = [r for r in hits if not _is_index_page(r.url) and _is_valid_url(r.url)]
-    dropped = len(hits) - len(kept)
-    if dropped:
-        logger.info("[prefetch] %r: 索引ページ/不正URL %d 件を除外", query, dropped)
+    kept = []
+    n_index = n_malformed = 0
+    for r in hits:
+        if _is_index_page(r.url):
+            n_index += 1
+        elif not _url_has_no_spaces(r.url):
+            n_malformed += 1
+        else:
+            kept.append(r)
+    if n_index:
+        logger.info("[prefetch] %r: 索引ページ %d 件を除外", query, n_index)
+    if n_malformed:
+        logger.info("[prefetch] %r: 不正URL(スペース含む) %d 件を除外", query, n_malformed)
     return kept[:count]
 
 

--- a/apps/python/tests/local_llm/test_briefing.py
+++ b/apps/python/tests/local_llm/test_briefing.py
@@ -20,7 +20,7 @@ from src.local_llm.briefing import (
     PrefetchedContext,
     UrlValidation,
     _is_index_page,
-    _is_valid_url,
+    _url_has_no_spaces,
     build_section_geo_events_prompt,
     build_section_insight_prompt,
     build_section_sector_prompt,
@@ -273,8 +273,8 @@ def test_prefetch_drops_urls_with_spaces():
     ctx = prefetch_briefing_context(cfg, search_client=search, today="2026-06-09")
 
     assert ctx.per_ticker["PLTR"] == [good]
-    assert not _is_valid_url(bad.url)
-    assert _is_valid_url(good.url)
+    assert not _url_has_no_spaces(bad.url)
+    assert _url_has_no_spaces(good.url)
 
 
 def test_prefetch_uses_english_geo_query_when_query_en_set():

--- a/apps/python/tests/local_llm/test_briefing.py
+++ b/apps/python/tests/local_llm/test_briefing.py
@@ -20,6 +20,7 @@ from src.local_llm.briefing import (
     PrefetchedContext,
     UrlValidation,
     _is_index_page,
+    _is_valid_url,
     build_section_geo_events_prompt,
     build_section_insight_prompt,
     build_section_sector_prompt,
@@ -260,6 +261,20 @@ def test_is_index_page_filters_forecast_and_rating_sites():
     # indmoney / trefis はパス限定 — クオート/予想ページ以外の記事は残す
     assert not _is_index_page("https://www.indmoney.com/blog/how-to-invest-in-us-stocks")
     assert not _is_index_page("https://www.trefis.com/insights/some-market-commentary")
+
+
+def test_prefetch_drops_urls_with_spaces():
+    # スペースを含む URL は不正形式。Markdown リンク崩壊 → <URL未検証> の原因 (#181)。
+    cfg = _minimal_cfg(tickers=["PLTR"])
+    bad = SearchResult("Bad", "https://example.com/Some Article Title", "d")
+    good = SearchResult("Good", "https://example.com/valid-article-123", "d")
+    search = _StubSearch(responses={"PLTR stock news 2026-06-09": [bad, good]})
+
+    ctx = prefetch_briefing_context(cfg, search_client=search, today="2026-06-09")
+
+    assert ctx.per_ticker["PLTR"] == [good]
+    assert not _is_valid_url(bad.url)
+    assert _is_valid_url(good.url)
 
 
 def test_prefetch_uses_english_geo_query_when_query_en_set():


### PR DESCRIPTION
## Summary
- Add `_is_valid_url(url)` helper: returns False for URLs containing spaces
- Apply it in `_safe_search()` alongside `_is_index_page()` filter
- Space-containing URLs break Markdown link syntax and cause `<URL未検証>` placeholders in the portfolio table (observed in 002 real-run PLTR row)

## Test plan
- [x] `test_prefetch_drops_urls_with_spaces` — bad URL excluded, good URL kept
- [x] Full `tests/local_llm/` suite: 108 passed

Closes #181

## Summary by Sourcery

Filter out malformed URLs containing spaces during local LLM briefing prefetch to avoid invalid Markdown links and placeholder entries in generated output.

Bug Fixes:
- Exclude search results with space-containing URLs from prefetch results alongside existing index-page filtering to prevent broken Markdown links and <URL未検証> placeholders.

Tests:
- Add a unit test verifying that prefetch drops URLs with spaces while retaining valid URLs.