### PR TITLE
fix: handle ) in Brave Search URLs without leaving garbage in validate_urls

### DIFF
--- a/apps/python/src/local_llm/briefing.py
+++ b/apps/python/src/local_llm/briefing.py
@@ -547,9 +547,16 @@ def generate_local_briefing(
     return content
 
 
-# Markdown リンク `[title](url)` と裸の URL の両方を拾う。
-# URL 部分のみキャプチャ。終端 `)` は escape 不要 (group の内部なので)。
-_URL_RE = re.compile(r"https?://[^\s)\]]+")
+# ) を除外しないことで URL 中の ) を正しくキャプチャする (#003 regression)。
+# Markdown リンク closer の ) は _trim_md_link_closer で除去する。
+_URL_RE = re.compile(r"https?://[^\s\]]+")
+
+
+def _trim_md_link_closer(url: str) -> str:
+    """URL 末尾の不均衡な ) を除去する (Markdown リンク `](url)` の closer 混入防止)。"""
+    while url.endswith(")") and url.count("(") < url.count(")"):
+        url = url[:-1]
+    return url
 
 
 @dataclass(frozen=True)
@@ -571,17 +578,19 @@ def validate_urls(body: str, ctx: PrefetchedContext) -> UrlValidation:
     信頼性を担保するため、Python 側でホワイトリスト照合して捏造分を可視化する。
     """
     allowed = ctx.allowed_urls
-    found = _URL_RE.findall(body)
-    total = len(found)
+    total = 0
     fabricated = 0
 
     def _replace(match: re.Match[str]) -> str:
-        nonlocal fabricated
-        url = match.group(0)
+        nonlocal total, fabricated
+        total += 1
+        raw = match.group(0)
+        url = _trim_md_link_closer(raw)
+        suffix = raw[len(url):]
         if url in allowed:
-            return url
+            return raw
         fabricated += 1
-        return "<URL未検証>"
+        return "<URL未検証>" + suffix
 
     cleaned = _URL_RE.sub(_replace, body)
     return UrlValidation(body=cleaned, total=total, fabricated=fabricated)

--- a/apps/python/tests/local_llm/test_briefing.py
+++ b/apps/python/tests/local_llm/test_briefing.py
@@ -809,6 +809,17 @@ def test_validate_urls_collects_from_all_prefetch_buckets():
     assert v.verified == 4
 
 
+def test_validate_urls_url_with_close_paren_does_not_leave_garbage():
+    """Brave Search returns URLs containing ) — validate_urls must not leave trailing garbage."""
+    ctx = _ctx_with_urls("https://e.com/real")
+    # URL contains ) in the middle (as seen with PLTR Brave hit in 003)
+    body = "[title](https://fabricated.com/path)+Opinions+on+Recent) あと [real](https://e.com/real)"
+    v = validate_urls(body, ctx)
+    assert ")+Opinions" not in v.body
+    assert v.fabricated == 1
+    assert "https://e.com/real" in v.body
+
+
 def test_compose_briefing_md_search_disabled_caveat():
     md = compose_briefing_md(
         body="body",


### PR DESCRIPTION
## Summary
- `_URL_RE` now allows `)` in URL body (previously stopped at first `)`)
- Added `_trim_md_link_closer()` to strip trailing unbalanced `)` (Markdown link closer)
- `validate_urls` re-appends stripped `)` so Markdown link syntax stays intact

## Root cause
003 output revealed that Brave Search returns URLs containing `)` (e.g., PLTR hit: `https://…+Stock+News)+Opinions+…`). The old regex `[^\s)\]]` stopped at the first `)`, leaving `)+Opinions+…` as visible garbage after `<URL未検証>`.

## Test plan
- [x] `test_validate_urls_url_with_close_paren_does_not_leave_garbage` — new RED→GREEN test
- [x] All 470 tests pass

## Summary by Sourcery

Handle URLs containing closing parentheses in Markdown validation without leaving trailing garbage.

Bug Fixes:
- Allow URLs with closing parentheses to be fully captured during Markdown URL extraction.
- Ensure validate_urls strips and then restores Markdown link-closing parentheses so fabricated URLs do not leave trailing text garbage while preserving valid Markdown syntax.

Tests:
- Add a regression test verifying that URLs containing a closing parenthesis do not leave trailing garbage text and that only non-whitelisted URLs are counted as fabricated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL validation to correctly handle URLs containing closing parentheses in Markdown text, preventing formatting disruption when URLs are validated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->