### PR TITLE
fix: collect_references loses pre-fetch URLs after _URL_RE captures trailing )

### DIFF
--- a/apps/python/src/local_llm/briefing.py
+++ b/apps/python/src/local_llm/briefing.py
@@ -439,8 +439,8 @@ def collect_references(ctx: PrefetchedContext, body: str) -> str:
     URL 引用追従限界)。Python 側で本文から URL を抜き、pre-fetch の (title, url)
     と突き合わせて Markdown リンク化する方がはるかに信頼できる。
     """
-    found = _URL_RE.findall(body)
-    if not found:
+    found_raw = _URL_RE.findall(body)
+    if not found_raw:
         return "## 参考記事\n- (本文中に引用 URL なし)"
 
     url_to_title: dict[str, str] = {}
@@ -458,7 +458,7 @@ def collect_references(ctx: PrefetchedContext, body: str) -> str:
 
     lines = ["## 参考記事"]
     seen: set[str] = set()
-    for url in found:
+    for url in (_trim_md_link_closer(u) for u in found_raw):
         if url in seen:
             continue
         seen.add(url)

--- a/apps/python/tests/local_llm/test_briefing.py
+++ b/apps/python/tests/local_llm/test_briefing.py
@@ -820,6 +820,22 @@ def test_validate_urls_url_with_close_paren_does_not_leave_garbage():
     assert "https://e.com/real" in v.body
 
 
+def test_collect_references_matches_url_inside_markdown_link():
+    """collect_references must match pre-fetch URLs even when body wraps them in [title](url)."""
+    ctx = _ctx_with_urls(
+        "https://www.reuters.com/world/ukraine-russia-war/",
+        "https://e.com/other",
+    )
+    body = (
+        "[Reuters](https://www.reuters.com/world/ukraine-russia-war/) "
+        "と [Other](https://e.com/other)"
+    )
+    md = collect_references(ctx, body)
+    assert "reuters.com" in md
+    assert "e.com/other" in md
+    assert "pre-fetch 外" not in md
+
+
 def test_compose_briefing_md_search_disabled_caveat():
     md = compose_briefing_md(
         body="body",


### PR DESCRIPTION
## Summary
- Regression from #185: `_URL_RE` now allows `)` in URLs, so `findall` extracts `https://reuters.com/path/)` (URL + Markdown link closer)
- `url_to_title` stores `https://reuters.com/path/` (no trailing `)`) → lookup returns None for all URLs
- Result: `## 参考記事` section always showed "(引用 URL は全て pre-fetch 外)" — observed in 004 output

## Fix
Apply `_trim_md_link_closer()` before `url_to_title` lookup in `collect_references`, consistent with how `validate_urls` handles the same issue.

## Test plan
- [x] `test_collect_references_matches_url_inside_markdown_link` — new RED→GREEN test
- [x] 471 tests pass

## Summary by Sourcery

Ensure collect_references correctly matches prefetched URLs when they appear inside Markdown links and avoid misclassifying them as outside pre-fetch coverage.

Bug Fixes:
- Fix collect_references losing matches for prefetched URLs when _URL_RE captures trailing closing parentheses from Markdown links.

Tests:
- Add a regression test verifying collect_references matches URLs wrapped in Markdown links and does not report them as outside pre-fetch coverage.