### PR TITLE
feat: log per-task Claude token usage and add aggregation CLI

### DIFF
--- a/apps/python/bin/usage_report.py
+++ b/apps/python/bin/usage_report.py
@@ -1,0 +1,85 @@
+"""log/usage/*.jsonl を集計し、label 別・日別のトークン/コスト合計を出力する。"""
+import argparse
+import json
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parents[1]))
+
+USAGE_DIR = Path(__file__).parents[1] / "log" / "usage"
+
+
+def _iter_records(usage_dir: Path, days: int | None):
+    cutoff = None
+    if days is not None:
+        cutoff = (datetime.now() - timedelta(days=days)).date()
+    for path in sorted(usage_dir.glob("*-usage.jsonl")):
+        try:
+            file_date = datetime.strptime(path.stem.replace("-usage", ""), "%Y%m%d").date()
+        except ValueError:
+            continue
+        if cutoff is not None and file_date < cutoff:
+            continue
+        day = file_date.isoformat()
+        with path.open(encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    yield day, json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+
+def build_summary(usage_dir: Path, days: int | None) -> dict:
+    """(day, label) ごとにトークン/コスト/呼び出し回数を集計する。"""
+    summary: dict = defaultdict(lambda: {
+        "calls": 0,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_creation_tokens": 0,
+        "cost_usd": 0.0,
+    })
+    for day, rec in _iter_records(usage_dir, days):
+        key = (day, rec.get("label", "(unknown)"))
+        agg = summary[key]
+        agg["calls"] += 1
+        agg["input_tokens"] += rec.get("input_tokens", 0) or 0
+        agg["output_tokens"] += rec.get("output_tokens", 0) or 0
+        agg["cache_read_tokens"] += rec.get("cache_read_tokens", 0) or 0
+        agg["cache_creation_tokens"] += rec.get("cache_creation_tokens", 0) or 0
+        agg["cost_usd"] += rec.get("cost_usd", 0.0) or 0.0
+    return summary
+
+
+def format_summary(summary: dict) -> str:
+    if not summary:
+        return "No usage records found."
+    header = f"{'DATE':<10}  {'LABEL':<24}  {'CALLS':>5}  {'IN':>8}  {'OUT':>8}  {'CACHE_R':>8}  {'COST_USD':>9}"
+    lines = [header, "-" * len(header)]
+    for (day, label), agg in sorted(summary.items()):
+        lines.append(
+            f"{day:<10}  {label[:24]:<24}  {agg['calls']:>5}  "
+            f"{agg['input_tokens']:>8}  {agg['output_tokens']:>8}  "
+            f"{agg['cache_read_tokens']:>8}  {agg['cost_usd']:>9.4f}"
+        )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Claude token usage report")
+    parser.add_argument(
+        "--days", type=int, default=None,
+        help="Limit lookback window to the last N days",
+    )
+    args = parser.parse_args()
+    summary = build_summary(USAGE_DIR, args.days)
+    print(format_summary(summary))
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/python/bin/usage_report.py
+++ b/apps/python/bin/usage_report.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parents[1]))
 
+from src.usage_logger import USAGE_FILE_GLOB, parse_usage_file_date
+
 USAGE_DIR = Path(__file__).parents[1] / "log" / "usage"
 
 
@@ -15,10 +17,9 @@ def _iter_records(usage_dir: Path, days: int | None):
     cutoff = None
     if days is not None:
         cutoff = (datetime.now() - timedelta(days=days)).date()
-    for path in sorted(usage_dir.glob("*-usage.jsonl")):
-        try:
-            file_date = datetime.strptime(path.stem.replace("-usage", ""), "%Y%m%d").date()
-        except ValueError:
+    for path in sorted(usage_dir.glob(USAGE_FILE_GLOB)):
+        file_date = parse_usage_file_date(path)
+        if file_date is None:
             continue
         if cutoff is not None and file_date < cutoff:
             continue

--- a/apps/python/bin/usage_report.py
+++ b/apps/python/bin/usage_report.py
@@ -59,13 +59,17 @@ def build_summary(usage_dir: Path, days: int | None) -> dict:
 def format_summary(summary: dict) -> str:
     if not summary:
         return "No usage records found."
-    header = f"{'DATE':<10}  {'LABEL':<24}  {'CALLS':>5}  {'IN':>8}  {'OUT':>8}  {'CACHE_R':>8}  {'COST_USD':>9}"
+    header = (
+        f"{'DATE':<10}  {'LABEL':<24}  {'CALLS':>5}  {'IN':>8}  {'OUT':>8}  "
+        f"{'CACHE_R':>8}  {'CACHE_C':>8}  {'COST_USD':>9}"
+    )
     lines = [header, "-" * len(header)]
     for (day, label), agg in sorted(summary.items()):
         lines.append(
             f"{day:<10}  {label[:24]:<24}  {agg['calls']:>5}  "
             f"{agg['input_tokens']:>8}  {agg['output_tokens']:>8}  "
-            f"{agg['cache_read_tokens']:>8}  {agg['cost_usd']:>9.4f}"
+            f"{agg['cache_read_tokens']:>8}  {agg['cache_creation_tokens']:>8}  "
+            f"{agg['cost_usd']:>9.4f}"
         )
     return "\n".join(lines)
 

--- a/apps/python/src/claude_runner.py
+++ b/apps/python/src/claude_runner.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 import subprocess
@@ -13,8 +14,38 @@ from src.constants import (
 )
 from src.logger import get_logger
 from src.transient_errors import is_transient
+from src.usage_logger import log_usage
 
 logger = get_logger(__name__)
+
+
+def _parse_and_log_usage(stdout: str, label: str) -> str:
+    """``--output-format json`` の stdout を解析し使用量を記録、テキスト結果を返す。
+
+    JSON でない / ``result`` フィールドが無い場合は警告を出して raw stdout を
+    そのまま返す（使用量ログはスキップ）— 使用量計測のために本処理を壊さない。
+    """
+    try:
+        parsed = json.loads(stdout)
+        result_text = parsed["result"]
+    except (json.JSONDecodeError, KeyError, TypeError):
+        logger.warning(
+            "claude CLI 出力を JSON として解析できませんでした、使用量ログをスキップ [%s]", label,
+        )
+        return stdout.strip()
+
+    usage = parsed.get("usage")
+    if isinstance(usage, dict):
+        log_usage(
+            label=label,
+            usage=usage,
+            cost_usd=parsed.get("total_cost_usd"),
+            duration_ms=parsed.get("duration_ms"),
+        )
+    else:
+        logger.warning("claude CLI 出力に usage が無いため使用量ログをスキップ [%s]", label)
+
+    return result_text.strip() if isinstance(result_text, str) else str(result_text)
 
 
 def get_model() -> str:
@@ -70,7 +101,12 @@ def run_claude(
 
     env = build_env(auth_mode=state_mod.read_state().auth_mode)
     model = get_model()
-    cmd = [claude_path, "-p", prompt, "--allowedTools", "WebSearch", "--model", model]
+    cmd = [
+        claude_path, "-p", prompt,
+        "--output-format", "json",
+        "--allowedTools", "WebSearch",
+        "--model", model,
+    ]
 
     last_returncode = 0
     last_detail = ""
@@ -94,7 +130,7 @@ def run_claude(
 
         if result.returncode == 0:
             logger.info("claude CLI 完了: %s (%d文字)", label, len(result.stdout))
-            return result.stdout.strip()
+            return _parse_and_log_usage(result.stdout, label)
 
         logger.error(
             "claude CLI エラー [%s] rc=%d attempt=%d/%d\nstdout=%s\nstderr=%s",

--- a/apps/python/src/claude_runner.py
+++ b/apps/python/src/claude_runner.py
@@ -43,7 +43,8 @@ def _parse_and_log_usage(stdout: str, label: str) -> str:
             duration_ms=parsed.get("duration_ms"),
         )
     else:
-        logger.warning("claude CLI 出力に usage が無いため使用量ログをスキップ [%s]", label)
+        # usage を出さない呼び出しは正常運用でもありうるため debug に留める（ノイズ回避）
+        logger.debug("claude CLI 出力に usage が無いため使用量ログをスキップ [%s]", label)
 
     return result_text.strip() if isinstance(result_text, str) else str(result_text)
 

--- a/apps/python/src/usage_logger.py
+++ b/apps/python/src/usage_logger.py
@@ -20,7 +20,7 @@ def _purge_old_logs(usage_dir: Path) -> None:
     for path in usage_dir.glob("*-usage.jsonl"):
         try:
             file_date = datetime.strptime(path.stem.replace("-usage", ""), "%Y%m%d")
-            if file_date < cutoff:
+            if file_date.date() < cutoff.date():
                 path.unlink()
         except (ValueError, OSError):
             pass

--- a/apps/python/src/usage_logger.py
+++ b/apps/python/src/usage_logger.py
@@ -1,0 +1,53 @@
+"""Claude CLI 呼び出しごとのトークン使用量・コストを JSONL に追記する。
+
+`src/logger.py` の「日次ファイル + 7 日リテンション」規約に倣う。
+ログ記録の失敗が元のタスクを壊してはならないため、例外は握りつぶす。
+"""
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from src.constants import LOG_RETENTION_DAYS
+from src.logger import get_logger
+
+logger = get_logger(__name__)
+
+USAGE_DIR = Path(__file__).parents[1] / "log" / "usage"
+
+
+def _purge_old_logs(usage_dir: Path) -> None:
+    cutoff = datetime.now() - timedelta(days=LOG_RETENTION_DAYS)
+    for path in usage_dir.glob("*-usage.jsonl"):
+        try:
+            file_date = datetime.strptime(path.stem.replace("-usage", ""), "%Y%m%d")
+            if file_date < cutoff:
+                path.unlink()
+        except (ValueError, OSError):
+            pass
+
+
+def log_usage(label: str, usage: dict, cost_usd: float | None, duration_ms: int | None) -> None:
+    """1 回の claude 呼び出しの使用量を当日ファイルに 1 行追記する。
+
+    例外は記録のみで握りつぶす — 使用量ログの失敗で本処理を止めない。
+    """
+    try:
+        USAGE_DIR.mkdir(parents=True, exist_ok=True)
+        _purge_old_logs(USAGE_DIR)
+
+        record = {
+            "timestamp": datetime.now().isoformat(timespec="seconds"),
+            "label": label,
+            "input_tokens": usage.get("input_tokens", 0),
+            "output_tokens": usage.get("output_tokens", 0),
+            "cache_read_tokens": usage.get("cache_read_input_tokens", 0),
+            "cache_creation_tokens": usage.get("cache_creation_input_tokens", 0),
+            "cost_usd": cost_usd,
+            "duration_ms": duration_ms,
+        }
+
+        log_file = USAGE_DIR / f"{datetime.now().strftime('%Y%m%d')}-usage.jsonl"
+        with log_file.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+    except Exception:  # noqa: BLE001 — 使用量ログの失敗は本処理を止めない
+        logger.warning("使用量ログの記録に失敗しました [%s]", label, exc_info=True)

--- a/apps/python/src/usage_logger.py
+++ b/apps/python/src/usage_logger.py
@@ -30,6 +30,22 @@ def parse_usage_file_date(path: Path):
         return None
 
 
+_last_purge_date = None
+
+
+def _maybe_purge(usage_dir: Path) -> None:
+    """同日内の重複 purge を避けるため、1 日 1 回だけ ``_purge_old_logs`` を呼ぶ。
+
+    高頻度呼び出し時にディレクトリ全 glob を毎回走らせる無駄を省く。
+    """
+    global _last_purge_date
+    today = datetime.now().date()
+    if _last_purge_date == today:
+        return
+    _purge_old_logs(usage_dir)
+    _last_purge_date = today
+
+
 def _purge_old_logs(usage_dir: Path) -> None:
     cutoff = (datetime.now() - timedelta(days=LOG_RETENTION_DAYS)).date()
     for path in usage_dir.glob(USAGE_FILE_GLOB):
@@ -50,7 +66,7 @@ def log_usage(label: str, usage: dict, cost_usd: float | None, duration_ms: int 
     """
     try:
         USAGE_DIR.mkdir(parents=True, exist_ok=True)
-        _purge_old_logs(USAGE_DIR)
+        _maybe_purge(USAGE_DIR)
 
         record = {
             "timestamp": datetime.now().isoformat(timespec="seconds"),

--- a/apps/python/src/usage_logger.py
+++ b/apps/python/src/usage_logger.py
@@ -15,14 +15,31 @@ logger = get_logger(__name__)
 USAGE_DIR = Path(__file__).parents[1] / "log" / "usage"
 
 
+USAGE_FILE_GLOB = "*-usage.jsonl"
+
+
+def parse_usage_file_date(path: Path):
+    """``YYYYMMDD-usage.jsonl`` のファイル名から日付 (date) を取り出す。
+
+    ``usage_logger`` と ``bin/usage_report.py`` で共有し、ファイル名規約の
+    ドリフトを防ぐ。解析できなければ ``None`` を返す。
+    """
+    try:
+        return datetime.strptime(path.stem.replace("-usage", ""), "%Y%m%d").date()
+    except ValueError:
+        return None
+
+
 def _purge_old_logs(usage_dir: Path) -> None:
-    cutoff = datetime.now() - timedelta(days=LOG_RETENTION_DAYS)
-    for path in usage_dir.glob("*-usage.jsonl"):
+    cutoff = (datetime.now() - timedelta(days=LOG_RETENTION_DAYS)).date()
+    for path in usage_dir.glob(USAGE_FILE_GLOB):
+        file_date = parse_usage_file_date(path)
+        if file_date is None:
+            continue
         try:
-            file_date = datetime.strptime(path.stem.replace("-usage", ""), "%Y%m%d")
-            if file_date.date() < cutoff.date():
+            if file_date < cutoff:
                 path.unlink()
-        except (ValueError, OSError):
+        except OSError:
             pass
 
 

--- a/apps/python/tests/test_claude_runner.py
+++ b/apps/python/tests/test_claude_runner.py
@@ -1,3 +1,4 @@
+import json
 import os
 import subprocess
 from unittest.mock import MagicMock, patch
@@ -98,6 +99,55 @@ class TestRunClaude:
                 run_claude("prompt", "test")
 
         assert captured["stdin"] == subprocess.DEVNULL
+
+
+class TestRunClaudeUsageLogging:
+    def test_json_output_returns_result_text_and_logs_usage(self):
+        """--output-format json の stdout から result を取り出して返し、
+        usage を usage_logger に渡す。"""
+        payload = json.dumps({
+            "result": "  the answer  ",
+            "total_cost_usd": 0.05,
+            "duration_ms": 1200,
+            "usage": {
+                "input_tokens": 11,
+                "output_tokens": 22,
+                "cache_read_input_tokens": 3,
+                "cache_creation_input_tokens": 4,
+            },
+        })
+        with patch("src.claude_runner.shutil.which", return_value="/usr/bin/claude"):
+            with patch("src.claude_runner.subprocess.run", return_value=_make_result(stdout=payload)):
+                with patch("src.claude_runner.log_usage") as mock_log:
+                    result = run_claude("prompt", "briefing")
+
+        assert result == "the answer"
+        mock_log.assert_called_once()
+        kwargs = mock_log.call_args.kwargs
+        assert kwargs["label"] == "briefing"
+        assert kwargs["usage"]["input_tokens"] == 11
+        assert kwargs["cost_usd"] == 0.05
+        assert kwargs["duration_ms"] == 1200
+
+    def test_malformed_output_falls_back_to_stdout_without_logging(self):
+        """JSON でない stdout はそのまま（strip して）返し、例外を出さず使用量も記録しない。"""
+        with patch("src.claude_runner.shutil.which", return_value="/usr/bin/claude"):
+            with patch("src.claude_runner.subprocess.run", return_value=_make_result(stdout="  plain text  ")):
+                with patch("src.claude_runner.log_usage") as mock_log:
+                    result = run_claude("prompt", "test")
+
+        assert result == "plain text"
+        mock_log.assert_not_called()
+
+    def test_json_without_usage_returns_result_and_skips_logging(self):
+        payload = json.dumps({"result": "ok"})
+        with patch("src.claude_runner.shutil.which", return_value="/usr/bin/claude"):
+            with patch("src.claude_runner.subprocess.run", return_value=_make_result(stdout=payload)):
+                with patch("src.claude_runner.log_usage") as mock_log:
+                    result = run_claude("prompt", "test")
+
+        assert result == "ok"
+        mock_log.assert_not_called()
 
 
 class TestRunClaudeRetry:

--- a/apps/python/tests/test_claude_runner.py
+++ b/apps/python/tests/test_claude_runner.py
@@ -149,6 +149,28 @@ class TestRunClaudeUsageLogging:
         assert result == "ok"
         mock_log.assert_not_called()
 
+    def test_json_without_result_field_falls_back_to_stdout(self):
+        """result フィールドの無い JSON は raw stdout にフォールバックし、使用量も記録しない。"""
+        payload = json.dumps({"foo": 1})
+        with patch("src.claude_runner.shutil.which", return_value="/usr/bin/claude"):
+            with patch("src.claude_runner.subprocess.run", return_value=_make_result(stdout=payload)):
+                with patch("src.claude_runner.log_usage") as mock_log:
+                    result = run_claude("prompt", "test")
+
+        assert result == payload
+        mock_log.assert_not_called()
+
+    def test_non_string_result_is_stringified_and_usage_logged(self):
+        """result が文字列以外でも str() 化して返し、usage は記録する。"""
+        payload = json.dumps({"result": ["x", "y"], "usage": {"input_tokens": 5, "output_tokens": 6}})
+        with patch("src.claude_runner.shutil.which", return_value="/usr/bin/claude"):
+            with patch("src.claude_runner.subprocess.run", return_value=_make_result(stdout=payload)):
+                with patch("src.claude_runner.log_usage") as mock_log:
+                    result = run_claude("prompt", "test")
+
+        assert result == str(["x", "y"])
+        mock_log.assert_called_once()
+
 
 class TestRunClaudeRetry:
     def test_retries_on_529_overloaded_and_succeeds(self):

--- a/apps/python/tests/test_usage_logger.py
+++ b/apps/python/tests/test_usage_logger.py
@@ -41,6 +41,7 @@ def test_log_usage_purges_files_older_than_retention(monkeypatch, tmp_path):
     usage_dir = tmp_path / "usage"
     usage_dir.mkdir()
     monkeypatch.setattr(usage_logger, "USAGE_DIR", usage_dir)
+    monkeypatch.setattr(usage_logger, "_last_purge_date", None)  # 同日 memo をリセット
 
     retention = usage_logger.LOG_RETENTION_DAYS
     old_day = (datetime.now() - timedelta(days=retention + 2)).strftime("%Y%m%d")
@@ -55,6 +56,27 @@ def test_log_usage_purges_files_older_than_retention(monkeypatch, tmp_path):
     remaining = {p.name for p in usage_dir.glob("*-usage.jsonl")}
     assert old_file.name not in remaining
     assert recent_file.name in remaining
+
+
+def test_purge_runs_at_most_once_per_day(monkeypatch, tmp_path):
+    """同日内の 2 回目以降の log_usage では _purge_old_logs を再実行しない。"""
+    usage_dir = tmp_path / "usage"
+    monkeypatch.setattr(usage_logger, "USAGE_DIR", usage_dir)
+    monkeypatch.setattr(usage_logger, "_last_purge_date", None)
+
+    calls = {"n": 0}
+    real_purge = usage_logger._purge_old_logs
+
+    def counting_purge(d):
+        calls["n"] += 1
+        real_purge(d)
+
+    monkeypatch.setattr(usage_logger, "_purge_old_logs", counting_purge)
+
+    usage_logger.log_usage(label="a", usage={}, cost_usd=None, duration_ms=None)
+    usage_logger.log_usage(label="b", usage={}, cost_usd=None, duration_ms=None)
+
+    assert calls["n"] == 1
 
 
 def test_log_usage_swallows_errors(monkeypatch, tmp_path):

--- a/apps/python/tests/test_usage_logger.py
+++ b/apps/python/tests/test_usage_logger.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timedelta
 
 from src import usage_logger
 
@@ -33,6 +34,27 @@ def test_log_usage_appends_one_jsonl_line(monkeypatch, tmp_path):
     assert rec["cost_usd"] == 0.0123
     assert rec["duration_ms"] == 1500
     assert "timestamp" in rec
+
+
+def test_log_usage_purges_files_older_than_retention(monkeypatch, tmp_path):
+    """LOG_RETENTION_DAYS より古い *-usage.jsonl は log_usage 呼び出し時に削除される。"""
+    usage_dir = tmp_path / "usage"
+    usage_dir.mkdir()
+    monkeypatch.setattr(usage_logger, "USAGE_DIR", usage_dir)
+
+    retention = usage_logger.LOG_RETENTION_DAYS
+    old_day = (datetime.now() - timedelta(days=retention + 2)).strftime("%Y%m%d")
+    recent_day = (datetime.now() - timedelta(days=1)).strftime("%Y%m%d")
+    old_file = usage_dir / f"{old_day}-usage.jsonl"
+    recent_file = usage_dir / f"{recent_day}-usage.jsonl"
+    old_file.write_text("{}\n", encoding="utf-8")
+    recent_file.write_text("{}\n", encoding="utf-8")
+
+    usage_logger.log_usage(label="x", usage={}, cost_usd=None, duration_ms=None)
+
+    remaining = {p.name for p in usage_dir.glob("*-usage.jsonl")}
+    assert old_file.name not in remaining
+    assert recent_file.name in remaining
 
 
 def test_log_usage_swallows_errors(monkeypatch, tmp_path):

--- a/apps/python/tests/test_usage_logger.py
+++ b/apps/python/tests/test_usage_logger.py
@@ -1,0 +1,43 @@
+import json
+
+from src import usage_logger
+
+
+def test_log_usage_appends_one_jsonl_line(monkeypatch, tmp_path):
+    usage_dir = tmp_path / "usage"
+    monkeypatch.setattr(usage_logger, "USAGE_DIR", usage_dir)
+
+    usage_logger.log_usage(
+        label="briefing",
+        usage={
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "cache_read_input_tokens": 5,
+            "cache_creation_input_tokens": 3,
+        },
+        cost_usd=0.0123,
+        duration_ms=1500,
+    )
+
+    files = list(usage_dir.glob("*-usage.jsonl"))
+    assert len(files) == 1
+    lines = files[0].read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+
+    rec = json.loads(lines[0])
+    assert rec["label"] == "briefing"
+    assert rec["input_tokens"] == 10
+    assert rec["output_tokens"] == 20
+    assert rec["cache_read_tokens"] == 5
+    assert rec["cache_creation_tokens"] == 3
+    assert rec["cost_usd"] == 0.0123
+    assert rec["duration_ms"] == 1500
+    assert "timestamp" in rec
+
+
+def test_log_usage_swallows_errors(monkeypatch, tmp_path):
+    """記録に失敗しても例外を送出しない（本処理を止めない）。"""
+    monkeypatch.setattr(usage_logger, "USAGE_DIR", tmp_path / "usage")
+    # json.dumps が落ちるようにして書き込み前に例外を起こす
+    monkeypatch.setattr(usage_logger.json, "dumps", lambda *a, **k: (_ for _ in ()).throw(ValueError("boom")))
+    usage_logger.log_usage(label="x", usage={}, cost_usd=None, duration_ms=None)  # 例外が出なければOK

--- a/apps/python/tests/test_usage_report.py
+++ b/apps/python/tests/test_usage_report.py
@@ -22,8 +22,10 @@ def test_build_summary_totals_per_label_per_day(tmp_path):
     usage_dir = tmp_path / "usage"
     today = datetime.now()
     _write_day(usage_dir, today, [
-        {"label": "briefing", "input_tokens": 10, "output_tokens": 5, "cost_usd": 0.01},
-        {"label": "briefing", "input_tokens": 20, "output_tokens": 7, "cost_usd": 0.02},
+        {"label": "briefing", "input_tokens": 10, "output_tokens": 5,
+         "cache_read_tokens": 2, "cache_creation_tokens": 1, "cost_usd": 0.01},
+        {"label": "briefing", "input_tokens": 20, "output_tokens": 7,
+         "cache_read_tokens": 3, "cache_creation_tokens": 4, "cost_usd": 0.02},
         {"label": "xss", "input_tokens": 3, "output_tokens": 1, "cost_usd": 0.005},
     ])
 
@@ -33,8 +35,43 @@ def test_build_summary_totals_per_label_per_day(tmp_path):
     assert summary[(day, "briefing")]["calls"] == 2
     assert summary[(day, "briefing")]["input_tokens"] == 30
     assert summary[(day, "briefing")]["output_tokens"] == 12
+    assert summary[(day, "briefing")]["cache_read_tokens"] == 5
+    assert summary[(day, "briefing")]["cache_creation_tokens"] == 5
     assert abs(summary[(day, "briefing")]["cost_usd"] - 0.03) < 1e-9
     assert summary[(day, "xss")]["calls"] == 1
+
+
+def test_iter_records_skips_malformed_lines(tmp_path):
+    usage_dir = tmp_path / "usage"
+    usage_dir.mkdir(parents=True)
+    path = usage_dir / f"{datetime.now().strftime('%Y%m%d')}-usage.jsonl"
+    path.write_text(
+        '{"label": "ok", "input_tokens": 5, "cost_usd": 0.01}\n'
+        "not-json-garbage\n"
+        "\n",
+        encoding="utf-8",
+    )
+
+    summary = usage_report.build_summary(usage_dir, days=7)
+    day = datetime.now().date().isoformat()
+    assert summary[(day, "ok")]["calls"] == 1
+    assert summary[(day, "ok")]["input_tokens"] == 5
+
+
+def test_format_summary_renders_header_and_rows(tmp_path):
+    usage_dir = tmp_path / "usage"
+    _write_day(usage_dir, datetime.now(), [
+        {"label": "briefing", "input_tokens": 10, "output_tokens": 5,
+         "cache_read_tokens": 2, "cache_creation_tokens": 1, "cost_usd": 0.0123},
+    ])
+    summary = usage_report.build_summary(usage_dir, days=7)
+    out = usage_report.format_summary(summary)
+
+    lines = out.splitlines()
+    assert "CACHE_C" in lines[0]  # cache_creation 列が出力される
+    assert "COST_USD" in lines[0]
+    assert "briefing" in lines[2]
+    assert "0.0123" in lines[2]  # コストは小数4桁
 
 
 def test_days_flag_excludes_old_files(tmp_path):

--- a/apps/python/tests/test_usage_report.py
+++ b/apps/python/tests/test_usage_report.py
@@ -1,0 +1,54 @@
+import importlib.util
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+
+# bin/ はパッケージではないので spec から直接ロードする
+_REPORT_PATH = Path(__file__).parents[1] / "bin" / "usage_report.py"
+_spec = importlib.util.spec_from_file_location("usage_report", _REPORT_PATH)
+usage_report = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(usage_report)
+
+
+def _write_day(usage_dir: Path, day: datetime, records: list[dict]) -> None:
+    usage_dir.mkdir(parents=True, exist_ok=True)
+    path = usage_dir / f"{day.strftime('%Y%m%d')}-usage.jsonl"
+    with path.open("w", encoding="utf-8") as f:
+        for rec in records:
+            f.write(json.dumps(rec) + "\n")
+
+
+def test_build_summary_totals_per_label_per_day(tmp_path):
+    usage_dir = tmp_path / "usage"
+    today = datetime.now()
+    _write_day(usage_dir, today, [
+        {"label": "briefing", "input_tokens": 10, "output_tokens": 5, "cost_usd": 0.01},
+        {"label": "briefing", "input_tokens": 20, "output_tokens": 7, "cost_usd": 0.02},
+        {"label": "xss", "input_tokens": 3, "output_tokens": 1, "cost_usd": 0.005},
+    ])
+
+    summary = usage_report.build_summary(usage_dir, days=7)
+
+    day = today.date().isoformat()
+    assert summary[(day, "briefing")]["calls"] == 2
+    assert summary[(day, "briefing")]["input_tokens"] == 30
+    assert summary[(day, "briefing")]["output_tokens"] == 12
+    assert abs(summary[(day, "briefing")]["cost_usd"] - 0.03) < 1e-9
+    assert summary[(day, "xss")]["calls"] == 1
+
+
+def test_days_flag_excludes_old_files(tmp_path):
+    usage_dir = tmp_path / "usage"
+    old = datetime.now() - timedelta(days=10)
+    _write_day(usage_dir, old, [{"label": "old", "input_tokens": 99, "cost_usd": 1.0}])
+    _write_day(usage_dir, datetime.now(), [{"label": "new", "input_tokens": 1, "cost_usd": 0.0}])
+
+    summary = usage_report.build_summary(usage_dir, days=7)
+    labels = {label for (_day, label) in summary}
+    assert "new" in labels
+    assert "old" not in labels
+
+
+def test_no_records_message(tmp_path):
+    summary = usage_report.build_summary(tmp_path / "usage", days=7)
+    assert usage_report.format_summary(summary) == "No usage records found."


### PR DESCRIPTION
## Summary
- `run_claude()` now calls `claude -p --output-format json`, parses usage/cost, and logs per call. Return type unchanged (text result); on non-JSON output it falls back to raw stdout and skips logging — never fails the task.
- New `src/usage_logger.py`: appends one JSONL line per call to `log/usage/YYYYMMDD-usage.jsonl` (7-day retention).
- New `bin/usage_report.py --days N`: per-label/per-day token & cost totals.

## Test plan
- [x] `pytest` (482 passed): JSON parse success + malformed fallback, usage_logger append, report aggregation/`--days`.
- [x] Existing `run_claude()` call sites unaffected (no signature change).

Closes #190

## Summary by Sourcery

Add per-call Claude CLI usage logging and introduce a reporting tool to aggregate token and cost statistics over recent days.

New Features:
- Record Claude CLI token usage, cache stats, cost, and duration per call into daily JSONL usage logs with automatic retention.
- Provide a usage_report CLI to aggregate usage logs into per-label, per-day token and cost summaries with optional day-based filtering.

Enhancements:
- Update run_claude to consume JSON-formatted CLI output, extract the result text, and opportunistically log usage without affecting existing callers.

Tests:
- Add unit tests for usage logging behavior, log retention, error swallowing, and for the usage_report aggregation and formatting, including malformed input handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added command-line tool to generate usage reports displaying aggregated token usage, cache metrics, and costs organized by date.
  * System now automatically logs token usage and costs per call for historical tracking and analysis.

* **Tests**
  * Added comprehensive test coverage for usage tracking and reporting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->