### PR TITLE
feat: allow model selection from briefing.json config

### DIFF
--- a/apps/python/config/briefing.json.example
+++ b/apps/python/config/briefing.json.example
@@ -1,4 +1,5 @@
 {
+  "model": "claude-haiku-4-5-20251001",
   "portfolio": {
     "tickers": [
       "PLTR",

--- a/apps/python/src/claude_runner.py
+++ b/apps/python/src/claude_runner.py
@@ -49,10 +49,31 @@ def _parse_and_log_usage(stdout: str, label: str) -> str:
     return result_text.strip() if isinstance(result_text, str) else str(result_text)
 
 
+def _config_model() -> str | None:
+    """briefing.json の ``model`` フィールドを返す。読めなければ None。
+
+    briefing.json が無い / 壊れている場合でもモデル解決を止めないため、
+    例外は握りつぶして None を返す（呼び出し側で DEFAULT_MODEL にフォールバック）。
+    """
+    try:
+        from src import config as config_mod
+
+        model = config_mod.CONFIG.model
+    except Exception:  # noqa: BLE001 — config 不在でもモデル解決を止めない
+        return None
+    return model.strip() if model and model.strip() else None
+
+
 def get_model() -> str:
-    """環境変数 CLAUDE_MODEL を読み、空・空白の場合はデフォルトを返す。"""
+    """claude CLI に渡すモデル ID を解決する。
+
+    優先順位: ``CLAUDE_MODEL`` env > briefing.json の ``model`` > ``DEFAULT_MODEL``。
+    env はアドホックな上書き用に最優先のまま。
+    """
     env_model = os.environ.get("CLAUDE_MODEL", "").strip()
-    return env_model if env_model else DEFAULT_MODEL
+    if env_model:
+        return env_model
+    return _config_model() or DEFAULT_MODEL
 
 
 def _backoff_delay(attempt: int) -> float:

--- a/apps/python/src/claude_runner.py
+++ b/apps/python/src/claude_runner.py
@@ -4,6 +4,7 @@ import shutil
 import subprocess
 import time
 
+from src import config as config_mod
 from src import credentials as cred_mod
 from src import state as state_mod
 from src.constants import (
@@ -56,10 +57,12 @@ def _config_model() -> str | None:
     例外は握りつぶして None を返す（呼び出し側で DEFAULT_MODEL にフォールバック）。
     """
     try:
-        from src import config as config_mod
-
         model = config_mod.CONFIG.model
-    except Exception:  # noqa: BLE001 — config 不在でもモデル解決を止めない
+    except FileNotFoundError:
+        # briefing.json 未作成（例: web 起動直後）は想定内なので静かに無視。
+        return None
+    except Exception:  # noqa: BLE001 — 予期しない config エラーでもモデル解決は止めない
+        logger.warning("config からのモデル取得に失敗、DEFAULT_MODEL を使用", exc_info=True)
         return None
     return model.strip() if model and model.strip() else None
 

--- a/apps/python/src/config.py
+++ b/apps/python/src/config.py
@@ -72,6 +72,9 @@ class BriefingFileConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    # claude CLI に渡すモデル ID（任意）。未設定なら DEFAULT_MODEL。
+    # 優先順位は CLAUDE_MODEL env > この config 値 > DEFAULT_MODEL（claude_runner.get_model 参照）。
+    model: str | None = None
     portfolio: PortfolioConfig
     geopolitical: GeopoliticalConfig = Field(default_factory=GeopoliticalConfig)
     watch_sectors: list[WatchSector] = Field(min_length=1)

--- a/apps/python/tests/config/briefing.json
+++ b/apps/python/tests/config/briefing.json
@@ -1,4 +1,5 @@
 {
+  "model": null,
   "portfolio": {
     "tickers": ["TICKER1", "TICKER2"],
     "themes": ["theme1", "theme2", "theme3"]

--- a/apps/python/tests/test_claude_runner.py
+++ b/apps/python/tests/test_claude_runner.py
@@ -7,6 +7,7 @@ import pytest
 
 from src import claude_runner, credentials, state as state_mod
 from src.claude_runner import run_claude
+from src.constants import DEFAULT_MODEL
 
 
 @pytest.fixture(autouse=True)
@@ -365,6 +366,47 @@ class TestRunClaudeRetry:
                     run_claude("prompt", "test", timeout=300)
 
         assert mock_run.call_count == 1
+
+
+class TestGetModel:
+    def test_env_var_takes_precedence_over_config(self, monkeypatch):
+        monkeypatch.setenv("CLAUDE_MODEL", "env-model")
+        monkeypatch.setattr(claude_runner, "_config_model", lambda: "config-model")
+        assert claude_runner.get_model() == "env-model"
+
+    def test_config_model_used_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv("CLAUDE_MODEL", raising=False)
+        monkeypatch.setattr(claude_runner, "_config_model", lambda: "config-model")
+        assert claude_runner.get_model() == "config-model"
+
+    def test_falls_back_to_default_when_neither_set(self, monkeypatch):
+        monkeypatch.delenv("CLAUDE_MODEL", raising=False)
+        monkeypatch.setattr(claude_runner, "_config_model", lambda: None)
+        assert claude_runner.get_model() == DEFAULT_MODEL
+
+    def test_blank_env_var_is_ignored(self, monkeypatch):
+        monkeypatch.setenv("CLAUDE_MODEL", "   ")
+        monkeypatch.setattr(claude_runner, "_config_model", lambda: None)
+        assert claude_runner.get_model() == DEFAULT_MODEL
+
+    def test_config_model_reads_config_field(self, monkeypatch):
+        """briefing.json の model フィールドが解決に反映される。"""
+        monkeypatch.delenv("CLAUDE_MODEL", raising=False)
+        fake_config = MagicMock()
+        fake_config.model = "claude-sonnet-4-6"
+        monkeypatch.setattr("src.config.CONFIG", fake_config, raising=False)
+        assert claude_runner._config_model() == "claude-sonnet-4-6"
+
+    def test_config_model_returns_none_on_load_failure(self, monkeypatch):
+        """config 読み込みが失敗してもモデル解決を止めず None を返す。"""
+        import src.config as config_mod
+
+        def boom():
+            raise FileNotFoundError("no briefing.json")
+
+        monkeypatch.setattr(config_mod, "load_config", boom)
+        monkeypatch.setattr(config_mod, "_CONFIG_CACHE", None)
+        assert claude_runner._config_model() is None
 
 
 class TestBuildEnv:

--- a/apps/python/tests/test_claude_runner.py
+++ b/apps/python/tests/test_claude_runner.py
@@ -391,22 +391,34 @@ class TestGetModel:
 
     def test_config_model_reads_config_field(self, monkeypatch):
         """briefing.json の model フィールドが解決に反映される。"""
-        monkeypatch.delenv("CLAUDE_MODEL", raising=False)
-        fake_config = MagicMock()
-        fake_config.model = "claude-sonnet-4-6"
-        monkeypatch.setattr("src.config.CONFIG", fake_config, raising=False)
+        fake_config_mod = MagicMock()
+        fake_config_mod.CONFIG.model = "claude-sonnet-4-6"
+        monkeypatch.setattr(claude_runner, "config_mod", fake_config_mod)
         assert claude_runner._config_model() == "claude-sonnet-4-6"
 
-    def test_config_model_returns_none_on_load_failure(self, monkeypatch):
-        """config 読み込みが失敗してもモデル解決を止めず None を返す。"""
-        import src.config as config_mod
+    def test_config_model_returns_none_when_missing_file(self, monkeypatch):
+        """briefing.json 未作成 (FileNotFoundError) は静かに None を返す。"""
+        class _Missing:
+            @property
+            def CONFIG(self):
+                raise FileNotFoundError("no briefing.json")
 
-        def boom():
-            raise FileNotFoundError("no briefing.json")
+        monkeypatch.setattr(claude_runner, "config_mod", _Missing())
+        with patch.object(claude_runner.logger, "warning") as mock_warn:
+            assert claude_runner._config_model() is None
+        mock_warn.assert_not_called()  # 想定内なので警告は出さない
 
-        monkeypatch.setattr(config_mod, "load_config", boom)
-        monkeypatch.setattr(config_mod, "_CONFIG_CACHE", None)
-        assert claude_runner._config_model() is None
+    def test_config_model_logs_and_returns_none_on_unexpected_error(self, monkeypatch):
+        """想定外の config エラーは握りつぶしつつ警告ログを出して None を返す。"""
+        class _Broken:
+            @property
+            def CONFIG(self):
+                raise ValueError("broken config")
+
+        monkeypatch.setattr(claude_runner, "config_mod", _Broken())
+        with patch.object(claude_runner.logger, "warning") as mock_warn:
+            assert claude_runner._config_model() is None
+        mock_warn.assert_called_once()
 
 
 class TestBuildEnv:


### PR DESCRIPTION
## Summary
- Add optional `model` field to `BriefingFileConfig` (Pydantic, lazy-load).
- Extend `get_model()` resolution order: `CLAUDE_MODEL` env > config `model` > `DEFAULT_MODEL`. Config load failure falls back gracefully (never blocks model resolution).
- Document the field in `briefing.json.example` and `tests/config/briefing.json`.

## Test plan
- [x] `pytest` (494 passed): env precedence, config-driven model, default fallback, blank-env ignore, config-load-failure fallback.
- [x] No behavior change when neither env nor config field is set.

Closes #191

## Summary by Sourcery

Allow selecting the Claude model via briefing.json configuration while preserving environment variable override and default fallback behavior.

New Features:
- Add an optional model field to the briefing configuration that can be used to select the Claude model for the CLI.

Enhancements:
- Extend model resolution logic so that CLAUDE_MODEL takes precedence over the config model, with a safe fallback to the default model even when config loading fails.

Documentation:
- Document the new model configuration field in the example and test briefing.json files.

Tests:
- Add tests covering precedence between environment variable and config model, default fallback behavior, and error handling when reading the config model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model configuration now supported in `briefing.json` configuration file
  * Environment variable takes precedence over configuration file setting

* **Tests**
  * Added comprehensive test coverage for model resolution logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->