### PR TITLE
feat(local-llm): cluster pre-fetched news into themes before generation

### DIFF
--- a/apps/python/src/local_llm/briefing/__init__.py
+++ b/apps/python/src/local_llm/briefing/__init__.py
@@ -26,6 +26,12 @@ Module layout:
 
 from __future__ import annotations
 
+from .cluster import (
+    DEFAULT_SIMILARITY_THRESHOLD,
+    NewsCluster,
+    cluster_news_hits,
+    render_clusters_block,
+)
 from .compose import compose_briefing_md
 from .filters import (
     _extract_url_date,
@@ -72,6 +78,8 @@ from .render import (
 from .validate import UrlValidation, validate_urls
 
 __all__ = [
+    "DEFAULT_SIMILARITY_THRESHOLD",
+    "NewsCluster",
     "OVERFETCH_EXTRA",
     "PER_EVENT_RESULTS",
     "PER_GEO_RESULTS",
@@ -85,8 +93,10 @@ __all__ = [
     "build_section_insight_prompt",
     "build_section_sector_prompt",
     "build_section_topnews_prompt",
+    "cluster_news_hits",
     "collect_references",
     "compose_briefing_md",
+    "render_clusters_block",
     "ensure_geo_topics_covered",
     "generate_local_briefing",
     "has_simplified_chinese_text",

--- a/apps/python/src/local_llm/briefing/cluster.py
+++ b/apps/python/src/local_llm/briefing/cluster.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass, field
 from typing import Callable
 
 from ..search import SearchResult
+from .prefetch import PrefetchedContext
 
 # Tokenizer for the heuristic similarity: lowercase alnum runs, length >= 2 so
 # single-char noise and most punctuation drop out.
@@ -70,9 +71,9 @@ class NewsCluster:
                 self.sources.append(source)
 
 
-def _clip(text: str, limit: int) -> str:
+def _clip(text: str | None, limit: int) -> str:
     """Flatten newlines and truncate to ``limit`` chars (with an ellipsis)."""
-    flat = text.strip().replace("\n", " ")
+    flat = (text or "").strip().replace("\n", " ")
     return flat[:limit] + "..." if len(flat) > limit else flat
 
 
@@ -106,7 +107,7 @@ def _cosine(a: list[float], b: list[float]) -> float:
     return dot / (na * nb)
 
 
-def _iter_tagged_hits(ctx) -> list[tuple[str, SearchResult]]:
+def _iter_tagged_hits(ctx: PrefetchedContext) -> list[tuple[str, SearchResult]]:
     """macro + per_ticker hits as (source_tag, result), in a stable order.
 
     geo/events are intentionally excluded: they are already distinct per-topic and
@@ -120,7 +121,7 @@ def _iter_tagged_hits(ctx) -> list[tuple[str, SearchResult]]:
 
 
 def cluster_news_hits(
-    ctx,
+    ctx: PrefetchedContext,
     *,
     embed_fn: EmbedFn | None = None,
     threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
@@ -154,6 +155,11 @@ def cluster_news_hits(
     # Pass 2: similarity grouping over the URL-unique representatives.
     if embed_fn is not None:
         vectors = embed_fn([_text_of(r) for _, r in deduped])
+        if len(vectors) != len(deduped):
+            raise ValueError(
+                f"embed_fn must return one vector per text, got {len(vectors)} "
+                f"for {len(deduped)} inputs"
+            )
 
         def sim(i: int, j: int) -> float:
             return _cosine(vectors[i], vectors[j])

--- a/apps/python/src/local_llm/briefing/cluster.py
+++ b/apps/python/src/local_llm/briefing/cluster.py
@@ -34,6 +34,10 @@ _TOKEN_RE = re.compile(r"[a-z0-9]{2,}")
 # stories that merely share a company name.
 DEFAULT_SIMILARITY_THRESHOLD = 0.5
 
+# Caps for the rendered block so a verbose article body doesn't bloat the prompt.
+_MAX_DESC_CHARS = 200
+_MAX_CONTENT_CHARS = 500
+
 EmbedFn = Callable[[list[str]], list[list[float]]]
 
 
@@ -58,6 +62,19 @@ class NewsCluster:
         if source not in self.sources:
             self.sources.append(source)
 
+    def merge_from(self, other: "NewsCluster") -> None:
+        """Absorb another cluster's member hits and source tags."""
+        self.results.extend(other.results)
+        for source in other.sources:
+            if source not in self.sources:
+                self.sources.append(source)
+
+
+def _clip(text: str, limit: int) -> str:
+    """Flatten newlines and truncate to ``limit`` chars (with an ellipsis)."""
+    flat = text.strip().replace("\n", " ")
+    return flat[:limit] + "..." if len(flat) > limit else flat
+
 
 def _text_of(result: SearchResult) -> str:
     return f"{result.title} {result.description}".strip()
@@ -76,6 +93,11 @@ def _jaccard(a: set[str], b: set[str]) -> float:
 
 
 def _cosine(a: list[float], b: list[float]) -> float:
+    if len(a) != len(b):
+        raise ValueError(
+            f"cosine similarity requires equal-length vectors, got {len(a)} and {len(b)} "
+            "(check embed_fn output dimensionality)"
+        )
     dot = sum(x * y for x, y in zip(a, b))
     na = math.sqrt(sum(x * x for x in a))
     nb = math.sqrt(sum(y * y for y in b))
@@ -161,14 +183,7 @@ def cluster_news_hits(
         result_clusters.append(clusters[i])
     for absorbed, survivor in parent.items():
         target = result_clusters[index_of_survivor[survivor]]
-        for r in clusters[absorbed].results:
-            target.add(r, "")  # merge member hits
-        for s in clusters[absorbed].sources:
-            if s and s not in target.sources:
-                target.sources.append(s)
-    # Drop the empty-string source artifact from merges.
-    for c in result_clusters:
-        c.sources = [s for s in c.sources if s]
+        target.merge_from(clusters[absorbed])
     return result_clusters
 
 
@@ -184,14 +199,12 @@ def render_clusters_block(clusters: list[NewsCluster]) -> str:
     lines = ["### クラスタ済みニュース"]
     for c in clusters:
         primary = c.primary
-        desc = primary.description.strip().replace("\n", " ")
-        if len(desc) > 200:
-            desc = desc[:200] + "..."
+        desc = _clip(primary.description, _MAX_DESC_CHARS)
         srcs = "、".join(c.sources) if c.sources else "-"
         lines.append(f"  - [{primary.title}]({primary.url}) — {desc}")
         lines.append(f"    - 関連: {srcs}")
         if primary.content:
-            lines.append(f"    - 本文抜粋: {primary.content}")
+            lines.append(f"    - 本文抜粋: {_clip(primary.content, _MAX_CONTENT_CHARS)}")
         for extra in c.results[1:]:
             lines.append(f"    - 関連記事: [{extra.title}]({extra.url})")
     return "\n".join(lines)

--- a/apps/python/src/local_llm/briefing/cluster.py
+++ b/apps/python/src/local_llm/briefing/cluster.py
@@ -1,0 +1,197 @@
+"""Cluster pre-fetched news hits into themes before section generation (#169).
+
+Pre-fetch queries macro + every ticker separately, so the same story (e.g. a Fed
+decision or a chip-export rule) shows up as duplicate hits across several tickers
+and the macro query. Feeding those raw per-query lists into the top-news prompt
+makes the model emit the same story several times. This module collapses
+overlapping hits into distinct ``NewsCluster`` stories before generation.
+
+Clustering is two-pass:
+1. Exact URL dedup — the same URL fetched under macro and a ticker becomes one
+   cluster, merging the source tags.
+2. Similarity grouping — remaining hits are greedily attached to an existing
+   cluster when similar enough. Similarity is pluggable: pass ``embed_fn`` to use
+   bge-m3 embeddings (cosine); the default is an offline, deterministic
+   token-Jaccard heuristic over title+description so the pipeline (and tests) run
+   without Ollama.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass, field
+from typing import Callable
+
+from ..search import SearchResult
+
+# Tokenizer for the heuristic similarity: lowercase alnum runs, length >= 2 so
+# single-char noise and most punctuation drop out.
+_TOKEN_RE = re.compile(r"[a-z0-9]{2,}")
+
+# Default Jaccard threshold to treat two hits as the same story. Tuned to merge
+# clear restatements (shared tickers/keywords) without collapsing distinct
+# stories that merely share a company name.
+DEFAULT_SIMILARITY_THRESHOLD = 0.5
+
+EmbedFn = Callable[[list[str]], list[list[float]]]
+
+
+@dataclass
+class NewsCluster:
+    """A single deduplicated news story drawn from one or more pre-fetch hits.
+
+    ``results`` keeps every member hit (the first is the representative); ``sources``
+    records which pre-fetch queries surfaced the story ("macro" or a ticker), so the
+    prompt can show "this story touches PLTR + NVDA" rather than listing it twice.
+    """
+
+    results: list[SearchResult] = field(default_factory=list)
+    sources: list[str] = field(default_factory=list)
+
+    @property
+    def primary(self) -> SearchResult:
+        return self.results[0]
+
+    def add(self, result: SearchResult, source: str) -> None:
+        self.results.append(result)
+        if source not in self.sources:
+            self.sources.append(source)
+
+
+def _text_of(result: SearchResult) -> str:
+    return f"{result.title} {result.description}".strip()
+
+
+def _tokens(text: str) -> set[str]:
+    return set(_TOKEN_RE.findall(text.lower()))
+
+
+def _jaccard(a: set[str], b: set[str]) -> float:
+    if not a or not b:
+        return 0.0
+    inter = len(a & b)
+    union = len(a | b)
+    return inter / union if union else 0.0
+
+
+def _cosine(a: list[float], b: list[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    if na == 0 or nb == 0:
+        return 0.0
+    return dot / (na * nb)
+
+
+def _iter_tagged_hits(ctx) -> list[tuple[str, SearchResult]]:
+    """macro + per_ticker hits as (source_tag, result), in a stable order.
+
+    geo/events are intentionally excluded: they are already distinct per-topic and
+    feed their own section (#169 targets top-news cross-ticker/macro duplication).
+    """
+    tagged: list[tuple[str, SearchResult]] = [("macro", r) for r in ctx.macro]
+    for ticker, hits in ctx.per_ticker.items():
+        for r in hits:
+            tagged.append((ticker, r))
+    return tagged
+
+
+def cluster_news_hits(
+    ctx,
+    *,
+    embed_fn: EmbedFn | None = None,
+    threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
+) -> list[NewsCluster]:
+    """Group macro + per_ticker hits into deduplicated ``NewsCluster`` stories.
+
+    ``embed_fn`` maps a list of texts to embedding vectors (e.g. bge-m3 via Ollama);
+    when omitted, a deterministic token-Jaccard heuristic is used so the step runs
+    offline. ``threshold`` is the minimum similarity (cosine or Jaccard) to merge a
+    hit into an existing cluster.
+    """
+    tagged = _iter_tagged_hits(ctx)
+    if not tagged:
+        return []
+
+    # Pass 1: exact URL dedup. Same URL across sources collapses to one cluster.
+    by_url: dict[str, NewsCluster] = {}
+    deduped: list[tuple[str, SearchResult]] = []
+    for source, result in tagged:
+        existing = by_url.get(result.url)
+        if existing is not None:
+            existing.add(result, source)
+            continue
+        cluster = NewsCluster()
+        cluster.add(result, source)
+        by_url[result.url] = cluster
+        deduped.append((source, result))
+
+    clusters = [by_url[result.url] for _, result in deduped]
+
+    # Pass 2: similarity grouping over the URL-unique representatives.
+    if embed_fn is not None:
+        vectors = embed_fn([_text_of(r) for _, r in deduped])
+
+        def sim(i: int, j: int) -> float:
+            return _cosine(vectors[i], vectors[j])
+    else:
+        token_sets = [_tokens(_text_of(r)) for _, r in deduped]
+
+        def sim(i: int, j: int) -> float:
+            return _jaccard(token_sets[i], token_sets[j])
+
+    merged: list[int] = []  # indices of surviving cluster representatives
+    parent: dict[int, int] = {}  # absorbed index -> surviving index
+    for i in range(len(deduped)):
+        target = None
+        for j in merged:
+            if sim(i, j) >= threshold:
+                target = j
+                break
+        if target is None:
+            merged.append(i)
+        else:
+            parent[i] = target
+
+    result_clusters: list[NewsCluster] = []
+    index_of_survivor: dict[int, int] = {}
+    for pos, i in enumerate(merged):
+        index_of_survivor[i] = pos
+        result_clusters.append(clusters[i])
+    for absorbed, survivor in parent.items():
+        target = result_clusters[index_of_survivor[survivor]]
+        for r in clusters[absorbed].results:
+            target.add(r, "")  # merge member hits
+        for s in clusters[absorbed].sources:
+            if s and s not in target.sources:
+                target.sources.append(s)
+    # Drop the empty-string source artifact from merges.
+    for c in result_clusters:
+        c.sources = [s for s in c.sources if s]
+    return result_clusters
+
+
+def render_clusters_block(clusters: list[NewsCluster]) -> str:
+    """Render clustered stories as the top-news search-result block.
+
+    Each cluster is one bullet (representative title/url + which tickers/macro it
+    touches), with any additional member links and body excerpts nested below, so
+    the model sees one deduplicated story instead of per-query repeats.
+    """
+    if not clusters:
+        return "### クラスタ済みニュース\n  - (検索ヒットなし)"
+    lines = ["### クラスタ済みニュース"]
+    for c in clusters:
+        primary = c.primary
+        desc = primary.description.strip().replace("\n", " ")
+        if len(desc) > 200:
+            desc = desc[:200] + "..."
+        srcs = "、".join(c.sources) if c.sources else "-"
+        lines.append(f"  - [{primary.title}]({primary.url}) — {desc}")
+        lines.append(f"    - 関連: {srcs}")
+        if primary.content:
+            lines.append(f"    - 本文抜粋: {primary.content}")
+        for extra in c.results[1:]:
+            lines.append(f"    - 関連記事: [{extra.title}]({extra.url})")
+    return "\n".join(lines)

--- a/apps/python/src/local_llm/briefing/prompts.py
+++ b/apps/python/src/local_llm/briefing/prompts.py
@@ -14,26 +14,32 @@ from src.config import BriefingConfig
 from src.generator.briefing import join_safe
 from src.generator.prompt import render
 
+from .cluster import EmbedFn, cluster_news_hits, render_clusters_block
 from .prefetch import PrefetchedContext
-from .render import render_geo_events_block, render_macro_block
+from .render import render_geo_events_block
 
 
 def build_section_topnews_prompt(
-    cfg: BriefingConfig, *, ctx: PrefetchedContext, today: str
+    cfg: BriefingConfig, *, ctx: PrefetchedContext, today: str, embed_fn: EmbedFn | None = None
 ) -> str:
     """Top-news generation prompt.
 
     cfg is taken so the model always judges "each news item's impact on the
-    holdings ($tickers)" as part of the 3-line causal block (#159). The sources
-    are the macro block only; per-ticker and geopolitical hits are not passed at
-    this stage.
+    holdings ($tickers)" as part of the 3-line causal block (#159).
+
+    Sources are macro + per-ticker hits, clustered into deduplicated stories
+    (#169) so the same event surfaced under several tickers/macro is presented
+    once. ``embed_fn`` optionally supplies bge-m3 embeddings for clustering;
+    omitted, a deterministic offline heuristic is used. Geopolitical/event hits
+    are still routed to their own section, not here.
     """
     tickers = join_safe(cfg.portfolio.tickers, sep=", ")
+    clusters = cluster_news_hits(ctx, embed_fn=embed_fn)
     return render(
         "local_section_topnews",
         today=today,
         tickers=tickers,
-        web_context=render_macro_block(ctx),
+        web_context=render_clusters_block(clusters),
     )
 
 

--- a/apps/python/tests/local_llm/test_briefing.py
+++ b/apps/python/tests/local_llm/test_briefing.py
@@ -421,6 +421,24 @@ def test_build_section_topnews_prompt_passes_clustered_macro_and_ticker_hits():
     assert "https://e.com/e" not in out
 
 
+def test_build_section_topnews_prompt_uses_embed_fn_for_clustering():
+    # #169: embed_fn must be wired through to cluster_news_hits. A constant-vector
+    # embed_fn collapses macro + ticker hits into a single clustered story.
+    cfg = _minimal_cfg(tickers=["PLTR", "NVDA"])
+    ctx = _full_ctx()
+    calls: list[list[str]] = []
+
+    def embed_fn(texts):
+        calls.append(list(texts))
+        return [[1.0, 0.0] for _ in texts]
+
+    out = build_section_topnews_prompt(cfg, ctx=ctx, today="2026-06-09", embed_fn=embed_fn)
+
+    assert calls and calls[0], "embed_fn was not invoked with the news texts"
+    # macro と PLTR が同一ベクトルで 1 クラスタに集約され、関連に両ソースが並ぶ
+    assert "関連: macro、PLTR" in out
+
+
 def test_topnews_prompt_drives_causal_holding_analysis():
     # 各トップニュースに「なぜ / 何が変わった / 保有銘柄への影響」の因果 3 行を
     # 要求し、影響判定用に保有銘柄リストを渡す (#159)。

--- a/apps/python/tests/local_llm/test_briefing.py
+++ b/apps/python/tests/local_llm/test_briefing.py
@@ -404,17 +404,21 @@ def test_render_geo_events_block_empty_when_both_missing():
 # ---------------------------------------------------------------------------
 
 
-def test_build_section_topnews_prompt_only_passes_macro_hits():
+def test_build_section_topnews_prompt_passes_clustered_macro_and_ticker_hits():
+    # #169: top-news now receives clustered macro + per-ticker context (geo/events
+    # still route to their own section).
     cfg = _minimal_cfg(tickers=["PLTR", "NVDA"])
     ctx = _full_ctx()
     out = build_section_topnews_prompt(cfg, ctx=ctx, today="2026-06-09")
     assert "今日のトップニュース" in out
     assert "2026-06-09" in out
     assert "## 検索結果" in out
+    # macro と銘柄別ヒットの両方がクラスタ済みブロックに含まれる
     assert "https://e.com/m" in out
-    # 出典は macro ブロックのみ — 銘柄別 URL・地政学ブロックはこの段では渡さない
-    assert "https://e.com/p" not in out
-    assert "地政学" not in out
+    assert "https://e.com/p" in out
+    # 地政学/イベントはこの段では渡さない
+    assert "https://e.com/g" not in out
+    assert "https://e.com/e" not in out
 
 
 def test_topnews_prompt_drives_causal_holding_analysis():

--- a/apps/python/tests/local_llm/test_cluster.py
+++ b/apps/python/tests/local_llm/test_cluster.py
@@ -113,5 +113,51 @@ def test_render_clusters_block_shows_story_sources_and_extra_links():
     assert "関連記事: [Chip rule restated](https://e.com/b)" in block
 
 
+def test_render_clusters_block_flattens_newlines_in_description():
+    hit = SearchResult("T", "https://e.com/t", "line1\nline2")
+    cluster = NewsCluster()
+    cluster.add(hit, "macro")
+
+    block = render_clusters_block([cluster])
+    assert "line1 line2" in block  # 改行はスペースへ平坦化
+
+
+def test_render_clusters_block_truncates_long_description():
+    hit = SearchResult("T", "https://e.com/t", "x" * 300)
+    cluster = NewsCluster()
+    cluster.add(hit, "macro")
+
+    block = render_clusters_block([cluster])
+    assert "x" * 200 in block  # 200 文字までは残る
+    assert "x" * 210 not in block  # 上限超過は切り詰め
+    assert "..." in block
+
+
+def test_render_clusters_block_truncates_long_content():
+    hit = SearchResult("T", "https://e.com/t", "d", content="y" * 600)
+    cluster = NewsCluster()
+    cluster.add(hit, "macro")
+
+    block = render_clusters_block([cluster])
+
+    assert "y" * 500 in block
+    assert "y" * 510 not in block
+    assert "..." in block
+
+
+def test_cosine_rejects_mismatched_vector_lengths():
+    import pytest
+
+    a = SearchResult("a", "https://e.com/a", "x")
+    b = SearchResult("b", "https://e.com/b", "y")
+    ctx = _ctx(macro=[a, b])
+
+    def bad_embed(texts):
+        return [[1.0, 0.0], [1.0]]  # 次元不一致
+
+    with pytest.raises(ValueError, match="equal-length"):
+        cluster_news_hits(ctx, embed_fn=bad_embed, threshold=0.5)
+
+
 def test_render_clusters_block_empty():
     assert "検索ヒットなし" in render_clusters_block([])

--- a/apps/python/tests/local_llm/test_cluster.py
+++ b/apps/python/tests/local_llm/test_cluster.py
@@ -1,0 +1,117 @@
+"""Tests for news clustering (#169)."""
+
+from src.local_llm.briefing.cluster import (
+    NewsCluster,
+    cluster_news_hits,
+    render_clusters_block,
+)
+from src.local_llm.briefing.prefetch import PrefetchedContext
+from src.local_llm.search import SearchResult
+
+
+def _ctx(*, macro=None, per_ticker=None) -> PrefetchedContext:
+    return PrefetchedContext(
+        macro=macro or [],
+        per_ticker=per_ticker or {},
+        geo_by_topic={},
+        events_by_name={},
+    )
+
+
+def test_same_url_across_macro_and_ticker_collapses_into_one_cluster():
+    hit = SearchResult("Fed holds rates", "https://e.com/fed", "FOMC decision")
+    ctx = _ctx(macro=[hit], per_ticker={"PLTR": [hit], "NVDA": [hit]})
+
+    clusters = cluster_news_hits(ctx)
+
+    assert len(clusters) == 1
+    # 同一 URL が macro/PLTR/NVDA から来ても 1 ストーリーに集約、source は統合
+    assert clusters[0].primary.url == "https://e.com/fed"
+    assert set(clusters[0].sources) == {"macro", "PLTR", "NVDA"}
+
+
+def test_similar_titles_are_grouped_by_heuristic():
+    a = SearchResult(
+        "US weighs new chip export rule on China",
+        "https://e.com/chip-a",
+        "semiconductor export restriction china",
+    )
+    b = SearchResult(
+        "New chip export rule on China weighed by US",
+        "https://e.com/chip-b",
+        "semiconductor export restriction china",
+    )
+    ctx = _ctx(macro=[a], per_ticker={"NVDA": [b]})
+
+    clusters = cluster_news_hits(ctx)
+
+    assert len(clusters) == 1
+    urls = {r.url for r in clusters[0].results}
+    assert urls == {"https://e.com/chip-a", "https://e.com/chip-b"}
+
+
+def test_distinct_stories_stay_separate():
+    a = SearchResult("Oil surges on Hormuz tension", "https://e.com/oil", "energy crude")
+    b = SearchResult("PLTR wins defense contract", "https://e.com/pltr", "palantir gov deal")
+    ctx = _ctx(macro=[a], per_ticker={"PLTR": [b]})
+
+    clusters = cluster_news_hits(ctx)
+
+    assert len(clusters) == 2
+
+
+def test_embed_fn_is_used_when_provided():
+    a = SearchResult("alpha story", "https://e.com/a", "x")
+    b = SearchResult("totally different words", "https://e.com/b", "y")
+    ctx = _ctx(macro=[a, b])
+
+    # 埋め込みが同一ベクトルを返せば、トークンが全く違っても 1 クラスタに集約される
+    def embed_fn(texts):
+        return [[1.0, 0.0] for _ in texts]
+
+    clusters = cluster_news_hits(ctx, embed_fn=embed_fn, threshold=0.9)
+    assert len(clusters) == 1
+
+    # 直交ベクトルを返せば別クラスタのまま
+    def orthogonal(texts):
+        return [[1.0, 0.0], [0.0, 1.0]]
+
+    clusters2 = cluster_news_hits(ctx, embed_fn=orthogonal, threshold=0.5)
+    assert len(clusters2) == 2
+
+
+def test_geo_and_events_are_not_clustered():
+    macro = SearchResult("M", "https://e.com/m", "d")
+    ctx = PrefetchedContext(
+        macro=[macro],
+        per_ticker={},
+        geo_by_topic={"米中": [SearchResult("G", "https://e.com/g", "dg")]},
+        events_by_name={"FOMC": [SearchResult("E", "https://e.com/e", "de")]},
+    )
+    clusters = cluster_news_hits(ctx)
+    all_urls = {r.url for c in clusters for r in c.results}
+    assert all_urls == {"https://e.com/m"}
+
+
+def test_empty_context_returns_no_clusters():
+    assert cluster_news_hits(_ctx()) == []
+
+
+def test_render_clusters_block_shows_story_sources_and_extra_links():
+    a = SearchResult("Chip rule", "https://e.com/a", "export", content="本文ここ")
+    b = SearchResult("Chip rule restated", "https://e.com/b", "export")
+    cluster = NewsCluster()
+    cluster.add(a, "macro")
+    cluster.add(b, "NVDA")
+
+    block = render_clusters_block([cluster])
+
+    assert "### クラスタ済みニュース" in block
+    assert "[Chip rule](https://e.com/a)" in block
+    assert "関連: macro、NVDA" in block
+    assert "本文抜粋: 本文ここ" in block
+    assert "関連記事: [Chip rule restated](https://e.com/b)" in block
+
+
+def test_render_clusters_block_empty():
+    assert "検索ヒットなし" in render_clusters_block([])

--- a/apps/python/tests/local_llm/test_cluster.py
+++ b/apps/python/tests/local_llm/test_cluster.py
@@ -159,5 +159,19 @@ def test_cosine_rejects_mismatched_vector_lengths():
         cluster_news_hits(ctx, embed_fn=bad_embed, threshold=0.5)
 
 
+def test_embed_fn_returning_wrong_count_raises():
+    import pytest
+
+    a = SearchResult("a", "https://e.com/a", "x")
+    b = SearchResult("b", "https://e.com/b", "y")
+    ctx = _ctx(macro=[a, b])
+
+    def short_embed(texts):
+        return [[1.0, 0.0]]  # 入力 2 件に対し 1 件しか返さない
+
+    with pytest.raises(ValueError, match="one vector per text"):
+        cluster_news_hits(ctx, embed_fn=short_embed)
+
+
 def test_render_clusters_block_empty():
     assert "検索ヒットなし" in render_clusters_block([])


### PR DESCRIPTION
## Summary
- Add `src/local_llm/briefing/cluster.py`: groups macro + per-ticker pre-fetch hits into deduplicated `NewsCluster` stories before top-news generation (#169, epic #172).
- Two-pass clustering: exact URL dedup, then similarity grouping. Similarity is pluggable via `embed_fn` (bge-m3 cosine); the default is a deterministic offline token-Jaccard heuristic, so the step and its tests run without Ollama.
- Wire the clustered context into `build_section_topnews_prompt` so the same event surfaced under several tickers/macro is presented once instead of as per-query repeats. Geo/event hits still route to their own section.

## Notes
- Previously top-news received only the macro block; per-ticker hits were dropped. It now receives clustered macro + per-ticker context.
- Production uses the heuristic by default; bge-m3 embeddings are pluggable for a follow-up. Importance scoring/ordering over clusters is #170.

## Test plan
- [x] `pytest` (507 passed): URL dedup across macro/ticker, heuristic grouping of restated stories, distinct stories stay separate, injected `embed_fn` path, geo/events excluded, rendered block shows sources + extra links.
- [x] Existing local-LLM briefing tests updated for the clustered top-news context.

Closes #169

## Summary by Sourcery

Cluster pre-fetched macro and per-ticker news hits into deduplicated themed stories before building the local LLM top-news prompt, and render these clusters as the web context for top-news generation.

New Features:
- Introduce a news clustering module that groups macro and per-ticker search hits into deduplicated NewsCluster stories using URL deduplication and pluggable similarity functions.
- Expose clustering utilities and rendering helpers from the local_llm.briefing package for use by other components.

Enhancements:
- Update the top-news section prompt to consume and render clustered macro and per-ticker news context instead of only the macro block, while keeping geo/event hits in their own sections.

Tests:
- Add comprehensive unit tests for news clustering behavior, similarity strategies, and cluster block rendering, and adjust top-news prompt tests to cover clustered context and embed_fn wiring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added news deduplication and clustering to group similar articles together in the top news section.
  * Related articles are now nested under primary stories for improved readability.

* **Tests**
  * Added comprehensive test coverage for the news clustering feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->