### PR TITLE
feat(local-llm): score and rank clustered news by investment importance

### DIFF
--- a/apps/python/src/local_llm/briefing/__init__.py
+++ b/apps/python/src/local_llm/briefing/__init__.py
@@ -28,9 +28,12 @@ from __future__ import annotations
 
 from .cluster import (
     DEFAULT_SIMILARITY_THRESHOLD,
+    TOP_NEWS_CLUSTER_LIMIT,
     NewsCluster,
     cluster_news_hits,
+    rank_clusters,
     render_clusters_block,
+    score_cluster,
 )
 from .compose import compose_briefing_md
 from .filters import (
@@ -81,6 +84,7 @@ __all__ = [
     "DEFAULT_SIMILARITY_THRESHOLD",
     "NewsCluster",
     "OVERFETCH_EXTRA",
+    "TOP_NEWS_CLUSTER_LIMIT",
     "PER_EVENT_RESULTS",
     "PER_GEO_RESULTS",
     "PER_MACRO_RESULTS",
@@ -96,7 +100,9 @@ __all__ = [
     "cluster_news_hits",
     "collect_references",
     "compose_briefing_md",
+    "rank_clusters",
     "render_clusters_block",
+    "score_cluster",
     "ensure_geo_topics_covered",
     "generate_local_briefing",
     "has_simplified_chinese_text",

--- a/apps/python/src/local_llm/briefing/cluster.py
+++ b/apps/python/src/local_llm/briefing/cluster.py
@@ -234,9 +234,14 @@ def score_cluster(cluster: NewsCluster) -> float:
     """
     keyword_score = 0.0
     for r in cluster.results:
-        toks = _tokens(_text_of(r))
+        text = _text_of(r).lower()
+        # ASCII keywords match on whole tokens (so "ban" doesn't hit "Lebanon");
+        # Japanese keywords match on substring because _TOKEN_RE only tokenizes
+        # ASCII runs and would otherwise never match 決算/買収/規制 etc.
+        ascii_tokens = set(_TOKEN_RE.findall(text))
         for kw, weight in _IMPORTANCE_KEYWORDS.items():
-            if kw in toks:
+            hit = kw in ascii_tokens if kw.isascii() else kw in text
+            if hit:
                 keyword_score += weight
     breadth = _SOURCE_BREADTH_WEIGHT * max(0, len(cluster.sources) - 1)
     content = _CONTENT_BOOST if any(r.content for r in cluster.results) else 0.0
@@ -264,6 +269,12 @@ def render_clusters_block(clusters: list[NewsCluster]) -> str:
     Each cluster is one bullet (representative title/url + which tickers/macro it
     touches), with any additional member links and body excerpts nested below, so
     the model sees one deduplicated story instead of per-query repeats.
+
+    Precondition (#170): ``clusters`` is expected to be already ranked via
+    ``rank_clusters`` — the block is labeled "重要度順" and prints each cluster's
+    ``score`` and 1-based position. Passing unranked clusters renders them in the
+    given order with ``score=0.0``; callers that want the importance ordering must
+    call ``rank_clusters`` first.
     """
     if not clusters:
         return "### クラスタ済みニュース\n  - (検索ヒットなし)"

--- a/apps/python/src/local_llm/briefing/cluster.py
+++ b/apps/python/src/local_llm/briefing/cluster.py
@@ -39,6 +39,35 @@ DEFAULT_SIMILARITY_THRESHOLD = 0.5
 _MAX_DESC_CHARS = 200
 _MAX_CONTENT_CHARS = 500
 
+# Default number of top-scoring clusters fed to the top-news section. The model
+# scatters attention over long lists, so lead with the most material stories (#170).
+TOP_NEWS_CLUSTER_LIMIT = 6
+
+# Investment-importance keyword weights (#170). Matched against the cluster's
+# title+description tokens (lowercased). Material catalysts (earnings, guidance,
+# M&A, policy) outrank routine product/partnership noise. Japanese terms are
+# included because pre-fetched titles are often localized.
+_IMPORTANCE_KEYWORDS: dict[str, float] = {
+    # Earnings / guidance — the strongest routine catalyst.
+    "earnings": 3.0, "guidance": 3.0, "forecast": 2.0, "outlook": 2.0,
+    "revenue": 2.0, "profit": 2.0, "決算": 3.0, "業績": 2.0, "ガイダンス": 3.0,
+    # M&A.
+    "acquisition": 3.0, "acquire": 3.0, "merger": 3.0, "buyout": 3.0,
+    "takeover": 3.0, "買収": 3.0, "合併": 3.0,
+    # Policy / regulation.
+    "regulation": 2.5, "sanction": 2.5, "tariff": 2.5, "ban": 2.5,
+    "antitrust": 2.5, "lawsuit": 1.5, "investigation": 1.5, "sec": 1.5,
+    "規制": 2.5, "制裁": 2.5, "関税": 2.5, "提訴": 1.5,
+    # Analyst actions.
+    "upgrade": 1.5, "downgrade": 1.5, "rating": 1.0, "格上げ": 1.5, "格下げ": 1.5,
+}
+
+# Each additional source (a story surfaced under several tickers/macro) signals
+# broader materiality.
+_SOURCE_BREADTH_WEIGHT = 1.0
+# Enriched body excerpt present (top hits only) — small boost for substance.
+_CONTENT_BOOST = 0.5
+
 EmbedFn = Callable[[list[str]], list[list[float]]]
 
 
@@ -53,6 +82,8 @@ class NewsCluster:
 
     results: list[SearchResult] = field(default_factory=list)
     sources: list[str] = field(default_factory=list)
+    # Investment-importance score, set by rank_clusters (#170). 0.0 until scored.
+    score: float = 0.0
 
     @property
     def primary(self) -> SearchResult:
@@ -193,6 +224,40 @@ def cluster_news_hits(
     return result_clusters
 
 
+def score_cluster(cluster: NewsCluster) -> float:
+    """Investment-importance score for a single cluster (#170).
+
+    Combines (a) material-catalyst keyword weights over every member hit's
+    title+description, (b) source breadth (a story surfaced under several
+    tickers/macro is more material), and (c) a small boost when an enriched body
+    excerpt is present. Higher = lead with it.
+    """
+    keyword_score = 0.0
+    for r in cluster.results:
+        toks = _tokens(_text_of(r))
+        for kw, weight in _IMPORTANCE_KEYWORDS.items():
+            if kw in toks:
+                keyword_score += weight
+    breadth = _SOURCE_BREADTH_WEIGHT * max(0, len(cluster.sources) - 1)
+    content = _CONTENT_BOOST if any(r.content for r in cluster.results) else 0.0
+    return keyword_score + breadth + content
+
+
+def rank_clusters(
+    clusters: list[NewsCluster], *, limit: int | None = None
+) -> list[NewsCluster]:
+    """Score each cluster, then return them ordered by importance (desc).
+
+    Sets ``cluster.score`` in place. The sort is stable, so clusters with equal
+    score keep their original (pre-fetch) order. ``limit`` caps the result to the
+    top-N most material clusters.
+    """
+    for c in clusters:
+        c.score = score_cluster(c)
+    ranked = sorted(clusters, key=lambda c: c.score, reverse=True)
+    return ranked[:limit] if limit is not None else ranked
+
+
 def render_clusters_block(clusters: list[NewsCluster]) -> str:
     """Render clustered stories as the top-news search-result block.
 
@@ -202,13 +267,13 @@ def render_clusters_block(clusters: list[NewsCluster]) -> str:
     """
     if not clusters:
         return "### クラスタ済みニュース\n  - (検索ヒットなし)"
-    lines = ["### クラスタ済みニュース"]
-    for c in clusters:
+    lines = ["### クラスタ済みニュース（重要度順）"]
+    for rank, c in enumerate(clusters, start=1):
         primary = c.primary
         desc = _clip(primary.description, _MAX_DESC_CHARS)
         srcs = "、".join(c.sources) if c.sources else "-"
         lines.append(f"  - [{primary.title}]({primary.url}) — {desc}")
-        lines.append(f"    - 関連: {srcs}")
+        lines.append(f"    - 関連: {srcs} / 重要度: {c.score:.1f} (#{rank})")
         if primary.content:
             lines.append(f"    - 本文抜粋: {_clip(primary.content, _MAX_CONTENT_CHARS)}")
         for extra in c.results[1:]:

--- a/apps/python/src/local_llm/briefing/prompts.py
+++ b/apps/python/src/local_llm/briefing/prompts.py
@@ -14,7 +14,13 @@ from src.config import BriefingConfig
 from src.generator.briefing import join_safe
 from src.generator.prompt import render
 
-from .cluster import EmbedFn, cluster_news_hits, render_clusters_block
+from .cluster import (
+    TOP_NEWS_CLUSTER_LIMIT,
+    EmbedFn,
+    cluster_news_hits,
+    rank_clusters,
+    render_clusters_block,
+)
 from .prefetch import PrefetchedContext
 from .render import render_geo_events_block
 
@@ -29,12 +35,15 @@ def build_section_topnews_prompt(
 
     Sources are macro + per-ticker hits, clustered into deduplicated stories
     (#169) so the same event surfaced under several tickers/macro is presented
-    once. ``embed_fn`` optionally supplies bge-m3 embeddings for clustering;
+    once. Clusters are then ranked by investment importance and capped to the
+    top ``TOP_NEWS_CLUSTER_LIMIT`` so the section leads with material catalysts
+    (#170). ``embed_fn`` optionally supplies bge-m3 embeddings for clustering;
     omitted, a deterministic offline heuristic is used. Geopolitical/event hits
     are still routed to their own section, not here.
     """
     tickers = join_safe(cfg.portfolio.tickers, sep=", ")
     clusters = cluster_news_hits(ctx, embed_fn=embed_fn)
+    clusters = rank_clusters(clusters, limit=TOP_NEWS_CLUSTER_LIMIT)
     return render(
         "local_section_topnews",
         today=today,

--- a/apps/python/tests/local_llm/test_cluster.py
+++ b/apps/python/tests/local_llm/test_cluster.py
@@ -3,7 +3,9 @@
 from src.local_llm.briefing.cluster import (
     NewsCluster,
     cluster_news_hits,
+    rank_clusters,
     render_clusters_block,
+    score_cluster,
 )
 from src.local_llm.briefing.prefetch import PrefetchedContext
 from src.local_llm.search import SearchResult
@@ -171,6 +173,69 @@ def test_embed_fn_returning_wrong_count_raises():
 
     with pytest.raises(ValueError, match="one vector per text"):
         cluster_news_hits(ctx, embed_fn=short_embed)
+
+
+# ---------------------------------------------------------------------------
+# Importance scoring / ranking (#170)
+# ---------------------------------------------------------------------------
+
+
+def _cluster(title, desc, *, sources=("macro",), content=""):
+    c = NewsCluster()
+    c.add(SearchResult(title, "https://e.com/x", desc, content=content), sources[0])
+    for s in sources[1:]:
+        c.sources.append(s)
+    return c
+
+
+def test_score_rewards_material_catalyst_keywords():
+    earnings = _cluster("NVDA earnings beat", "guidance raised")
+    noise = _cluster("NVDA new logo unveiled", "branding refresh")
+    assert score_cluster(earnings) > score_cluster(noise)
+
+
+def test_score_rewards_source_breadth():
+    broad = _cluster("Chip rule", "policy", sources=("macro", "NVDA", "PLTR"))
+    narrow = _cluster("Chip rule", "policy", sources=("macro",))
+    assert score_cluster(broad) > score_cluster(narrow)
+
+
+def test_score_rewards_enriched_content():
+    with_body = _cluster("story", "desc", content="本文抜粋あり")
+    without = _cluster("story", "desc")
+    assert score_cluster(with_body) > score_cluster(without)
+
+
+def test_rank_orders_by_score_and_limits():
+    noise = _cluster("logo refresh", "branding")
+    earnings = _cluster("Q2 earnings beat", "guidance raised, revenue up")
+    mna = _cluster("acquisition announced", "merger buyout")
+
+    ranked = rank_clusters([noise, earnings, mna], limit=2)
+
+    assert len(ranked) == 2
+    # 最重要 2 件（決算・M&A）がノイズより上位に来る
+    assert noise not in ranked
+    assert ranked[0].score >= ranked[1].score
+    # スコアが各クラスタに設定される
+    assert earnings.score > 0
+
+
+def test_rank_is_stable_for_equal_scores():
+    a = _cluster("neutral one", "xx")
+    b = _cluster("neutral two", "yy")
+    # 同点なら元の順序を保つ（安定ソート）
+    ranked = rank_clusters([a, b])
+    assert ranked == [a, b]
+
+
+def test_render_clusters_block_shows_score_and_rank():
+    c = _cluster("Q2 earnings beat", "guidance raised")
+    ranked = rank_clusters([c])
+    block = render_clusters_block(ranked)
+    assert "重要度順" in block
+    assert "重要度:" in block
+    assert "(#1)" in block
 
 
 def test_render_clusters_block_empty():

--- a/apps/python/tests/local_llm/test_cluster.py
+++ b/apps/python/tests/local_llm/test_cluster.py
@@ -194,6 +194,28 @@ def test_score_rewards_material_catalyst_keywords():
     assert score_cluster(earnings) > score_cluster(noise)
 
 
+def test_score_rewards_japanese_catalyst_keywords():
+    # 決算 / 買収 等の日本語キーワードもスコアに効く（_TOKEN_RE は ASCII のみ
+    # なので部分一致でマッチさせている）。
+    catalyst = _cluster("トヨタ 決算 発表", "通期ガイダンス据え置き、買収も検討")
+    neutral = _cluster("トヨタ 新モデル発表", "デザイン刷新")
+    assert score_cluster(catalyst) > score_cluster(neutral)
+
+
+def test_score_is_additive_over_multiple_keywords():
+    multi = _cluster("earnings beat and guidance raised", "acquisition announced")
+    single = _cluster("earnings beat", "strong quarter")
+    assert score_cluster(multi) > score_cluster(single)
+
+
+def test_ascii_keyword_matches_whole_token_only():
+    # "ban" は "Lebanon" の部分一致でヒットしてはいけない（トークン一致）。
+    false_match = _cluster("Lebanon update", "regional news")
+    real_match = _cluster("export ban imposed", "policy")
+    assert score_cluster(false_match) == 0.0
+    assert score_cluster(real_match) > 0.0
+
+
 def test_score_rewards_source_breadth():
     broad = _cluster("Chip rule", "policy", sources=("macro", "NVDA", "PLTR"))
     narrow = _cluster("Chip rule", "policy", sources=("macro",))


### PR DESCRIPTION
## Summary
- Add importance scoring over `NewsCluster`s (#170, epic #172): `score_cluster()` combines material-catalyst keyword weights (earnings/guidance/M&A/policy, EN+JP), source breadth (a story surfaced under several tickers/macro), and an enriched-content boost.
- `rank_clusters()` sets `cluster.score`, sorts by importance (stable for ties), and caps to a limit.
- Wire into `build_section_topnews_prompt`: clusters are ranked and capped to `TOP_NEWS_CLUSTER_LIMIT` so the section leads with the most material stories (sector consumes this via `prior_text`).
- Surface the score and rank per story in the clustered block for transparency.

## Test plan
- [x] `pytest` (519 passed): keyword/source-breadth/content scoring, rank ordering + limit, stable ties, score/rank rendered in the block.
- [x] Builds on #169 clustering; geo/event hits unaffected.

Closes #170

## Summary by Sourcery

Introduce investment-importance scoring for clustered news and integrate it into the top-news briefing flow so that the most material stories appear first.

New Features:
- Add investment-importance scoring for news clusters based on catalyst keywords, source breadth, and enriched content.
- Expose cluster importance scores and ranks in the rendered clustered-news block for transparency.
- Limit the top-news section to a configurable number of top-ranked clusters so the briefing leads with the most material stories.

Enhancements:
- Ensure cluster ranking is stable for equal scores and propagate scores onto clusters for reuse.
- Update the top-news prompt builder to rank and cap clusters before rendering, and export the new ranking and scoring utilities from the briefing package.

Tests:
- Add unit tests covering keyword-based importance scoring (including Japanese terms), source breadth and content boosts, stable ranking behavior, result limiting, and score/rank rendering in the clusters block.