### PR TITLE
docs(local-llm): document configurable generation model presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,22 @@ ollama pull bge-m3        # embedding model (#135): stronger JP + code retrieval
 
 The default generation model is `qwen2.5:14b` for more stable instruction-following and citation quality in the `--briefing` path. If you only run `--ask` / `--index`, override with `LOCAL_LLM_MODEL=qwen2.5:7b`.
 
+#### Model options
+
+Swap the generation model without code edits via `LOCAL_LLM_MODEL` (env) or `--model` (CLI flag). RAM figures are approximate for Q4 quantization; leave headroom for the embedding model and OS.
+
+| Model | Approx. RAM (Q4) | Best for | Trade-offs |
+|---|---|---|---|
+| `qwen2.5:7b` | ~5 GB | `--ask` / `--index` on the RAG path | Fastest; weaker tool calling, so less reliable for `--briefing` web_search |
+| `qwen2.5-coder:14b` | ~9 GB | Code-heavy `--ask` queries over this repo | Stronger on code, but tuned less for general JP briefing prose |
+| `qwen2.5:14b` (default) | ~8.5 GB | `--briefing`: reliable tool calling + citation quality | Balanced; fits comfortably on 24 GB RAM with 16K ctx |
+| `qwen2.5:32b` | ~20 GB | Deepest explanations / final synthesis stage | Slow; tight on 24 GB RAM — close other apps |
+
+```bash
+LOCAL_LLM_MODEL=qwen2.5:32b bin/local_llm.sh --ask "..."   # one-off override
+bin/local_llm.sh --briefing --model qwen2.5:7b             # per-invocation flag
+```
+
 > **Switching embed models requires a rebuild.** `bge-m3` (1024 dim) and the legacy `nomic-embed-text` (768 dim) produce incompatible vectors. If you change `LOCAL_LLM_EMBED_MODEL` (or are upgrading from a pre-#135 index), the CLI refuses with an `EmbedModelMismatch` error — rebuild with `bin/local_llm.sh --index --reset`.
 
 ### Usage

--- a/README.md
+++ b/README.md
@@ -240,6 +240,10 @@ ollama serve &
 ollama pull qwen2.5:14b   # for --briefing: reliable tool calling (~8.5GB RAM with Q4)
 ollama pull qwen2.5:7b    # for --ask / --index: smaller, fits the RAG path
 ollama pull bge-m3        # embedding model (#135): stronger JP + code retrieval than nomic-embed-text
+
+# optional alternatives — see the Model options table below
+ollama pull qwen2.5-coder:14b  # code-heavy --ask queries
+ollama pull qwen2.5:32b        # deepest explanations / final synthesis (~20GB RAM)
 ```
 
 The default generation model is `qwen2.5:14b` for more stable instruction-following and citation quality in the `--briefing` path. If you only run `--ask` / `--index`, override with `LOCAL_LLM_MODEL=qwen2.5:7b`.


### PR DESCRIPTION
## Summary
- Add a Model options table (qwen2.5 7b / coder:14b / 14b / 32b) with approximate Q4 RAM and trade-offs to the Local LLM README section.
- The generation model is already swappable without code edits via `LOCAL_LLM_MODEL` (env) and `--model` (CLI). This documents the presets and RAM hints.

## Test plan
- [x] `LOCAL_LLM_MODEL=qwen2.5:32b` is picked up by `load_config()` (verified locally)
- [ ] Empirical 7b vs 14b/32b quality comparison on sample queries — requires local Ollama run by operator

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document configurable local LLM generation model presets and usage for swapping models without code changes.

Documentation:
- Add a model options table describing available generation model presets, their approximate RAM usage, and recommended use cases.
- Document environment variable and CLI flag examples for overriding the default generation model on a per-run basis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on overriding the local generation model using environment variables or CLI flags.
  * Added RAM requirements table for supported models.
  * Included example commands for model selection and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->