### PR TITLE
feat(local-llm): route briefing synthesis stage to a reasoning model

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,22 @@ LOCAL_LLM_MODEL=qwen2.5:32b bin/local_llm.sh --ask "..."   # one-off override
 bin/local_llm.sh --briefing --model qwen2.5:7b             # per-invocation flag
 ```
 
+#### Dual-model briefing (reasoning final stage)
+
+For `--briefing`, the final synthesis stage (自分への示唆 / insight) can run on a
+stronger reasoning model while the cheaper main model handles the
+extraction/summary stages (#171). Set `LOCAL_LLM_SYNTHESIS_MODEL`:
+
+```bash
+LOCAL_LLM_MODEL=qwen2.5:14b \
+LOCAL_LLM_SYNTHESIS_MODEL=qwen2.5:32b \
+  bin/local_llm.sh --briefing
+```
+
+When unset, the synthesis stage uses `LOCAL_LLM_MODEL`, so behavior is unchanged.
+On 24 GB RAM, Ollama swaps models between stages — keep the two models within the
+memory budget (e.g. 14b + 32b run sequentially, not concurrently).
+
 > **Switching embed models requires a rebuild.** `bge-m3` (1024 dim) and the legacy `nomic-embed-text` (768 dim) produce incompatible vectors. If you change `LOCAL_LLM_EMBED_MODEL` (or are upgrading from a pre-#135 index), the CLI refuses with an `EmbedModelMismatch` error — rebuild with `bin/local_llm.sh --index --reset`.
 
 ### Usage
@@ -280,7 +296,7 @@ bin/local_llm.sh --briefing --notion           # ...and post to Notion alongside
 
 Chroma data is stored in `apps/python/.chroma_db/` (gitignored).
 
-Override defaults via env: `LOCAL_LLM_MODEL`, `LOCAL_LLM_EMBED_MODEL`, `LOCAL_LLM_TOP_K`, `LOCAL_LLM_CHROMA_PATH`, `OLLAMA_HOST`.
+Override defaults via env: `LOCAL_LLM_MODEL`, `LOCAL_LLM_SYNTHESIS_MODEL`, `LOCAL_LLM_EMBED_MODEL`, `LOCAL_LLM_TOP_K`, `LOCAL_LLM_CHROMA_PATH`, `OLLAMA_HOST`.
 
 `--briefing` requires `BRAVE_API_KEY` in `.env` (Free-plan key at https://api-dashboard.search.brave.com/ — see `.env.example`). The CLI pre-fetches Brave Search results for all portfolio tickers, macro news, and geopolitical topics, then injects them as context before local generation; without the key the command exits with an error. Tracked under [#142](https://github.com/KazusaNakagawa/ai-agent-cli/issues/142) (initial offline version) and [#144](https://github.com/KazusaNakagawa/ai-agent-cli/issues/144) (Brave Search integration).
 

--- a/apps/python/src/local_llm/cli.py
+++ b/apps/python/src/local_llm/cli.py
@@ -179,7 +179,11 @@ def _cmd_ask(cfg, question: str) -> int:
 
 
 def _cmd_briefing(cfg, *, post_to_notion: bool) -> int:
-    logger.info("=== ローカル LLM ブリーフィング開始 (model=%s) ===", cfg.model)
+    logger.info(
+        "=== ローカル LLM ブリーフィング開始 (model=%s, synthesis_model=%s) ===",
+        cfg.model,
+        cfg.synthesis_model,
+    )
 
     brave_api_key = os.environ.get("BRAVE_API_KEY", "").strip()
     if not brave_api_key:
@@ -194,6 +198,9 @@ def _cmd_briefing(cfg, *, post_to_notion: bool) -> int:
         olm = make_ollama_client(cfg)
         # briefing only generates; pass None so an un-pulled embed_model does not block it.
         ensure_models_available(olm, cfg.model, embed_model=None)
+        # The insight stage routes to a (possibly stronger) reasoning model (#171).
+        if cfg.synthesis_model != cfg.model:
+            ensure_models_available(olm, cfg.synthesis_model, embed_model=None)
     except OllamaUnavailable as e:
         logger.error("Ollama に接続できません: %s", e)
         return 1
@@ -235,13 +242,14 @@ def _cmd_briefing(cfg, *, post_to_notion: bool) -> int:
     # Ollama's default num_ctx (4096) can still overflow on a section prompt, so set it explicitly (#150).
     gen_options = {"num_ctx": cfg.num_ctx, "temperature": cfg.temperature}
 
-    def _gen(label: str, prompt: str) -> str:
-        logger.info("[section] %s 生成開始", label)
+    def _gen(label: str, prompt: str, *, model: str | None = None) -> str:
+        gen_model = model or cfg.model
+        logger.info("[section] %s 生成開始 (model=%s)", label, gen_model)
         for attempt in range(2):
             out = generate_local_briefing(
                 prompt,
                 ollama_client=olm,
-                model=cfg.model,
+                model=gen_model,
                 system_prompt=system_prompt,
                 options=gen_options,
             )
@@ -287,11 +295,14 @@ def _cmd_briefing(cfg, *, post_to_notion: bool) -> int:
     # Stack in the order world (top news) → sector → geopolitics → tickers (table)
     # and pass it to the insight stage (#162).
     prior_text = "\n\n".join([body_top, body_sector, body_geo, body_port]).strip()
+    # Final synthesis stage — route to the (possibly stronger) reasoning model
+    # while the cheaper main model handled the extraction/summary stages (#171).
     body_insight = _gen(
         "自分への示唆",
         build_section_insight_prompt(
             briefing_cfg, prior_text=prior_text, today=today
         ),
+        model=cfg.synthesis_model,
     )
 
     references_md = collect_references(ctx, prior_text)

--- a/apps/python/src/local_llm/config.py
+++ b/apps/python/src/local_llm/config.py
@@ -63,6 +63,18 @@ class LocalLLMConfig:
     chunk_overlap: int
 
 
+def _env_str(name: str, default: str) -> str:
+    """Read a string env var, treating empty/whitespace-only as unset.
+
+    `export LOCAL_LLM_MODEL=` otherwise yields "" rather than the default, which
+    would reach Ollama as an empty model name (Sourcery feedback).
+    """
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    return raw.strip()
+
+
 def _env_number(name: str, default, cast):
     """Convert an env var to a number. On an invalid value, warn and fall back to the default.
 
@@ -90,14 +102,14 @@ def load_config(repo_root: Path | None = None) -> LocalLLMConfig:
     root = (repo_root or Path(os.environ.get("LOCAL_LLM_REPO_ROOT", DEFAULT_REPO_ROOT))).resolve()
     chroma_env = os.environ.get("LOCAL_LLM_CHROMA_PATH")
     chroma_path = Path(chroma_env) if chroma_env else root / DEFAULT_CHROMA_REL
-    model = os.environ.get("LOCAL_LLM_MODEL", DEFAULT_MODEL)
+    model = _env_str("LOCAL_LLM_MODEL", DEFAULT_MODEL)
     return LocalLLMConfig(
-        ollama_host=os.environ.get("OLLAMA_HOST", DEFAULT_OLLAMA_HOST),
+        ollama_host=_env_str("OLLAMA_HOST", DEFAULT_OLLAMA_HOST),
         model=model,
         # Defaults to the main model so the synthesis stage is unchanged until
         # LOCAL_LLM_SYNTHESIS_MODEL is set to a stronger reasoning model (#171).
-        synthesis_model=os.environ.get("LOCAL_LLM_SYNTHESIS_MODEL", model),
-        embed_model=os.environ.get("LOCAL_LLM_EMBED_MODEL", DEFAULT_EMBED_MODEL),
+        synthesis_model=_env_str("LOCAL_LLM_SYNTHESIS_MODEL", model),
+        embed_model=_env_str("LOCAL_LLM_EMBED_MODEL", DEFAULT_EMBED_MODEL),
         num_ctx=_env_number("LOCAL_LLM_NUM_CTX", DEFAULT_NUM_CTX, int),
         temperature=_env_number("LOCAL_LLM_TEMPERATURE", DEFAULT_TEMPERATURE, float),
         top_k=_env_number("LOCAL_LLM_TOP_K", DEFAULT_TOP_K, int),

--- a/apps/python/src/local_llm/config.py
+++ b/apps/python/src/local_llm/config.py
@@ -15,6 +15,10 @@ DEFAULT_OLLAMA_HOST = "http://localhost:11434"
 # to reliably trigger web_search on the `--briefing` path. ~8.5GB RAM at Q4.
 # To go back to a smaller model, override with env LOCAL_LLM_MODEL=qwen2.5:7b.
 DEFAULT_MODEL = "qwen2.5:14b"
+# Only the final synthesis stage (insight) routes to this model, so a stronger
+# reasoning model (e.g. qwen2.5:32b / DeepSeek R1) can be used there while the
+# cheaper DEFAULT_MODEL handles extraction/summary stages (#171). Unset means
+# "same as LOCAL_LLM_MODEL", so behavior is unchanged until it is configured.
 # bge-m3 (1024d) outperforms nomic-embed-text (768d) on Japanese + code retrieval
 # (#135). Switching changes embedding dimensions, so an existing .chroma_db built
 # with the previous default must be rebuilt: bin/local_llm.sh --index --reset.
@@ -48,6 +52,7 @@ MAX_FILE_BYTES = 500 * 1024
 class LocalLLMConfig:
     ollama_host: str
     model: str
+    synthesis_model: str
     embed_model: str
     num_ctx: int
     temperature: float
@@ -85,9 +90,13 @@ def load_config(repo_root: Path | None = None) -> LocalLLMConfig:
     root = (repo_root or Path(os.environ.get("LOCAL_LLM_REPO_ROOT", DEFAULT_REPO_ROOT))).resolve()
     chroma_env = os.environ.get("LOCAL_LLM_CHROMA_PATH")
     chroma_path = Path(chroma_env) if chroma_env else root / DEFAULT_CHROMA_REL
+    model = os.environ.get("LOCAL_LLM_MODEL", DEFAULT_MODEL)
     return LocalLLMConfig(
         ollama_host=os.environ.get("OLLAMA_HOST", DEFAULT_OLLAMA_HOST),
-        model=os.environ.get("LOCAL_LLM_MODEL", DEFAULT_MODEL),
+        model=model,
+        # Defaults to the main model so the synthesis stage is unchanged until
+        # LOCAL_LLM_SYNTHESIS_MODEL is set to a stronger reasoning model (#171).
+        synthesis_model=os.environ.get("LOCAL_LLM_SYNTHESIS_MODEL", model),
         embed_model=os.environ.get("LOCAL_LLM_EMBED_MODEL", DEFAULT_EMBED_MODEL),
         num_ctx=_env_number("LOCAL_LLM_NUM_CTX", DEFAULT_NUM_CTX, int),
         temperature=_env_number("LOCAL_LLM_TEMPERATURE", DEFAULT_TEMPERATURE, float),

--- a/apps/python/tests/local_llm/test_cli.py
+++ b/apps/python/tests/local_llm/test_cli.py
@@ -11,8 +11,8 @@ def _isolate_local_llm_env(monkeypatch):
     運用者が LOCAL_LLM_MODEL=gemma2:9b 等を設定していると --status の出力が変わり
     アサーションが env 依存で揺れる。CLI の既定値経路をテストするため隔離する。
     """
-    for key in ("LOCAL_LLM_MODEL", "LOCAL_LLM_EMBED_MODEL", "LOCAL_LLM_NUM_CTX",
-                "LOCAL_LLM_TEMPERATURE", "LOCAL_LLM_TOP_K"):
+    for key in ("LOCAL_LLM_MODEL", "LOCAL_LLM_SYNTHESIS_MODEL", "LOCAL_LLM_EMBED_MODEL",
+                "LOCAL_LLM_NUM_CTX", "LOCAL_LLM_TEMPERATURE", "LOCAL_LLM_TOP_K"):
         monkeypatch.delenv(key, raising=False)
 
 
@@ -135,3 +135,99 @@ def test_cli_notion_without_briefing_errors(tmp_path, capsys):
         cli.main(["--status", "--notion", "--root", str(tmp_path)])
     err = capsys.readouterr().err
     assert "--notion requires --briefing" in err
+
+
+def _stub_briefing_pipeline(monkeypatch, cli_mod, tmp_path, gen_calls, ensured):
+    """Patch out the heavy --briefing collaborators, recording the model used per
+    section generation so the dual-model routing (#171) can be asserted."""
+    import types
+
+    monkeypatch.setenv("BRAVE_API_KEY", "test-key")
+
+    monkeypatch.setattr(cli_mod, "make_ollama_client", lambda cfg: object())
+    monkeypatch.setattr(
+        cli_mod,
+        "ensure_models_available",
+        lambda client, model, embed_model=None: ensured.append(model),
+    )
+
+    briefing_cfg = types.SimpleNamespace(
+        portfolio=types.SimpleNamespace(tickers=["AAA"]),
+        notion_api_key=None,
+        notion_database_id=None,
+    )
+    monkeypatch.setattr(cli_mod, "load_briefing_config", lambda: briefing_cfg)
+    monkeypatch.setattr(cli_mod, "fetch_stock_move_map", lambda tickers: {})
+    monkeypatch.setattr(cli_mod, "BraveSearchClient", lambda key: object())
+    monkeypatch.setattr(cli_mod, "prefetch_briefing_context", lambda *a, **k: object())
+    monkeypatch.setattr(cli_mod, "enrich_with_article_text", lambda ctx: ctx)
+    monkeypatch.setattr(cli_mod, "count_article_fetches", lambda ctx: (0, 0))
+    monkeypatch.setattr(cli_mod, "load_local_briefing_system_prompt", lambda: "sys")
+    for name in (
+        "build_section_topnews_prompt",
+        "build_section_sector_prompt",
+        "build_section_geo_events_prompt",
+        "build_section_insight_prompt",
+    ):
+        monkeypatch.setattr(cli_mod, name, lambda *a, **k: "prompt")
+    monkeypatch.setattr(cli_mod, "generate_portfolio_table", lambda *a, **k: "PORT")
+    monkeypatch.setattr(cli_mod, "ensure_geo_topics_covered", lambda body, ctx: body)
+    monkeypatch.setattr(cli_mod, "collect_references", lambda ctx, prior: "REF")
+    monkeypatch.setattr(cli_mod, "render_prefetch_debug_block", lambda ctx: "DBG")
+    monkeypatch.setattr(cli_mod, "summarize_prefetch_hits", lambda ctx: "SUM")
+    monkeypatch.setattr(
+        cli_mod,
+        "validate_urls",
+        lambda body, ctx: types.SimpleNamespace(
+            body=body, fabricated=0, total=0, verified=0
+        ),
+    )
+    monkeypatch.setattr(cli_mod, "compose_briefing_md", lambda *a, **k: "MD")
+    monkeypatch.setattr(cli_mod, "BRIEFING_OUTPUT_DIR", tmp_path / "out")
+
+    def _fake_generate(prompt, *, ollama_client, model, system_prompt, options):
+        gen_calls.append(model)
+        return "section"
+
+    monkeypatch.setattr(cli_mod, "generate_local_briefing", _fake_generate)
+
+
+def test_briefing_routes_only_insight_to_synthesis_model(monkeypatch, tmp_path):
+    # Extraction/summary stages use the main model; only the final synthesis
+    # (insight) stage routes to the separate reasoning model (#171).
+    monkeypatch.setenv("LOCAL_LLM_MODEL", "qwen2.5:14b")
+    monkeypatch.setenv("LOCAL_LLM_SYNTHESIS_MODEL", "qwen2.5:32b")
+
+    gen_calls: list[str] = []
+    ensured: list[str] = []
+    _stub_briefing_pipeline(monkeypatch, cli, tmp_path, gen_calls, ensured)
+
+    rc = cli.main(["--briefing", "--root", str(tmp_path)])
+
+    assert rc == 0
+    # top / sector / geo / insight — only the last (insight) uses the synthesis model.
+    assert gen_calls == [
+        "qwen2.5:14b",
+        "qwen2.5:14b",
+        "qwen2.5:14b",
+        "qwen2.5:32b",
+    ]
+    # Both models are verified as pulled before generation.
+    assert "qwen2.5:14b" in ensured
+    assert "qwen2.5:32b" in ensured
+
+
+def test_briefing_synthesis_model_defaults_to_main_model(monkeypatch, tmp_path):
+    # With no separate synthesis model configured, every stage uses the main
+    # model and the extra availability check is skipped.
+    monkeypatch.setenv("LOCAL_LLM_MODEL", "qwen2.5:14b")
+
+    gen_calls: list[str] = []
+    ensured: list[str] = []
+    _stub_briefing_pipeline(monkeypatch, cli, tmp_path, gen_calls, ensured)
+
+    rc = cli.main(["--briefing", "--root", str(tmp_path)])
+
+    assert rc == 0
+    assert gen_calls == ["qwen2.5:14b"] * 4
+    assert ensured == ["qwen2.5:14b"]

--- a/apps/python/tests/local_llm/test_clients.py
+++ b/apps/python/tests/local_llm/test_clients.py
@@ -79,6 +79,7 @@ def _make_cfg(chroma_path, embed_model):
     return LocalLLMConfig(
         ollama_host="http://localhost:11434",
         model="qwen2.5:14b",
+        synthesis_model="qwen2.5:14b",
         embed_model=embed_model,
         num_ctx=16384,
         temperature=0.2,

--- a/apps/python/tests/local_llm/test_config.py
+++ b/apps/python/tests/local_llm/test_config.py
@@ -8,6 +8,7 @@ def test_load_config_defaults(monkeypatch, tmp_path):
     for key in [
         "OLLAMA_HOST",
         "LOCAL_LLM_MODEL",
+        "LOCAL_LLM_SYNTHESIS_MODEL",
         "LOCAL_LLM_EMBED_MODEL",
         "LOCAL_LLM_NUM_CTX",
         "LOCAL_LLM_TEMPERATURE",
@@ -21,6 +22,8 @@ def test_load_config_defaults(monkeypatch, tmp_path):
     assert isinstance(cfg, LocalLLMConfig)
     assert cfg.ollama_host == "http://localhost:11434"
     assert cfg.model == "qwen2.5:14b"
+    # Unset synthesis model defaults to the main model (behavior unchanged).
+    assert cfg.synthesis_model == "qwen2.5:14b"
     assert cfg.embed_model == "bge-m3"
     assert cfg.num_ctx == 16384
     assert cfg.temperature == 0.2
@@ -49,6 +52,27 @@ def test_load_config_env_overrides(monkeypatch, tmp_path):
     assert cfg.temperature == 0.7
     assert cfg.top_k == 10
     assert cfg.chroma_path == tmp_path / "custom_chroma"
+
+
+def test_load_config_synthesis_model_override(monkeypatch, tmp_path):
+    # Only the synthesis stage can be pointed at a separate reasoning model (#171).
+    monkeypatch.setenv("LOCAL_LLM_MODEL", "qwen2.5:14b")
+    monkeypatch.setenv("LOCAL_LLM_SYNTHESIS_MODEL", "qwen2.5:32b")
+
+    cfg = load_config(repo_root=tmp_path)
+
+    assert cfg.model == "qwen2.5:14b"
+    assert cfg.synthesis_model == "qwen2.5:32b"
+
+
+def test_load_config_synthesis_model_follows_main_model(monkeypatch, tmp_path):
+    # When only the main model is overridden, the synthesis model tracks it.
+    monkeypatch.delenv("LOCAL_LLM_SYNTHESIS_MODEL", raising=False)
+    monkeypatch.setenv("LOCAL_LLM_MODEL", "gemma2:9b")
+
+    cfg = load_config(repo_root=tmp_path)
+
+    assert cfg.synthesis_model == "gemma2:9b"
 
 
 def test_load_config_falls_back_on_malformed_numeric_env(monkeypatch, tmp_path, caplog):

--- a/apps/python/tests/local_llm/test_config.py
+++ b/apps/python/tests/local_llm/test_config.py
@@ -75,6 +75,17 @@ def test_load_config_synthesis_model_follows_main_model(monkeypatch, tmp_path):
     assert cfg.synthesis_model == "gemma2:9b"
 
 
+def test_load_config_treats_empty_model_env_as_unset(monkeypatch, tmp_path):
+    # `export LOCAL_LLM_MODEL=` must not reach Ollama as an empty model name.
+    monkeypatch.setenv("LOCAL_LLM_MODEL", "")
+    monkeypatch.setenv("LOCAL_LLM_SYNTHESIS_MODEL", "   ")
+
+    cfg = load_config(repo_root=tmp_path)
+
+    assert cfg.model == "qwen2.5:14b"
+    assert cfg.synthesis_model == "qwen2.5:14b"
+
+
 def test_load_config_falls_back_on_malformed_numeric_env(monkeypatch, tmp_path, caplog):
     monkeypatch.setenv("LOCAL_LLM_NUM_CTX", "abc")
     monkeypatch.setenv("LOCAL_LLM_TEMPERATURE", "warm")


### PR DESCRIPTION
## Summary
- Add `LOCAL_LLM_SYNTHESIS_MODEL` so the final insight (synthesis) stage of `--briefing` runs on a stronger reasoning model (e.g. qwen2.5:32b), while the cheaper main model handles the extraction/summary stages.
- Unset tracks `LOCAL_LLM_MODEL`, so behavior is unchanged until configured. Both models are verified as pulled before generation.
- Document the dual-model setup and 24GB RAM constraint in the README.

## Test plan
- [x] `pytest tests/local_llm/` — 143 passed
- [x] Config: synthesis model override + fallback-to-main covered
- [x] CLI: insight stage routes to synthesis model; other stages unchanged (dual-model + default cases)

Part of epic #172. Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add support for a separate synthesis model for local LLM briefings and route only the final insight stage to it while keeping existing behavior by default.

New Features:
- Introduce a LOCAL_LLM_SYNTHESIS_MODEL configuration that allows the briefing synthesis stage to run on a different reasoning model than the main model.

Enhancements:
- Ensure empty or whitespace-only model-related environment variables fall back to sensible defaults instead of passing empty names to Ollama.
- Log the synthesis model alongside the main model when running the local LLM briefing CLI command.

Documentation:
- Document the dual-model briefing setup, usage of LOCAL_LLM_SYNTHESIS_MODEL, and memory considerations in the README.

Tests:
- Add configuration tests covering synthesis model overrides, defaulting behavior, and handling of empty model env vars.
- Add CLI tests to verify that only the insight stage uses the synthesis model and that model availability checks run for both models when configured.