### PR TITLE
feat(eval): render scorecard as modern colored HTML report

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ See [docs/launchd-setup.md](docs/launchd-setup.md) for the full setup guide (pli
 
 A separate pipeline scores past briefings to measure how well their views held up. It extracts
 macro, theme-level views from each briefing, judges them against *later* briefings as ground truth,
-and aggregates hit rates into a Mermaid scorecard. LLM calls go through the same `claude` CLI path
-(subscription auth) — no extra API key required.
+and aggregates hit rates into a self-contained HTML scorecard (modern dark theme, colored hit-rate
+bars). LLM calls go through the same `claude` CLI path (subscription auth) — no extra API key required.
 
 ```bash
 # 1. Extract structured themes from briefings (all dates; already-extracted ones are skipped)
@@ -146,7 +146,7 @@ Outputs (all under git-ignored `output/`):
 
 - `output/eval/claims/<date>.json` — extracted themes (`direction`, `targets`, `horizon_days`, `type`)
 - `output/eval/scores/<date>.json` — verdicts (`hit` / `miss` / `partial` / `unresolved`)
-- `output/eval/report.md` — Mermaid `pie` + `xychart-beta` scorecard (hit rate by type / sector / time)
+- `output/eval/report.html` — HTML scorecard (hit rate by type / sector / time); open it in a browser. Per-target view shows the top 10 by count.
 
 A theme stays `unresolved` until at least one briefing exists inside its window `(date, date + horizon_days]`;
 re-running `score` only re-evaluates `unresolved` entries and never overwrites finalized verdicts.

--- a/apps/python/src/evaluator/report.py
+++ b/apps/python/src/evaluator/report.py
@@ -38,31 +38,78 @@ def aggregate(scores: list[dict], claims_by_id: dict[str, dict]) -> dict:
     }
 
 
-def pie_block(title: str, rates: dict[str, dict]) -> str:
-    lines = ["```mermaid", f"pie title {title} (hit率)"]
-    for k, v in rates.items():
-        lines.append(f'    "{k}" : {v["hit_rate"]}')
-    lines.append("```")
-    return "\n".join(lines)
+_TARGET_TOP_N = 10
+
+_CSS = """
+:root { color-scheme: dark; }
+* { box-sizing: border-box; }
+body {
+  margin: 0; padding: 2.5rem 1.5rem;
+  font-family: -apple-system, "Hiragino Sans", "Segoe UI", system-ui, sans-serif;
+  background: #0f1115; color: #e6e8ec; line-height: 1.5;
+}
+.wrap { max-width: 880px; margin: 0 auto; }
+h1 { font-size: 1.7rem; font-weight: 700; letter-spacing: .02em; margin: 0 0 .25rem; }
+.sub { color: #8b93a1; font-size: .85rem; margin-bottom: 2rem; }
+.card {
+  background: #171a21; border: 1px solid #232732; border-radius: 14px;
+  padding: 1.25rem 1.5rem; margin-bottom: 1.25rem;
+  box-shadow: 0 1px 3px rgba(0,0,0,.4);
+}
+.card h2 { font-size: 1.05rem; margin: 0 0 1rem; display: flex; gap: .5rem; align-items: baseline; }
+.card h2 .note { font-size: .75rem; color: #8b93a1; font-weight: 400; }
+table { width: 100%; border-collapse: collapse; }
+td { padding: .45rem .5rem; border-top: 1px solid #232732; vertical-align: middle; }
+tr:first-child td { border-top: none; }
+.label { font-weight: 600; white-space: nowrap; }
+.num { color: #aeb6c2; font-variant-numeric: tabular-nums; text-align: right; white-space: nowrap; }
+.bar { background: #232732; border-radius: 6px; height: 14px; width: 100%; overflow: hidden; }
+.bar .fill { height: 100%; border-radius: 6px; transition: width .3s; }
+"""
 
 
-def xychart_block(by_date: list[dict]) -> str:
-    xs = ", ".join(f'"{d["date"]}"' for d in by_date)
-    ys = ", ".join(str(d["hit_rate"]) for d in by_date)
-    return "\n".join([
-        "```mermaid",
-        "xychart-beta",
-        '    title "hit率の推移"',
-        f"    x-axis [{xs}]",
-        '    y-axis "hit率" 0 --> 1',
-        f"    line [{ys}]",
-        "```",
-    ])
+def _color(rate: float) -> str:
+    # hit率 0=赤 → 1=緑 へ連続変化（hue 0→120）。
+    hue = int(round(rate * 120))
+    return f"hsl({hue}, 65%, 48%)"
 
 
-def _table(title: str, rates: dict[str, dict]) -> str:
-    rows = [f"| {k} | {v['count']} | {v['hit_rate']} |" for k, v in rates.items()]
-    return "\n".join([f"#### {title}", "| 区分 | 件数 | hit率 |", "|---|---|---|", *rows])
+def _bar_html(rate: float) -> str:
+    pct = round(rate * 100)
+    return (f'<div class="bar"><div class="fill" '
+            f'style="width:{pct}%;background:{_color(rate)}"></div></div>')
+
+
+def _esc(text: str) -> str:
+    return (str(text).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;"))
+
+
+def _section_rows(rates: dict[str, dict], top_n: int | None = None) -> str:
+    items = sorted(rates.items(), key=lambda kv: (-kv[1]["count"], -kv[1]["hit_rate"]))
+    if top_n is not None:
+        items = items[:top_n]
+    return "\n".join(
+        f'<tr><td class="label">{_esc(k)}</td>'
+        f'<td class="num">{v["count"]}</td>'
+        f'<td class="num">{v["hit_rate"]:.2f}</td>'
+        f'<td>{_bar_html(v["hit_rate"])}</td></tr>'
+        for k, v in items
+    )
+
+
+def _trend_rows(by_date: list[dict]) -> str:
+    return "\n".join(
+        f'<tr><td class="label">{_esc(d["date"])}</td>'
+        f'<td class="num">{d["hit_rate"]:.2f}</td>'
+        f'<td>{_bar_html(d["hit_rate"])}</td></tr>'
+        for d in by_date
+    )
+
+
+def _card(title: str, body: str, note: str = "") -> str:
+    note_html = f'<span class="note">{_esc(note)}</span>' if note else ""
+    return (f'<section class="card"><h2>{_esc(title)}{note_html}</h2>'
+            f'<table>{body}</table></section>')
 
 
 def build_report() -> str:
@@ -74,14 +121,26 @@ def build_report() -> str:
     for f in sorted(storage.SCORES_DIR.glob("*.json")):
         scores.extend(storage.load_json(f))
     agg = aggregate(scores, claims_by_id)
-    parts = [
-        "# ブリーフィング評価スコアカード",
-        "## type別", pie_block("type別", agg["by_type"]), _table("type別", agg["by_type"]),
-        "## セクター/銘柄別", pie_block("target別", agg["by_target"]),
-        _table("target別", agg["by_target"]),
-        "## 時系列", xychart_block(agg["by_date"]),
-    ]
-    report_md = "\n\n".join(parts) + "\n"
+
+    target_count = len(agg["by_target"])
+    target_note = (f"上位 {_TARGET_TOP_N} 件 / 全 {target_count} 件"
+                   if target_count > _TARGET_TOP_N else "")
+    cards = "\n".join([
+        _card("type別 hit率", _section_rows(agg["by_type"])),
+        _card("セクター/銘柄別 hit率",
+              _section_rows(agg["by_target"], top_n=_TARGET_TOP_N), target_note),
+        _card("hit率の推移", _trend_rows(agg["by_date"])),
+    ])
+    html = (
+        "<!doctype html>\n"
+        '<html lang="ja"><head><meta charset="utf-8">'
+        '<meta name="viewport" content="width=device-width, initial-scale=1">'
+        "<title>ブリーフィング評価スコアカード</title>"
+        f"<style>{_CSS}</style></head><body><div class=\"wrap\">"
+        "<h1>ブリーフィング評価スコアカード</h1>"
+        '<div class="sub">後日のブリーフィングを真値とした的中率（hit=1.0 / partial=0.5 / miss=0）</div>'
+        f"{cards}</div></body></html>\n"
+    )
     storage.REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
-    storage.REPORT_PATH.write_text(report_md, encoding="utf-8")
-    return report_md
+    storage.REPORT_PATH.write_text(html, encoding="utf-8")
+    return html

--- a/apps/python/src/evaluator/report.py
+++ b/apps/python/src/evaluator/report.py
@@ -56,8 +56,20 @@ h1 { font-size: 1.7rem; font-weight: 700; letter-spacing: .02em; margin: 0 0 .25
   padding: 1.25rem 1.5rem; margin-bottom: 1.25rem;
   box-shadow: 0 1px 3px rgba(0,0,0,.4);
 }
-.card h2 { font-size: 1.05rem; margin: 0 0 1rem; display: flex; gap: .5rem; align-items: baseline; }
+.card h2 { font-size: 1.05rem; margin: 0 0 .35rem; display: flex; gap: .5rem; align-items: baseline; }
 .card h2 .note { font-size: .75rem; color: #8b93a1; font-weight: 400; }
+.card .desc { font-size: .8rem; color: #8b93a1; margin: 0 0 1rem; }
+.legend {
+  background: #141821; border: 1px solid #232732; border-radius: 12px;
+  padding: 1rem 1.25rem; margin-bottom: 1.5rem; font-size: .82rem; color: #b8c0cc;
+}
+.legend b { color: #e6e8ec; }
+.legend ul { margin: .5rem 0 0; padding-left: 1.1rem; }
+.legend li { margin: .15rem 0; }
+.legend .chip {
+  display: inline-block; padding: .05rem .4rem; border-radius: 5px;
+  font-size: .75rem; font-weight: 600; color: #0f1115;
+}
 table { width: 100%; border-collapse: collapse; }
 td { padding: .45rem .5rem; border-top: 1px solid #232732; vertical-align: middle; }
 tr:first-child td { border-top: none; }
@@ -71,7 +83,7 @@ tr:first-child td { border-top: none; }
 def _color(rate: float) -> str:
     # hit率 0=赤 → 1=緑 へ連続変化（hue 0→120）。
     hue = int(round(rate * 120))
-    return f"hsl({hue}, 65%, 48%)"
+    return f"hsla({hue}, 65%, 48%, .6)"
 
 
 def _bar_html(rate: float) -> str:
@@ -106,10 +118,28 @@ def _trend_rows(by_date: list[dict]) -> str:
     )
 
 
-def _card(title: str, body: str, note: str = "") -> str:
+def _card(title: str, body: str, desc: str = "", note: str = "") -> str:
     note_html = f'<span class="note">{_esc(note)}</span>' if note else ""
-    return (f'<section class="card"><h2>{_esc(title)}{note_html}</h2>'
+    desc_html = f'<p class="desc">{_esc(desc)}</p>' if desc else ""
+    return (f'<section class="card"><h2>{_esc(title)}{note_html}</h2>{desc_html}'
             f'<table>{body}</table></section>')
+
+
+_LEGEND = (
+    '<div class="legend">'
+    '<b>このレポートの読み方</b>'
+    '<ul>'
+    '<li><b>hit率</b> … 過去のブリーフィングの「見立て」が、後日のブリーフィング（真値）に'
+    '照らしてどれだけ当たったかの平均スコア。'
+    '<span class="chip" style="background:hsla(0,65%,48%,.6);color:#fff">miss=0</span> / '
+    '<span class="chip" style="background:hsla(60,65%,48%,.6)">partial=0.5</span> / '
+    '<span class="chip" style="background:hsla(120,65%,48%,.6);color:#fff">hit=1.0</span> '
+    'の平均で、<b>1.0 に近いほどよく当たっている</b>。バーの色も赤→緑で同じ意味。</li>'
+    '<li><b>type</b> … 見立ての種類。<b>prediction</b>＝将来こうなるという予測、'
+    '<b>causal</b>＝「ある出来事が相場のこう動かした」という因果説明。</li>'
+    '<li><b>件数</b> … 集計に使ったテーマ数。少ないほどブレやすい（1件なら 0 か 1 に振れる）。</li>'
+    '</ul></div>'
+)
 
 
 def build_report() -> str:
@@ -126,10 +156,14 @@ def build_report() -> str:
     target_note = (f"上位 {_TARGET_TOP_N} 件 / 全 {target_count} 件"
                    if target_count > _TARGET_TOP_N else "")
     cards = "\n".join([
-        _card("type別 hit率", _section_rows(agg["by_type"])),
+        _card("type別 hit率", _section_rows(agg["by_type"]),
+              desc="予測（prediction）と因果説明（causal）、どちらの見立てが当たりやすいか。"),
         _card("セクター/銘柄別 hit率",
-              _section_rows(agg["by_target"], top_n=_TARGET_TOP_N), target_note),
-        _card("hit率の推移", _trend_rows(agg["by_date"])),
+              _section_rows(agg["by_target"], top_n=_TARGET_TOP_N),
+              desc="どの銘柄・セクターの見立てが当たりやすい／読みにくいか。",
+              note=target_note),
+        _card("hit率の推移", _trend_rows(agg["by_date"]),
+              desc="日ごとの平均 hit率。ブリーフィング全体の精度が時間とともにどう動くか。"),
     ])
     html = (
         "<!doctype html>\n"
@@ -138,8 +172,8 @@ def build_report() -> str:
         "<title>ブリーフィング評価スコアカード</title>"
         f"<style>{_CSS}</style></head><body><div class=\"wrap\">"
         "<h1>ブリーフィング評価スコアカード</h1>"
-        '<div class="sub">後日のブリーフィングを真値とした的中率（hit=1.0 / partial=0.5 / miss=0）</div>'
-        f"{cards}</div></body></html>\n"
+        '<div class="sub">後日のブリーフィングを真値とした、過去の見立ての的中率スコア</div>'
+        f"{_LEGEND}{cards}</div></body></html>\n"
     )
     storage.REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
     storage.REPORT_PATH.write_text(html, encoding="utf-8")

--- a/apps/python/src/evaluator/storage.py
+++ b/apps/python/src/evaluator/storage.py
@@ -11,7 +11,7 @@ from src.constants import BRIEFING_OUTPUT_DIR, OUTPUT_DIR
 EVAL_DIR = OUTPUT_DIR / "eval"
 CLAIMS_DIR = EVAL_DIR / "claims"
 SCORES_DIR = EVAL_DIR / "scores"
-REPORT_PATH = EVAL_DIR / "report.md"
+REPORT_PATH = EVAL_DIR / "report.html"
 
 _BRIEFING_RE = re.compile(r"^briefing_(\d{4}-\d{2}-\d{2})\.md$")
 

--- a/apps/python/tests/evaluator/test_report.py
+++ b/apps/python/tests/evaluator/test_report.py
@@ -1,9 +1,15 @@
-from src.evaluator import report
+import re
+
+from src.evaluator import report, storage
 
 
 def _claim(cid, ctype, targets):
     return {"id": cid, "type": ctype, "targets": targets,
             "theme": "t", "direction": "弱気", "horizon_days": 5}
+
+
+def _hue(color: str) -> int:
+    return int(re.search(r"hsl\((\d+)", color).group(1))
 
 
 def test_aggregate_hit_rate_with_partial_weight():
@@ -18,21 +24,42 @@ def test_aggregate_hit_rate_with_partial_weight():
         {"id": "d1-03", "verdict": "unresolved"},  # excluded
     ]
     agg = report.aggregate(scores, claims)
-    # prediction: (1.0 + 0.5) / 2 = 0.75 ; causal excluded (unresolved)
     assert agg["by_type"]["prediction"] == {"count": 2, "hit_rate": 0.75}
     assert "causal" not in agg["by_type"]
     assert agg["by_target"]["PLTR"] == {"count": 2, "hit_rate": 0.75}
 
 
-def test_pie_block_is_mermaid():
-    block = report.pie_block("type別", {"prediction": {"count": 2, "hit_rate": 0.75}})
-    assert "```mermaid" in block and "pie" in block
+def test_color_higher_rate_is_greener():
+    # hue 0 = red, 120 = green; higher hit_rate -> higher hue
+    assert _hue(report._color(1.0)) > _hue(report._color(0.0))
 
 
-def test_xychart_block_quotes_dates_and_comma_separates_values():
-    block = report.xychart_block([
-        {"date": "2026-06-17", "hit_rate": 0.5},
-        {"date": "2026-06-19", "hit_rate": 1.0},
-    ])
-    assert 'x-axis ["2026-06-17", "2026-06-19"]' in block
-    assert "line [0.5, 1.0]" in block
+def test_bar_html_width_matches_rate():
+    html = report._bar_html(0.5)
+    assert "width:50%" in html
+
+
+def test_section_rows_sorts_by_count_then_rate_and_limits():
+    rates = {
+        "A": {"count": 1, "hit_rate": 1.0},
+        "B": {"count": 3, "hit_rate": 0.2},
+        "C": {"count": 3, "hit_rate": 0.9},
+    }
+    rows = report._section_rows(rates, top_n=2)
+    # only top 2 by count; C before B (higher rate); A excluded
+    assert rows.index("C") < rows.index("B")
+    assert "A" not in rows
+
+
+def test_build_report_writes_html(tmp_path, monkeypatch):
+    monkeypatch.setattr(storage, "CLAIMS_DIR", tmp_path / "claims")
+    monkeypatch.setattr(storage, "SCORES_DIR", tmp_path / "scores")
+    monkeypatch.setattr(storage, "REPORT_PATH", tmp_path / "report.html")
+    storage.save_json(storage.CLAIMS_DIR / "2026-06-15.json",
+                      [_claim("2026-06-15-01", "prediction", ["PLTR"])])
+    storage.save_json(storage.SCORES_DIR / "2026-06-15.json",
+                      [{"id": "2026-06-15-01", "verdict": "hit"}])
+    html = report.build_report()
+    assert "<!doctype html>" in html.lower()
+    assert "PLTR" in html
+    assert (tmp_path / "report.html").exists()

--- a/apps/python/tests/evaluator/test_report.py
+++ b/apps/python/tests/evaluator/test_report.py
@@ -9,7 +9,7 @@ def _claim(cid, ctype, targets):
 
 
 def _hue(color: str) -> int:
-    return int(re.search(r"hsl\((\d+)", color).group(1))
+    return int(re.search(r"hsla?\((\d+)", color).group(1))
 
 
 def test_aggregate_hit_rate_with_partial_weight():


### PR DESCRIPTION
## Summary
- Replace the non-rendering Mermaid blocks with a self-contained HTML scorecard (`output/eval/report.html`): dark modern theme, translucent red→green hit-rate bars, a "how to read" legend, and per-card descriptions.
- Per-target view limited to top 10 by count (full set noted); single-date reports render fine.

## Test plan
- [x] `pytest tests/evaluator/` — 22 passed
- [x] Regenerated `report.html` from live 2026-06-15 data and verified in browser

Closes #213

## Summary by Sourcery

Render the evaluator scorecard as a standalone HTML report instead of a Mermaid-based Markdown file.

New Features:
- Generate a self-contained, dark-themed HTML scorecard with colored hit-rate bars and explanatory legend for evaluation results.
- Limit per-target hit-rate reporting to the top 10 entries, while still aggregating over all targets.

Enhancements:
- Introduce HTML helper utilities for coloring, bar rendering, escaping, and table/card layout to structure the report content.
- Sort section rows by count then hit rate to surface the most statistically meaningful targets first.

Documentation:
- Update README to describe the new HTML scorecard output file and its location.

Tests:
- Replace report Markdown/mermaid tests with HTML-focused tests covering color mapping, bar rendering, section sorting/limiting, and end-to-end report generation.