### PR TITLE
perf(eval): batch eval-judge calls per followup group to cut cache_creation cost

### DIFF
--- a/apps/python/prompts/eval_judge.md
+++ b/apps/python/prompts/eval_judge.md
@@ -1,13 +1,15 @@
 あなたは投資ブリーフィングの見立てを後追い検証する審査員です。
 
-元の見立て（テーマ）:
-$theme
-
 検証期間中の後日ブリーフィング（真値）:
 $followups
 
-このテーマの方向性が、後日ブリーフィングの記述に照らして妥当だったかを判定してください。
+以下のテーマ一覧（JSON 配列）を全件判定してください:
+$themes
+
+各テーマについて:
 - verdict: "hit"（方向性が当たった）| "miss"（外れた）| "partial"（部分的）| "unresolved"（判断材料不足）
 - confidence: 0.0〜1.0
 - rationale: 1〜2文の根拠（後日ブリーフィングの記述を引用）
-出力は {"verdict":"hit|miss|partial|unresolved","confidence":0.0,"rationale":"..."} の JSON オブジェクトのみ。
+
+出力は JSON 配列のみ（前後のテキスト不要）:
+[{"id":"...","verdict":"hit|miss|partial|unresolved","confidence":0.0,"rationale":"..."},...]

--- a/apps/python/src/evaluator/score.py
+++ b/apps/python/src/evaluator/score.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import re
 from datetime import date, timedelta
+from itertools import groupby
 
 from src.claude_runner import run_claude
 from src.evaluator import storage
@@ -40,8 +41,33 @@ def parse_verdict(raw: str) -> dict:
     }
 
 
+def parse_verdicts_batch(raw: str) -> list[dict] | None:
+    """バッチ応答 (JSON 配列) をパースする。失敗時は None を返す。"""
+    text = raw.strip()
+    m = _FENCE_RE.search(text)
+    if m:
+        text = m.group(1).strip()
+    try:
+        data = json.loads(text)
+        if not isinstance(data, list):
+            return None
+    except (json.JSONDecodeError, TypeError):
+        return None
+    results = []
+    for item in data:
+        verdict = item.get("verdict", "unresolved")
+        if verdict not in _VALID_VERDICT:
+            verdict = "unresolved"
+        results.append({
+            "id": str(item.get("id", "")),
+            "verdict": verdict,
+            "confidence": _to_float(item.get("confidence"), 0.0),
+            "rationale": str(item.get("rationale", "")),
+        })
+    return results
+
+
 def _to_float(value, default: float) -> float:
-    # confidence が "high" や null でも採点が落ちないよう既定値に倒す。
     try:
         return float(value)
     except (TypeError, ValueError):
@@ -49,17 +75,84 @@ def _to_float(value, default: float) -> float:
 
 
 def score_claim(claim: dict, all_dates: list[str]) -> dict:
-    followups = followup_dates(claim["id"][:10], claim["horizon_days"], all_dates)
-    if not followups:
-        return {"id": claim["id"], "verdict": "unresolved", "confidence": 0.0,
-                "rationale": "no follow-up briefing in window"}
-    bodies = "\n\n---\n\n".join(
-        storage.briefing_path(d).read_text(encoding="utf-8") for d in followups
+    """1 件の claim を採点する。内部では score_claims_batch を経由する。"""
+    results = score_claims_batch([claim], all_dates)
+    return results[0]
+
+
+def score_claims_batch(claims: list[dict], all_dates: list[str]) -> list[dict]:
+    """同一 followup グループの claims を 1 回の LLM 呼び出しで採点する。
+
+    フォールバック: バッチ応答のパースに失敗した場合は per-claim で再実行する。
+    """
+    # followup_dates の解決 (グループ内で同一前提で呼ばれるが、念のり個別に解決)
+    followup_map: dict[str, list[str]] = {
+        c["id"]: followup_dates(c["id"][:10], c["horizon_days"], all_dates)
+        for c in claims
+    }
+
+    # followup が 1 件もない claim はここで即解決
+    resolved: list[dict] = []
+    pending: list[dict] = []
+    for c in claims:
+        if not followup_map[c["id"]]:
+            resolved.append({"id": c["id"], "verdict": "unresolved", "confidence": 0.0,
+                              "rationale": "no follow-up briefing in window"})
+        else:
+            pending.append(c)
+
+    if not pending:
+        return resolved
+
+    # followup 本文を union して構築（グループ内で重複しないよう set で結合）
+    all_followup_dates: list[str] = sorted(
+        {d for c in pending for d in followup_map[c["id"]]}
     )
-    theme = json.dumps(claim, ensure_ascii=False)
-    prompt = render("eval_judge", theme=theme, followups=bodies)
-    raw = run_claude(prompt, label=f"eval-judge {claim['id']}")
-    return {"id": claim["id"], **parse_verdict(raw)}
+    bodies = "\n\n---\n\n".join(
+        storage.briefing_path(d).read_text(encoding="utf-8") for d in all_followup_dates
+    )
+    themes_json = json.dumps(
+        [{"id": c["id"], "theme": c.get("theme", ""), "direction": c.get("direction", ""),
+          "targets": c.get("targets", []), "horizon_days": c.get("horizon_days", 0),
+          "type": c.get("type", "")}
+         for c in pending],
+        ensure_ascii=False,
+    )
+
+    base_date = pending[0]["id"][:10]
+    label = f"eval-judge {base_date} ({len(pending)} claims)"
+    prompt = render("eval_judge", themes=themes_json, followups=bodies)
+    raw = run_claude(prompt, label=label)
+
+    batch_results = parse_verdicts_batch(raw)
+    if batch_results is not None and len(batch_results) == len(pending):
+        return resolved + batch_results
+
+    # フォールバック: バッチ応答が壊れていた場合は 1 件ずつ再実行
+    logger.warning(
+        "eval-judge バッチ応答のパースに失敗 (%s)、per-claim フォールバック実行", base_date,
+    )
+    fallback = []
+    for c in pending:
+        fup_dates = followup_map[c["id"]]
+        fup_bodies = "\n\n---\n\n".join(
+            storage.briefing_path(d).read_text(encoding="utf-8") for d in fup_dates
+        )
+        single_themes = json.dumps(
+            [{"id": c["id"], "theme": c.get("theme", ""), "direction": c.get("direction", ""),
+              "targets": c.get("targets", []), "horizon_days": c.get("horizon_days", 0),
+              "type": c.get("type", "")}],
+            ensure_ascii=False,
+        )
+        single_prompt = render("eval_judge", themes=single_themes, followups=fup_bodies)
+        single_raw = run_claude(single_prompt, label=f"eval-judge {c['id']}")
+        single_results = parse_verdicts_batch(single_raw)
+        if single_results and len(single_results) == 1:
+            fallback.append(single_results[0])
+        else:
+            fallback.append({"id": c["id"], "verdict": "unresolved", "confidence": 0.0,
+                             "rationale": "parse error"})
+    return resolved + fallback
 
 
 def score(target: str = "all") -> None:
@@ -73,11 +166,31 @@ def score(target: str = "all") -> None:
         scores_file = storage.SCORES_DIR / f"{date_str}.json"
         existing = {s["id"]: s for s in storage.load_json(scores_file)} \
             if scores_file.exists() else {}
-        results = []
+
+        # 確定済みと未処理に分ける
+        finalized: list[dict] = []
+        pending: list[dict] = []
         for claim in claims:
             prev = existing.get(claim["id"])
             if prev and prev["verdict"] != "unresolved":
-                results.append(prev)  # idempotent: keep finalized
-                continue
-            results.append(score_claim(claim, all_dates))
+                finalized.append(prev)
+            else:
+                pending.append(claim)
+
+        if not pending:
+            storage.save_json(scores_file, finalized)
+            continue
+
+        # followup_dates キーでグループ化してバッチ処理
+        def _key(c: dict) -> tuple[str, ...]:
+            return tuple(followup_dates(c["id"][:10], c["horizon_days"], all_dates))
+
+        pending.sort(key=_key)
+        batch_results: list[dict] = []
+        for _, group in groupby(pending, key=_key):
+            batch_results.extend(score_claims_batch(list(group), all_dates))
+
+        # 元の claim 順序に合わせて保存
+        id_to_result = {r["id"]: r for r in finalized + batch_results}
+        results = [id_to_result[c["id"]] for c in claims if c["id"] in id_to_result]
         storage.save_json(scores_file, results)

--- a/apps/python/src/evaluator/score.py
+++ b/apps/python/src/evaluator/score.py
@@ -42,7 +42,11 @@ def parse_verdict(raw: str) -> dict:
 
 
 def parse_verdicts_batch(raw: str) -> list[dict] | None:
-    """バッチ応答 (JSON 配列) をパースする。失敗時は None を返す。"""
+    """バッチ応答 (JSON 配列) をパースする。失敗時は None を返す。
+
+    非 dict 要素が 1 件でもあれば None を返してフォールバックを促す。
+    id は呼び出し側でポジションベースに上書きするため、ここでは raw 値をそのまま格納する。
+    """
     text = raw.strip()
     m = _FENCE_RE.search(text)
     if m:
@@ -55,11 +59,13 @@ def parse_verdicts_batch(raw: str) -> list[dict] | None:
         return None
     results = []
     for item in data:
+        if not isinstance(item, dict):
+            return None
         verdict = item.get("verdict", "unresolved")
         if verdict not in _VALID_VERDICT:
             verdict = "unresolved"
         results.append({
-            "id": str(item.get("id", "")),
+            "id": item.get("id"),  # 呼び出し側でポジションベースに確定する
             "verdict": verdict,
             "confidence": _to_float(item.get("confidence"), 0.0),
             "rationale": str(item.get("rationale", "")),
@@ -80,13 +86,19 @@ def score_claim(claim: dict, all_dates: list[str]) -> dict:
     return results[0]
 
 
-def score_claims_batch(claims: list[dict], all_dates: list[str]) -> list[dict]:
+def score_claims_batch(
+    claims: list[dict],
+    all_dates: list[str],
+    precomputed: dict[str, list[str]] | None = None,
+) -> list[dict]:
     """同一 followup グループの claims を 1 回の LLM 呼び出しで採点する。
 
+    precomputed: {claim_id: followup_dates} の事前計算済みマップ。
+    渡された場合は followup_dates() の再計算を省略する。
     フォールバック: バッチ応答のパースに失敗した場合は per-claim で再実行する。
     """
-    # followup_dates の解決 (グループ内で同一前提で呼ばれるが、念のり個別に解決)
-    followup_map: dict[str, list[str]] = {
+    # followup_dates の解決
+    followup_map: dict[str, list[str]] = precomputed if precomputed is not None else {
         c["id"]: followup_dates(c["id"][:10], c["horizon_days"], all_dates)
         for c in claims
     }
@@ -126,6 +138,9 @@ def score_claims_batch(claims: list[dict], all_dates: list[str]) -> list[dict]:
 
     batch_results = parse_verdicts_batch(raw)
     if batch_results is not None and len(batch_results) == len(pending):
+        # LLM の id は信頼せず、ポジションベースで pending の id を確定する
+        for result, claim in zip(batch_results, pending):
+            result["id"] = claim["id"]
         return resolved + batch_results
 
     # フォールバック: バッチ応答が壊れていた場合は 1 件ずつ再実行
@@ -148,6 +163,7 @@ def score_claims_batch(claims: list[dict], all_dates: list[str]) -> list[dict]:
         single_raw = run_claude(single_prompt, label=f"eval-judge {c['id']}")
         single_results = parse_verdicts_batch(single_raw)
         if single_results and len(single_results) == 1:
+            single_results[0]["id"] = c["id"]  # ポジションベースで id 確定
             fallback.append(single_results[0])
         else:
             fallback.append({"id": c["id"], "verdict": "unresolved", "confidence": 0.0,
@@ -181,14 +197,21 @@ def score(target: str = "all") -> None:
             storage.save_json(scores_file, finalized)
             continue
 
-        # followup_dates キーでグループ化してバッチ処理
+        # followup_dates を一度だけ計算してキャッシュし、グループ化とバッチ処理で再利用
+        followups_cache: dict[str, list[str]] = {
+            c["id"]: followup_dates(c["id"][:10], c["horizon_days"], all_dates)
+            for c in pending
+        }
+
         def _key(c: dict) -> tuple[str, ...]:
-            return tuple(followup_dates(c["id"][:10], c["horizon_days"], all_dates))
+            return tuple(followups_cache[c["id"]])
 
         pending.sort(key=_key)
         batch_results: list[dict] = []
         for _, group in groupby(pending, key=_key):
-            batch_results.extend(score_claims_batch(list(group), all_dates))
+            claims_in_group = list(group)
+            group_cache = {c["id"]: followups_cache[c["id"]] for c in claims_in_group}
+            batch_results.extend(score_claims_batch(claims_in_group, all_dates, group_cache))
 
         # 元の claim 順序に合わせて保存
         id_to_result = {r["id"]: r for r in finalized + batch_results}

--- a/apps/python/tests/evaluator/test_score.py
+++ b/apps/python/tests/evaluator/test_score.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import patch
 
 from src.evaluator import score, storage
@@ -25,6 +26,19 @@ def test_parse_verdict_non_numeric_confidence_defaults():
     assert v["confidence"] == 0.0
 
 
+def test_parse_verdicts_batch_valid():
+    raw = '[{"id":"2026-06-17-01","verdict":"hit","confidence":0.8,"rationale":"ok"}]'
+    results = score.parse_verdicts_batch(raw)
+    assert results is not None
+    assert results[0]["verdict"] == "hit"
+    assert results[0]["id"] == "2026-06-17-01"
+
+
+def test_parse_verdicts_batch_invalid_returns_none():
+    assert score.parse_verdicts_batch("garbage") is None
+    assert score.parse_verdicts_batch('{"verdict":"hit"}') is None  # object not array
+
+
 def test_score_claim_unresolved_without_followup():
     claim = {"id": "2026-06-17-01", "theme": "t", "direction": "弱気",
              "targets": ["PLTR"], "horizon_days": 1, "type": "prediction"}
@@ -40,8 +54,51 @@ def test_score_claim_uses_judge_when_followup_exists(tmp_path, monkeypatch):
     monkeypatch.setattr(storage, "BRIEFING_OUTPUT_DIR", bdir)
     claim = {"id": "2026-06-17-01", "theme": "t", "direction": "弱気",
              "targets": ["PLTR"], "horizon_days": 5, "type": "prediction"}
-    judge_out = '{"verdict": "hit", "confidence": 0.7, "rationale": "ok"}'
-    with patch("src.evaluator.score.run_claude", return_value=judge_out):
+    batch_out = '[{"id":"2026-06-17-01","verdict":"hit","confidence":0.7,"rationale":"ok"}]'
+    with patch("src.evaluator.score.run_claude", return_value=batch_out):
         result = score.score_claim(claim, _DATES)
     assert result["verdict"] == "hit"
     assert result["id"] == "2026-06-17-01"
+
+
+def test_score_claims_batch_single_call(tmp_path, monkeypatch):
+    """同一 followup を持つ 2 件の claim が 1 回の run_claude で処理される。"""
+    bdir = tmp_path / "briefing"
+    bdir.mkdir()
+    (bdir / "briefing_2026-06-19.md").write_text("後日本文", encoding="utf-8")
+    monkeypatch.setattr(storage, "BRIEFING_OUTPUT_DIR", bdir)
+    claims = [
+        {"id": "2026-06-17-01", "theme": "t1", "direction": "強気",
+         "targets": ["PLTR"], "horizon_days": 5, "type": "prediction"},
+        {"id": "2026-06-17-02", "theme": "t2", "direction": "弱気",
+         "targets": ["NVDA"], "horizon_days": 5, "type": "prediction"},
+    ]
+    batch_out = json.dumps([
+        {"id": "2026-06-17-01", "verdict": "hit", "confidence": 0.9, "rationale": "r1"},
+        {"id": "2026-06-17-02", "verdict": "miss", "confidence": 0.6, "rationale": "r2"},
+    ])
+    with patch("src.evaluator.score.run_claude", return_value=batch_out) as mock_run:
+        results = score.score_claims_batch(claims, _DATES)
+    assert mock_run.call_count == 1
+    assert len(results) == 2
+    assert results[0]["verdict"] == "hit"
+    assert results[1]["verdict"] == "miss"
+
+
+def test_score_claims_batch_fallback_on_bad_response(tmp_path, monkeypatch):
+    """バッチ応答が壊れていたら per-claim フォールバックが走る。"""
+    bdir = tmp_path / "briefing"
+    bdir.mkdir()
+    (bdir / "briefing_2026-06-19.md").write_text("後日本文", encoding="utf-8")
+    monkeypatch.setattr(storage, "BRIEFING_OUTPUT_DIR", bdir)
+    claims = [
+        {"id": "2026-06-17-01", "theme": "t", "direction": "強気",
+         "targets": ["PLTR"], "horizon_days": 5, "type": "prediction"},
+    ]
+    single_out = json.dumps([
+        {"id": "2026-06-17-01", "verdict": "partial", "confidence": 0.5, "rationale": "fb"},
+    ])
+    # 1回目(バッチ)は壊れたJSON、2回目(フォールバック)は正常
+    with patch("src.evaluator.score.run_claude", side_effect=["garbage", single_out]):
+        results = score.score_claims_batch(claims, _DATES)
+    assert results[0]["verdict"] == "partial"

--- a/apps/python/tests/evaluator/test_score.py
+++ b/apps/python/tests/evaluator/test_score.py
@@ -37,6 +37,7 @@ def test_parse_verdicts_batch_valid():
 def test_parse_verdicts_batch_invalid_returns_none():
     assert score.parse_verdicts_batch("garbage") is None
     assert score.parse_verdicts_batch('{"verdict":"hit"}') is None  # object not array
+    assert score.parse_verdicts_batch('[null, {"verdict":"hit"}]') is None  # non-dict element
 
 
 def test_score_claim_unresolved_without_followup():
@@ -59,6 +60,23 @@ def test_score_claim_uses_judge_when_followup_exists(tmp_path, monkeypatch):
         result = score.score_claim(claim, _DATES)
     assert result["verdict"] == "hit"
     assert result["id"] == "2026-06-17-01"
+
+
+def test_score_claims_batch_id_assigned_positionally(tmp_path, monkeypatch):
+    """LLM が id を間違えて返しても pending の id がポジションベースで確定される。"""
+    bdir = tmp_path / "briefing"
+    bdir.mkdir()
+    (bdir / "briefing_2026-06-19.md").write_text("後日本文", encoding="utf-8")
+    monkeypatch.setattr(storage, "BRIEFING_OUTPUT_DIR", bdir)
+    claims = [
+        {"id": "2026-06-17-01", "theme": "t", "direction": "強気",
+         "targets": ["PLTR"], "horizon_days": 5, "type": "prediction"},
+    ]
+    # LLM が間違った id を返す
+    batch_out = '[{"id":"WRONG-ID","verdict":"hit","confidence":0.9,"rationale":"r"}]'
+    with patch("src.evaluator.score.run_claude", return_value=batch_out):
+        results = score.score_claims_batch(claims, _DATES)
+    assert results[0]["id"] == "2026-06-17-01"  # pending の id に上書きされる
 
 
 def test_score_claims_batch_single_call(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Group claims sharing the same followup date set into a single LLM call (was one subprocess per claim)
- Add `score_claims_batch()` with per-claim fallback on malformed batch response
- Update `eval_judge.md` to accept a themes array and return a JSON array
- Add batch-specific tests; all 559 tests pass

## Test plan
- [ ] `pytest tests/evaluator/test_score.py` — 10 tests pass including batch and fallback cases
- [ ] Full suite `pytest` — 559 passed

Closes #215

## Summary by Sourcery

Batch eval-judge scoring calls by grouping claims with shared follow-up briefings and adjust the evaluator to consume and produce batched JSON results.

New Features:
- Introduce batch claim scoring via score_claims_batch to evaluate multiple claims in a single LLM call.
- Add support for parsing batched eval-judge responses that return a JSON array of verdict objects.

Enhancements:
- Refine score workflow to reuse finalized results, group pending claims by follow-up dates, and preserve original claim ordering when saving scores.
- Update the eval_judge prompt to accept an array of themes and require a JSON array response including claim IDs.

Tests:
- Add unit tests for batched verdict parsing, batch scoring behavior, and fallback logic when batch responses are malformed.