### PR TITLE
refactor: modularize common patterns across handlers and notifiers

### DIFF
--- a/apps/python/src/generator/briefing_api.py
+++ b/apps/python/src/generator/briefing_api.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import sys
 from datetime import date, datetime
-from pathlib import Path
 
 from src.config import BriefingConfig, load_config
 from src.constants import BRIEFING_OUTPUT_DIR
@@ -29,6 +28,7 @@ from src.generator.briefing import (
 )
 from src.generator.prompt import render
 from src.logger import get_logger
+from src.notifier.local_md import write_md_file
 from src.usage_logger import log_usage
 from src.local_llm.articles import enrich_with_article_text
 from src.local_llm.briefing import prefetch_briefing_context, render_context_block
@@ -196,9 +196,7 @@ def main(argv: list[str] | None = None) -> int:
     md = run_briefing_api(config, client)
 
     today = date.today().isoformat()
-    BRIEFING_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-    out_path = Path(BRIEFING_OUTPUT_DIR) / f"briefing_api_{today}.md"
-    out_path.write_text(md, encoding="utf-8")
+    out_path = write_md_file(BRIEFING_OUTPUT_DIR, f"briefing_api_{today}.md", md)
     logger.info("保存完了: %s", out_path)
     logger.info("=== Claude API ブリーフィング終了 ===")
     return 0

--- a/apps/python/src/handler.py
+++ b/apps/python/src/handler.py
@@ -10,12 +10,9 @@ from src.notifier.discord import send_to_discord
 from src.notifier.local_md import save_briefing_md
 from src.notifier.notion import send_to_notion
 from src.logger import get_logger
+from src.utils import is_configured as _is_configured
 
 logger = get_logger(__name__)
-
-
-def _is_configured(*values: str) -> bool:
-    return all(values)
 
 
 def _preflight() -> None:

--- a/apps/python/src/notifier/local_md.py
+++ b/apps/python/src/notifier/local_md.py
@@ -33,6 +33,15 @@ def save_briefing_md(
     return path
 
 
+def write_md_file(output_dir: Path, filename: str, text: str) -> Path:
+    """output_dir/filename にテキストを書き込む。ディレクトリがなければ作成する。"""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / filename
+    path.write_text(text, encoding="utf-8")
+    logger.info("MD 出力: %s (%d文字)", path, len(text))
+    return path
+
+
 def _prune_old(output_dir: Path, retention_days: int) -> None:
     matched = [
         p for p in output_dir.iterdir()

--- a/apps/python/src/notifier/notion.py
+++ b/apps/python/src/notifier/notion.py
@@ -371,20 +371,29 @@ def _block_to_text(block: dict) -> str:
     return text
 
 
-def _fetch_blocks(notion: Client, block_id: str) -> list[dict]:
-    """指定ブロックの全子ブロックをページネーションして返す。"""
+def _paginate(call, base_kwargs: dict) -> list[dict]:
+    """Notion API のカーソルページネーションを共通化する。
+
+    ``call`` は ``start_cursor`` を含む kwargs を受け取り ``has_more`` / ``next_cursor`` /
+    ``results`` キーを持つレスポンスを返す callable。
+    """
     results: list[dict] = []
     cursor: str | None = None
     while True:
-        kwargs: dict = {"block_id": block_id, "page_size": 100}
+        kwargs = dict(base_kwargs)
         if cursor:
             kwargs["start_cursor"] = cursor
-        resp = notion.blocks.children.list(**kwargs)
+        resp = call(**kwargs)
         results.extend(resp.get("results", []))
         if not resp.get("has_more"):
             break
         cursor = resp.get("next_cursor")
     return results
+
+
+def _fetch_blocks(notion: Client, block_id: str) -> list[dict]:
+    """指定ブロックの全子ブロックをページネーションして返す。"""
+    return _paginate(notion.blocks.children.list, {"block_id": block_id, "page_size": 100})
 
 
 def _fetch_page_text(notion: Client, page_id: str) -> str:
@@ -448,22 +457,12 @@ def fetch_weekly_pages(
     since_dt = _utcnow() - timedelta(days=days)
     normalized_db_id = database_id.replace("-", "")
 
-    all_results: list[dict] = []
-    cursor: str | None = None
     try:
-        while True:
-            kwargs: dict = {
-                "filter": {"value": "page", "property": "object"},
-                "sort": {"direction": "descending", "timestamp": "last_edited_time"},
-                "page_size": 100,
-            }
-            if cursor:
-                kwargs["start_cursor"] = cursor
-            resp = notion.search(**kwargs)
-            all_results.extend(resp.get("results", []))
-            if not resp.get("has_more"):
-                break
-            cursor = resp.get("next_cursor")
+        all_results = _paginate(notion.search, {
+            "filter": {"value": "page", "property": "object"},
+            "sort": {"direction": "descending", "timestamp": "last_edited_time"},
+            "page_size": 100,
+        })
     except Exception:
         logger.exception("Notion 検索に失敗しました (database_id=%s)", database_id)
         return []

--- a/apps/python/src/utils.py
+++ b/apps/python/src/utils.py
@@ -1,0 +1,6 @@
+"""Project-wide utility functions shared across modules."""
+
+
+def is_configured(*values: str) -> bool:
+    """Return True if all credential values are non-empty strings."""
+    return all(values)

--- a/apps/python/src/xss_handler.py
+++ b/apps/python/src/xss_handler.py
@@ -8,12 +8,9 @@ from src.metrics.xss import extract_xss_metrics
 from src.notifier.discord import send_to_discord
 from src.notifier.notion import send_to_notion
 from src.logger import get_logger
+from src.utils import is_configured as _is_configured
 
 logger = get_logger(__name__)
-
-
-def _is_configured(*values: str) -> bool:
-    return all(values)
 
 
 def _write_md_fallback(text: str, filename: str) -> Path:


### PR DESCRIPTION
## Summary

コードベース横断で重複していた3パターンを共通モジュールに集約。

| パターン | 変更前 | 変更後 |
|---|---|---|
| `_is_configured()` | `handler.py` / `xss_handler.py` に同一関数が2つ | `src/utils.py` に一元化 |
| Notion ページネーション | `notion.py` 内に `while has_more` が2箇所 | `_paginate()` ヘルパーに統合 |
| MD ファイル書き込み | `briefing_api.py` で `mkdir + write_text` をインライン | `local_md.write_md_file()` に集約 |

挙動変更なし。

## Test plan
- [x] `pytest` — 560 tests pass (unchanged from baseline)
- [ ] Manual smoke: `lambda_handler` / `xss_handler` / `briefing_api` が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Modularize shared utility patterns across handlers, notifiers, and generators without changing behavior.

Enhancements:
- Introduce a generic Notion API pagination helper and reuse it for block fetching and search-based weekly page retrieval.
- Add a shared Markdown file writer helper and use it in the briefing API generator to centralize directory creation and file output.
- Extract a project-wide configuration presence check helper and reuse it in multiple handlers to remove duplicated logic.