### PR TITLE
docs: restructure README/CLAUDE.md — cut sections to docs/, remove roadmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,8 +2,8 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-> Setup, architecture, configuration, and testing details are documented in [README.md](README.md).
-> Custom Claude Code skills used in this project: [.claude/skills/](.claude/skills/README.md).
+> Project overview and user-facing docs: [README.md](README.md) and [docs/](docs/).
+> Custom Claude Code skills: [.claude/skills/](.claude/skills/README.md).
 
 ## Layout
 
@@ -13,15 +13,14 @@ Python sources live under `apps/python/`. Root-level `bin/run.sh` and `bin/chat.
 
 ```bash
 # From apps/python/
-cd apps/python
 uv venv .venv                  # Create venv (first time only)
 uv pip sync requirements.txt   # Install deps
 .venv/bin/pytest -v            # Run tests
 uv pip compile requirements.in -o requirements.txt  # Recompile deps
 
 # From repo root
-bin/run.sh                     # Run both agents (delegates to apps/python/bin/run.sh)
-bin/chat.sh                    # Launch chat session
+bin/run.sh    # Run both agents
+bin/chat.sh   # Launch chat session
 ```
 
 ## Key Implementation Notes
@@ -31,9 +30,9 @@ bin/chat.sh                    # Launch chat session
   - `cli`: the key is **stripped** so the claude CLI uses its OAuth session.
   - `api`: the key from `credentials.get_credential("ANTHROPIC_API_KEY")` (Keychain → `.env` fallback) is **injected** into the subprocess env.
 
-  If you add new subprocess calls to claude, route them through `_build_env(state.read_state().auth_mode)` so they honor the same toggle. Never set `ANTHROPIC_API_KEY` directly in the subprocess env outside this helper.
+  Route new subprocess calls to claude through `_build_env(state.read_state().auth_mode)`. Never set `ANTHROPIC_API_KEY` directly in the subprocess env outside this helper.
 - **`apps/python/requirements.txt` is auto-generated** — only edit `requirements.in`, then recompile.
-- **`src.config.CONFIG` is lazy.** A module-level `__getattr__` calls `load_config()` on the first attribute access — importing `src.config` itself does **not** read `briefing.json`. This is what lets the FastAPI web server boot before `briefing.json` exists (the operator creates it via `PUT /api/config`). Batch jobs that dereference `CONFIG.portfolio` etc. still get a clear `FileNotFoundError` at first use if the file is missing. Tests that call `load_config()` directly must patch `src.config.CONFIG_PATH`.
+- **`src.config.CONFIG` is lazy.** A module-level `__getattr__` calls `load_config()` on first attribute access — importing `src.config` does **not** read `briefing.json`. Tests that call `load_config()` directly must patch `src.config.CONFIG_PATH`.
 
 ## Config File Rules
 
@@ -43,10 +42,9 @@ bin/chat.sh                    # Launch chat session
 | `apps/python/config/briefing.json.example` | Schema documentation and template | Tracked |
 | `apps/python/tests/config/briefing.json` | Fixture config for CI and local tests | Tracked |
 
-- **`apps/python/config/briefing.json` is never committed.** It holds personal portfolio data used only at runtime.
-- **CI and local `pytest` always load `apps/python/tests/config/briefing.json`** — `apps/python/tests/conftest.py` sets `BRIEFING_CONFIG_PATH` before any import of `src.config`, so no `cp` step is needed in CI.
-- **When adding or changing config schema** (new fields, renamed keys), update both `apps/python/config/briefing.json.example` and `apps/python/tests/config/briefing.json` to keep them in sync.
-- **`apps/python/config/briefing.json`** must be updated manually by the operator after any schema change.
+- `apps/python/config/briefing.json` is **never committed**.
+- CI and local `pytest` always load `apps/python/tests/config/briefing.json` — `conftest.py` sets `BRIEFING_CONFIG_PATH` before any import of `src.config`.
+- When adding or changing config schema, update both `.example` and `tests/config/briefing.json`.
 
 ## Git Conventions
 

--- a/README.md
+++ b/README.md
@@ -14,324 +14,72 @@ Bloomberg and NewsPicks surface raw data. This agent ties every event to your ho
 
 ## Architecture
 
-```bash
+```
 bin/run.sh
-  ├── bin/briefing.py
-  │     └── src/handler.py
-  │           ├── src/fetcher/stocks.py        # Previous-day % change via yfinance
-  │           ├── src/generator/briefing.py    # Builds prompts, calls run_claude() in parallel
-  │           │     └── prompts/briefing.md    # Prompt template
-  │           ├── src/notifier/discord.py
-  │           └── src/notifier/notion.py
-  └── bin/xss_intel.py
-        └── src/xss_handler.py
-              ├── src/generator/xss_report.py  # Builds prompt, calls run_claude()
-              │     └── prompts/xss_intel.md
-              ├── src/notifier/discord.py
-              └── src/notifier/notion.py
+  ├── bin/briefing.py → src/handler.py
+  │     ├── src/fetcher/stocks.py        # Previous-day % change via yfinance
+  │     ├── src/generator/briefing.py    # Builds prompts, calls run_claude() in parallel
+  │     ├── src/notifier/discord.py
+  │     └── src/notifier/notion.py
+  └── bin/xss_intel.py → src/xss_handler.py
+        ├── src/generator/xss_report.py
+        ├── src/notifier/discord.py
+        └── src/notifier/notion.py
 
 src/claude_runner.py   # Shared claude CLI helper (subprocess + WebSearch)
-config/
-  briefing.json        # Portfolio, watch sectors (14 sectors), geopolitical risks
-  xss_intel.json       # XSS target frameworks / libraries / keywords
-src/config.py          # JSON → dataclass schema
-skills/                # Claude Code custom skills — see skills/README.md
+config/briefing.json   # Portfolio, watch sectors, geopolitical risks
 ```
 
-See [skills/](skills/README.md) for custom Claude Code skills bundled with this repo.
+**Key design decisions**
 
-### Key Design Decisions
-
-- **No NewsAPI** — Claude Code CLI's built-in WebSearch handles real-time search
-- **No Anthropic API billing** — reuses Claude Code CLI's OAuth authentication; `ANTHROPIC_API_KEY` is explicitly excluded from the subprocess environment to prevent accidental API charges
-- **Geopolitical → stock causality** is baked into every daily output
-- **watch_sectors** (14 sectors, ~90 tickers) give Claude full market coverage to surface sector moves
-- **Degraded mode** — if the sector sweep fails, the main analysis is still delivered
+- No NewsAPI — Claude Code CLI's built-in WebSearch handles real-time search
+- No Anthropic API billing — reuses Claude Code CLI's OAuth authentication
+- Geopolitical → stock causality is baked into every daily output
+- Degraded mode — if the sector sweep fails, the main analysis is still delivered
 
 ---
 
 ## Setup
 
-### Prerequisites
-
-- Python 3.11+
-- [uv](https://github.com/astral-sh/uv) installed
-- [Claude Code CLI](https://claude.ai/code) installed and authenticated (`claude` in PATH)
-- Discord Bot created (Send Messages permission granted)
-- Notion integration created with database access
-
-### Install
+**Prerequisites:** Python 3.11+, [uv](https://github.com/astral-sh/uv), [Claude Code CLI](https://claude.ai/code) authenticated, Discord Bot, Notion integration.
 
 ```bash
 git clone https://github.com/KazusaNakagawa/ai-agent-cli.git
 cd ai-agent-cli
-
 uv venv .venv
 uv pip sync requirements.txt
+cp .env.example .env   # add DISCORD_TOKEN, NOTION_API_KEY, etc.
 ```
 
-### Environment Variables
+See [docs/configuration.md](docs/configuration.md) for all environment variables and config schema.
+
+## Run
 
 ```bash
-cp .env.example .env
-# Edit .env
-```
+bin/run.sh             # both agents
 
-| Variable | Source | Purpose |
-|---|---|---|
-| `DISCORD_TOKEN` | Discord Developer Portal | Bot authentication |
-| `CHANNEL_ID` | Right-click channel → Copy ID | Target channel |
-| `NOTION_API_KEY` | Notion integrations page | API authentication |
-| `NOTION_DATABASE_ID` | Database URL | Target database |
+# Interactive Q&A on today's briefing
+bin/chat.sh            # new or resumed session
+bin/chat.sh 2026-05-16 # specific past briefing
+bin/chat.sh --list     # list saved sessions
 
-### Run
-
-```bash
-bin/run.sh
-```
-
-### Interactive Q&A on today's briefing
-
-```bash
-bin/chat.sh                # today's briefing (new or resumed session)
-bin/chat.sh 2026-05-16    # specific past briefing
-bin/chat.sh --list         # list all saved sessions
-```
-
-Opens an interactive Claude session with the briefing loaded as context.
-On the first run a session UUID is generated and saved to `output/briefing/.sessions/<date>`.
-On subsequent runs for the same date the previous conversation is automatically resumed
-via `--session-id`, so the full Q&A history carries over between restarts.
-
-Exits with an error if the briefing file for the specified date does not exist.
-Session files are stored inside `output/` which is already git-ignored.
-
-### Dry-run (validate credentials without executing)
-
-```bash
+# Dry-run (validate credentials without executing)
 .venv/bin/python bin/briefing.py --dry-run
 .venv/bin/python bin/xss_intel.py --dry-run
 ```
 
-Prints a WARNING for each missing credential and exits without calling Claude or any API.
-
 ---
 
-## Scheduled Execution (macOS launchd)
+## Docs
 
-See [docs/launchd-setup.md](docs/launchd-setup.md) for the full setup guide (plist template, dry-run validation, register/trigger/unload commands).
-
----
-
-## Briefing Evaluation
-
-A separate pipeline scores past briefings to measure how well their views held up. It extracts
-macro, theme-level views from each briefing, judges them against *later* briefings as ground truth,
-and aggregates hit rates into a Mermaid scorecard. LLM calls go through the same `claude` CLI path
-(subscription auth) — no extra API key required.
-
-```bash
-# 1. Extract structured themes from briefings (all dates; already-extracted ones are skipped)
-apps/python/bin/evaluate.sh extract
-apps/python/bin/evaluate.sh extract 2026-06-15   # single date
-
-# 2. Score themes whose verification window is covered by later briefings
-apps/python/bin/evaluate.sh score
-
-# 3. Build the aggregate report
-apps/python/bin/evaluate.sh report
-```
-
-Outputs (all under git-ignored `output/`):
-
-- `output/eval/claims/<date>.json` — extracted themes (`direction`, `targets`, `horizon_days`, `type`)
-- `output/eval/scores/<date>.json` — verdicts (`hit` / `miss` / `partial` / `unresolved`)
-- `output/eval/report.md` — Mermaid `pie` + `xychart-beta` scorecard (hit rate by type / sector / time)
-
-A theme stays `unresolved` until at least one briefing exists inside its window `(date, date + horizon_days]`;
-re-running `score` only re-evaluates `unresolved` entries and never overwrites finalized verdicts.
-Design notes: [docs/superpowers/specs/2026-06-17-briefing-eval-foundation-design.md](docs/superpowers/specs/2026-06-17-briefing-eval-foundation-design.md).
-
----
-
-## Configuration
-
-### `config/briefing.json`
-
-All monitoring targets are managed here — no code changes needed.
-
-```json
-{
-  "portfolio": {
-    "tickers": ["PLTR", "NVDA"],
-    "themes": ["AI regulation", "US-China relations", "semiconductors"]
-  },
-  "watch_sectors": [
-    {
-      "sector": "AI & Cloud",
-      "tickers": ["NVDA", "MSFT", "GOOGL", "META", "AMZN"],
-      "notes": "AI capex cycle, model competition, and regulation are the main drivers"
-    }
-  ],
-  "geopolitical": {
-    "conflicts": [
-      {
-        "name": "Russia-Ukraine War",
-        "affected_sectors": ["Energy", "Defense", "Grains"],
-        "related_tickers": ["LMT", "RTX", "XOM"],
-        "notes": "NATO defense spending increase is a tailwind for LMT/RTX"
-      }
-    ]
-  }
-}
-```
-
-### `prompts/briefing.md`
-
-Prompt template for the briefing agent. Variables: `{tickers}` `{themes}` `{geopolitical}` `{watch_sectors}` `{stocks}`. Edit this file to change Claude's output behavior.
-
----
-
-## Testing
-
-```bash
-# Run all tests
-.venv/bin/pytest -v
-
-# Run a specific module
-.venv/bin/pytest tests/test_claude_runner.py -v
-```
-
-| Test file | Coverage |
+| Topic | Link |
 |---|---|
-| `test_claude_runner.py` | `run_claude()` — CLI discovery, timeout, error handling, env masking |
-| `test_generator_briefing.py` | Context builders, parallel execution, degraded mode |
-| `test_config.py` | `load_config()` validation (watch_sectors, tickers) |
-
----
-
-## Sample Output
-
-```markdown
-## Today's Summary (1 sentence)
-...
-
-## Why It Moved (Story)
-...geopolitics, sentiment, supply/demand in 3–4 lines...
-
-## Geopolitical → Market Causality
-...how each risk translated to sector/ticker moves today...
-
-## Sector Movements (All Sectors)
-- AI & Cloud: NVDA 10-day winning streak (+18%)...
-- Energy (Oil & Gas): Brent $128 on Hormuz closure...
-...
-
-## What This Means for You
-...1–2 lines for portfolio holders...
-
-## Sources
-- Article title — outlet (URL)
-```
-
----
-
-## Dependency Management
-
-```bash
-# After adding a package to requirements.in
-uv pip compile requirements.in -o requirements.txt
-uv pip sync requirements.txt
-```
-
----
-
-## Roadmap
-
-| Phase | Description | Status |
-|---|---|---|
-| 1 | Local manual run | ✅ Done |
-| 2 | Discord delivery | ✅ Done |
-| 3 | Notion delivery | ✅ Done |
-| 4 | Unit tests (pytest) | ✅ Done |
-| 5 | AWS Lambda + EventBridge automation | 📋 Planned |
-| 6 | DynamoDB for dynamic config | 📋 Planned |
-
----
-
-## Local LLM (experimental)
-
-Optional fully-local RAG over this repository, powered by Ollama + Chroma. The existing Claude Code / briefing / XSS agents are unaffected.
-
-### Prerequisites
-
-```bash
-brew install ollama       # or follow https://ollama.com
-ollama serve &
-ollama pull qwen2.5:14b   # for --briefing: reliable tool calling (~8.5GB RAM with Q4)
-ollama pull qwen2.5:7b    # for --ask / --index: smaller, fits the RAG path
-ollama pull bge-m3        # embedding model (#135): stronger JP + code retrieval than nomic-embed-text
-
-# optional alternatives — see the Model options table below
-ollama pull qwen2.5-coder:14b  # code-heavy --ask queries
-ollama pull qwen2.5:32b        # deepest explanations / final synthesis (~20GB RAM)
-```
-
-The default generation model is `qwen2.5:14b` for more stable instruction-following and citation quality in the `--briefing` path. If you only run `--ask` / `--index`, override with `LOCAL_LLM_MODEL=qwen2.5:7b`.
-
-#### Model options
-
-Swap the generation model without code edits via `LOCAL_LLM_MODEL` (env) or `--model` (CLI flag). RAM figures are approximate for Q4 quantization; leave headroom for the embedding model and OS.
-
-| Model | Approx. RAM (Q4) | Best for | Trade-offs |
-|---|---|---|---|
-| `qwen2.5:7b` | ~5 GB | `--ask` / `--index` on the RAG path | Fastest; weaker tool calling, so less reliable for `--briefing` web_search |
-| `qwen2.5-coder:14b` | ~9 GB | Code-heavy `--ask` queries over this repo | Stronger on code, but tuned less for general JP briefing prose |
-| `qwen2.5:14b` (default) | ~8.5 GB | `--briefing`: reliable tool calling + citation quality | Balanced; fits comfortably on 24 GB RAM with 16K ctx |
-| `qwen2.5:32b` | ~20 GB | Deepest explanations / final synthesis stage | Slow; tight on 24 GB RAM — close other apps |
-
-```bash
-LOCAL_LLM_MODEL=qwen2.5:32b bin/local_llm.sh --ask "..."   # one-off override
-bin/local_llm.sh --briefing --model qwen2.5:7b             # per-invocation flag
-```
-
-#### Dual-model briefing (reasoning final stage)
-
-For `--briefing`, the final synthesis stage (自分への示唆 / insight) can run on a
-stronger reasoning model while the cheaper main model handles the
-extraction/summary stages (#171). Set `LOCAL_LLM_SYNTHESIS_MODEL`:
-
-```bash
-LOCAL_LLM_MODEL=qwen2.5:14b \
-LOCAL_LLM_SYNTHESIS_MODEL=qwen2.5:32b \
-  bin/local_llm.sh --briefing
-```
-
-When unset, the synthesis stage uses `LOCAL_LLM_MODEL`, so behavior is unchanged.
-On 24 GB RAM, Ollama swaps models between stages — keep the two models within the
-memory budget (e.g. 14b + 32b run sequentially, not concurrently).
-
-> **Switching embed models requires a rebuild.** `bge-m3` (1024 dim) and the legacy `nomic-embed-text` (768 dim) produce incompatible vectors. If you change `LOCAL_LLM_EMBED_MODEL` (or are upgrading from a pre-#135 index), the CLI refuses with an `EmbedModelMismatch` error — rebuild with `bin/local_llm.sh --index --reset`.
-
-### Usage
-
-```bash
-bin/local_llm.sh --index                       # index ~/work/ai-agent into Chroma
-bin/local_llm.sh --status                      # show indexed chunk count & models
-bin/local_llm.sh --ask "認証はどう動く？"
-bin/local_llm.sh --sources "認証はどう動く？"  # retrieval-only debug
-bin/local_llm.sh --index --reset               # rebuild from scratch
-bin/local_llm.sh --briefing                    # generate daily briefing locally (saves local_<date>.md)
-bin/local_llm.sh --briefing --notion           # ...and post to Notion alongside the Claude version
-```
-
-Chroma data is stored in `apps/python/.chroma_db/` (gitignored).
-
-Override defaults via env: `LOCAL_LLM_MODEL`, `LOCAL_LLM_SYNTHESIS_MODEL`, `LOCAL_LLM_EMBED_MODEL`, `LOCAL_LLM_TOP_K`, `LOCAL_LLM_CHROMA_PATH`, `OLLAMA_HOST`.
-
-`--briefing` requires `BRAVE_API_KEY` in `.env` (Free-plan key at https://api-dashboard.search.brave.com/ — see `.env.example`). The CLI pre-fetches Brave Search results for all portfolio tickers, macro news, and geopolitical topics, then injects them as context before local generation; without the key the command exits with an error. Tracked under [#142](https://github.com/KazusaNakagawa/ai-agent-cli/issues/142) (initial offline version) and [#144](https://github.com/KazusaNakagawa/ai-agent-cli/issues/144) (Brave Search integration).
-
-Tracked under [#140](https://github.com/KazusaNakagawa/ai-agent/issues/140) (Epic [#139](https://github.com/KazusaNakagawa/ai-agent/issues/139)). Quality improvements (#135 bge-m3, #136 reranker, #138 AST chunking, #137 generation model) ship as follow-up PRs.
+| Configuration (env vars, config schema, prompts) | [docs/configuration.md](docs/configuration.md) |
+| Scheduled execution (macOS launchd) | [docs/launchd-setup.md](docs/launchd-setup.md) |
+| Briefing evaluation pipeline | [docs/evaluation.md](docs/evaluation.md) |
+| Local LLM mode (Ollama + Chroma) | [docs/local-llm.md](docs/local-llm.md) |
+| Testing & dependency management | [docs/testing.md](docs/testing.md) |
+| Web UI setup | [docs/web-ui-setup.md](docs/web-ui-setup.md) |
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,50 @@
+# Configuration
+
+## `config/briefing.json`
+
+All monitoring targets are managed here — no code changes needed.
+
+```json
+{
+  "portfolio": {
+    "tickers": ["PLTR", "NVDA"],
+    "themes": ["AI regulation", "US-China relations", "semiconductors"]
+  },
+  "watch_sectors": [
+    {
+      "sector": "AI & Cloud",
+      "tickers": ["NVDA", "MSFT", "GOOGL", "META", "AMZN"],
+      "notes": "AI capex cycle, model competition, and regulation are the main drivers"
+    }
+  ],
+  "geopolitical": {
+    "conflicts": [
+      {
+        "name": "Russia-Ukraine War",
+        "affected_sectors": ["Energy", "Defense", "Grains"],
+        "related_tickers": ["LMT", "RTX", "XOM"],
+        "notes": "NATO defense spending increase is a tailwind for LMT/RTX"
+      }
+    ]
+  }
+}
+```
+
+## `prompts/briefing.md`
+
+Prompt template for the briefing agent. Variables: `{tickers}` `{themes}` `{geopolitical}` `{watch_sectors}` `{stocks}`. Edit this file to change Claude's output behavior.
+
+## Environment Variables
+
+```bash
+cp .env.example .env
+# Edit .env
+```
+
+| Variable | Source | Purpose |
+|---|---|---|
+| `DISCORD_TOKEN` | Discord Developer Portal | Bot authentication |
+| `CHANNEL_ID` | Right-click channel → Copy ID | Target channel |
+| `NOTION_API_KEY` | Notion integrations page | API authentication |
+| `NOTION_DATABASE_ID` | Database URL | Target database |
+| `BRAVE_API_KEY` | [api-dashboard.search.brave.com](https://api-dashboard.search.brave.com/) | Local LLM briefing web search |

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -1,0 +1,34 @@
+# Briefing Evaluation
+
+A separate pipeline scores past briefings to measure how well their views held up. It extracts
+macro, theme-level views from each briefing, judges them against *later* briefings as ground truth,
+and aggregates hit rates into a Mermaid scorecard. LLM calls go through the same `claude` CLI path
+(subscription auth) — no extra API key required.
+
+## Usage
+
+```bash
+# 1. Extract structured themes from briefings (all dates; already-extracted ones are skipped)
+apps/python/bin/evaluate.sh extract
+apps/python/bin/evaluate.sh extract 2026-06-15   # single date
+
+# 2. Score themes whose verification window is covered by later briefings
+apps/python/bin/evaluate.sh score
+
+# 3. Build the aggregate report
+apps/python/bin/evaluate.sh report
+```
+
+## Outputs
+
+All under git-ignored `output/`:
+
+| Path | Content |
+|---|---|
+| `output/eval/claims/<date>.json` | Extracted themes (`direction`, `targets`, `horizon_days`, `type`) |
+| `output/eval/scores/<date>.json` | Verdicts (`hit` / `miss` / `partial` / `unresolved`) |
+| `output/eval/report.md` | Mermaid `pie` + `xychart-beta` scorecard (hit rate by type / sector / time) |
+
+A theme stays `unresolved` until at least one briefing exists inside its window `(date, date + horizon_days]`; re-running `score` only re-evaluates `unresolved` entries and never overwrites finalized verdicts.
+
+Design notes: [docs/superpowers/specs/2026-06-17-briefing-eval-foundation-design.md](superpowers/specs/2026-06-17-briefing-eval-foundation-design.md).

--- a/docs/local-llm.md
+++ b/docs/local-llm.md
@@ -21,7 +21,7 @@ Requires `BRAVE_API_KEY` in `.env` for `--briefing` (Free-plan key at <https://a
 ## Usage
 
 ```bash
-bin/local_llm.sh --index                       # index ~/work/ai-agent into Chroma
+bin/local_llm.sh --index                       # index ~/work/ai-agent-cli into Chroma
 bin/local_llm.sh --status                      # show indexed chunk count & models
 bin/local_llm.sh --ask "認証はどう動く？"
 bin/local_llm.sh --sources "認証はどう動く？"  # retrieval-only debug

--- a/docs/local-llm.md
+++ b/docs/local-llm.md
@@ -1,0 +1,67 @@
+# Local LLM (experimental)
+
+Optional fully-local RAG over this repository, powered by Ollama + Chroma. The existing Claude Code / briefing / XSS agents are unaffected.
+
+## Prerequisites
+
+```bash
+brew install ollama       # or follow https://ollama.com
+ollama serve &
+ollama pull qwen2.5:14b   # for --briefing: reliable tool calling (~8.5GB RAM with Q4)
+ollama pull qwen2.5:7b    # for --ask / --index: smaller, fits the RAG path
+ollama pull bge-m3        # embedding model: stronger JP + code retrieval
+
+# optional alternatives
+ollama pull qwen2.5-coder:14b  # code-heavy --ask queries
+ollama pull qwen2.5:32b        # deepest explanations / final synthesis (~20GB RAM)
+```
+
+Requires `BRAVE_API_KEY` in `.env` for `--briefing` (Free-plan key at <https://api-dashboard.search.brave.com/>).
+
+## Usage
+
+```bash
+bin/local_llm.sh --index                       # index ~/work/ai-agent into Chroma
+bin/local_llm.sh --status                      # show indexed chunk count & models
+bin/local_llm.sh --ask "認証はどう動く？"
+bin/local_llm.sh --sources "認証はどう動く？"  # retrieval-only debug
+bin/local_llm.sh --index --reset               # rebuild from scratch
+bin/local_llm.sh --briefing                    # generate daily briefing locally
+bin/local_llm.sh --briefing --notion           # ...and post to Notion
+```
+
+Chroma data is stored in `apps/python/.chroma_db/` (gitignored).
+
+## Model options
+
+Swap the generation model via `LOCAL_LLM_MODEL` (env) or `--model` (CLI flag).
+
+| Model | Approx. RAM (Q4) | Best for |
+|---|---|---|
+| `qwen2.5:7b` | ~5 GB | `--ask` / `--index` — fastest |
+| `qwen2.5-coder:14b` | ~9 GB | Code-heavy `--ask` queries |
+| `qwen2.5:14b` (default) | ~8.5 GB | `--briefing` — balanced |
+| `qwen2.5:32b` | ~20 GB | Deepest explanations / final synthesis |
+
+```bash
+LOCAL_LLM_MODEL=qwen2.5:32b bin/local_llm.sh --ask "..."
+bin/local_llm.sh --briefing --model qwen2.5:7b
+```
+
+## Dual-model briefing (reasoning final stage)
+
+The final synthesis stage (自分への示唆) can run on a stronger model while the cheaper main model handles extraction/summary stages.
+
+```bash
+LOCAL_LLM_MODEL=qwen2.5:14b \
+LOCAL_LLM_SYNTHESIS_MODEL=qwen2.5:32b \
+  bin/local_llm.sh --briefing
+```
+
+When `LOCAL_LLM_SYNTHESIS_MODEL` is unset, both stages use `LOCAL_LLM_MODEL`.
+
+## Environment overrides
+
+`LOCAL_LLM_MODEL`, `LOCAL_LLM_SYNTHESIS_MODEL`, `LOCAL_LLM_EMBED_MODEL`, `LOCAL_LLM_TOP_K`, `LOCAL_LLM_CHROMA_PATH`, `OLLAMA_HOST`
+
+> **Switching embed models requires a rebuild.** `bge-m3` (1024 dim) and the legacy `nomic-embed-text` (768 dim) produce incompatible vectors. If you change `LOCAL_LLM_EMBED_MODEL`, rebuild with `bin/local_llm.sh --index --reset`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,24 @@
+# Testing
+
+```bash
+cd apps/python
+.venv/bin/pytest -v                              # all tests
+.venv/bin/pytest tests/test_claude_runner.py -v  # specific module
+```
+
+| Test file | Coverage |
+|---|---|
+| `test_claude_runner.py` | `run_claude()` — CLI discovery, timeout, error handling, env masking |
+| `test_generator_briefing.py` | Context builders, parallel execution, degraded mode |
+| `test_config.py` | `load_config()` validation (watch_sectors, tickers) |
+| `test_notion.py` | Notion page creation, markdown→block conversion |
+
+## Dependency management
+
+```bash
+# After adding a package to requirements.in
+uv pip compile requirements.in -o requirements.txt
+uv pip sync requirements.txt
+```
+
+`requirements.txt` is auto-generated — only edit `requirements.in`.


### PR DESCRIPTION
## Summary

- README.md を ~70行に圧縮。長い節を docs/ に切り出し、Docs インデックステーブルで参照
- Roadmap セクション（AWS Lambda 項目含む）を削除
- CLAUDE.md を現状に合わせて整理、docs/ へのポインタに更新

## 切り出した docs/ ページ

| ファイル | 内容 |
|---|---|
| `docs/configuration.md` | env vars + briefing.json スキーマ + prompts |
| `docs/evaluation.md` | eval パイプライン使い方 + 出力一覧 |
| `docs/local-llm.md` | Ollama セットアップ + モデル表 + dual-model |
| `docs/testing.md` | pytest コマンド + 依存管理 |

## Test plan
- [x] 既存テストへの影響なし（ドキュメントのみ変更）
- [ ] README.md のリンクが正しくたどれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Restructure and slim down the README by moving detailed usage, configuration, evaluation, testing, and local LLM sections into dedicated docs pages, while updating CLAUDE.md to point to the new documentation layout.

Documentation:
- Introduce separate docs pages for configuration, evaluation pipeline, testing, and experimental local LLM usage, and link them from a docs index in the README.
- Update README to provide a concise overview with a docs table, and remove the roadmap section.
- Refresh CLAUDE.md to reflect current project layout and reference the new docs directory.