### PR TITLE
fix(weekly-summary): switch from local Ollama to Claude model

### DIFF
--- a/apps/python/src/generator/weekly_summary.py
+++ b/apps/python/src/generator/weekly_summary.py
@@ -1,16 +1,9 @@
-"""週次ブリーフィングサマリーを生成する。
-
-このステップは「既に生成済みのブリーフィング群を決定的に要約する」低推論タスクで、
-WebSearch も強い推論も要らない。コスト削減のため Claude API ではなくローカルの
-Ollama スタック (src/local_llm/) で実行する (#193)。地政学・ポートフォリオ分析など
-推論が重いステップは引き続き Claude API 経路 (generator/briefing.py) のまま。
-"""
+"""週次ブリーフィングサマリーを生成する。"""
 from datetime import date, timedelta
 
+from src.claude_runner import run_claude
+from src.constants import TIMEOUT_WEEKLY_SUMMARY
 from src.generator.prompt import render
-from src.local_llm.briefing.generate import generate_local_briefing
-from src.local_llm.clients import make_ollama_client
-from src.local_llm.config import load_config as load_local_config
 from src.logger import get_logger
 from src.prompt_safety import wrap_untrusted
 
@@ -18,7 +11,7 @@ logger = get_logger(__name__)
 
 
 def _format_briefings(pages: list[dict]) -> str:
-    """ページリストを要約プロンプト用テキストにまとめる。
+    """ページリストを Claude プロンプト用テキストにまとめる。
 
     Each page body is wrapped in an untrusted-context block because the
     page text is prior LLM output that may itself have ingested
@@ -38,28 +31,12 @@ def week_label() -> str:
     return f"{start.strftime('%Y-%m-%d')}〜{today.strftime('%Y-%m-%d')}"
 
 
-def generate_weekly_summary(pages: list[dict], *, ollama_client=None, cfg=None) -> str:
-    """過去7日分のページリストから週次サマリーを生成して返す。
-
-    ローカル Ollama スタックで生成する。``cfg`` / ``ollama_client`` は注入可能で、
-    省略時は env ベースの ``load_local_config()`` と実 Ollama クライアントを使う
-    （テストはここを差し替えてライブ呼び出しなしで検証できる）。
-    """
+def generate_weekly_summary(pages: list[dict]) -> str:
+    """過去7日分のページリストから週次サマリーを生成して返す。"""
     if not pages:
         raise ValueError("週次サマリー生成に必要なページが見つかりませんでした")
 
-    # 明示的な None 判定: falsy だが有効な cfg/client（テスト用スタブ等）を
-    # 取りこぼさないため、`or` ではなく省略時のみフォールバックする。
-    if cfg is None:
-        cfg = load_local_config()
-    client = ollama_client if ollama_client is not None else make_ollama_client(cfg)
-
     prompt = render("weekly_summary", briefings=_format_briefings(pages), week_label=week_label())
 
-    logger.info("週次サマリー生成中 (ローカル Ollama=%s, 対象ページ数=%d)...", cfg.model, len(pages))
-    return generate_local_briefing(
-        prompt,
-        ollama_client=client,
-        model=cfg.model,
-        options={"num_ctx": cfg.num_ctx, "temperature": cfg.temperature},
-    )
+    logger.info("週次サマリー生成中 (対象ページ数=%d)...", len(pages))
+    return run_claude(prompt, "週次サマリー生成", TIMEOUT_WEEKLY_SUMMARY)

--- a/apps/python/src/generator/weekly_summary.py
+++ b/apps/python/src/generator/weekly_summary.py
@@ -1,7 +1,7 @@
 """週次ブリーフィングサマリーを生成する。"""
 from datetime import date, timedelta
 
-from src.claude_runner import run_claude
+from src.claude_runner import get_model, run_claude
 from src.constants import TIMEOUT_WEEKLY_SUMMARY
 from src.generator.prompt import render
 from src.logger import get_logger
@@ -38,5 +38,5 @@ def generate_weekly_summary(pages: list[dict]) -> str:
 
     prompt = render("weekly_summary", briefings=_format_briefings(pages), week_label=week_label())
 
-    logger.info("週次サマリー生成中 (対象ページ数=%d)...", len(pages))
+    logger.info("週次サマリー生成中 (model=%s, 対象ページ数=%d)...", get_model(), len(pages))
     return run_claude(prompt, "週次サマリー生成", TIMEOUT_WEEKLY_SUMMARY)

--- a/apps/python/tests/test_weekly_handler.py
+++ b/apps/python/tests/test_weekly_handler.py
@@ -115,17 +115,12 @@ class TestFormatBriefings:
 
 
 class TestGenerateWeeklySummary:
-    def _fake_cfg(self):
-        from types import SimpleNamespace
-
-        return SimpleNamespace(model="qwen2.5:14b", num_ctx=16384, temperature=0.2)
-
     def test_empty_pages_raises(self):
         with pytest.raises(ValueError, match="見つかりませんでした"):
             generate_weekly_summary([])
 
     def test_delegates_to_run_claude(self):
-        """週次サマリーは run_claude 経路に委譲し、プロンプトにページ本文が含まれる。"""
+        """週次サマリーは run_claude 経路に委譲し、プロンプトにページ本文と purpose が含まれる。"""
         pages = [{"date": "2026-04-25", "title": "T", "text": "content"}]
 
         with patch(
@@ -136,11 +131,13 @@ class TestGenerateWeeklySummary:
 
         assert result == "週次サマリー本文"
         mock_run.assert_called_once()
-        prompt = mock_run.call_args.args[0]
-        assert "content" in prompt
+        args, kwargs = mock_run.call_args
+        prompt_arg, purpose_arg = args[:2]
+        assert "content" in prompt_arg
+        assert purpose_arg == "週次サマリー生成"
 
     def test_run_claude_receives_timeout(self):
-        """run_claude に TIMEOUT_WEEKLY_SUMMARY が渡される。"""
+        """run_claude に TIMEOUT_WEEKLY_SUMMARY が timeout キーワードで渡される。"""
         from src.constants import TIMEOUT_WEEKLY_SUMMARY
 
         pages = [{"date": "2026-04-25", "title": "T", "text": "content"}]
@@ -151,7 +148,10 @@ class TestGenerateWeeklySummary:
         ) as mock_run:
             generate_weekly_summary(pages)
 
-        assert mock_run.call_args.args[2] == TIMEOUT_WEEKLY_SUMMARY
+        _, call_kwargs = mock_run.call_args
+        # timeout is the 3rd positional arg; accept both positional and keyword form
+        timeout_val = call_kwargs.get("timeout", mock_run.call_args.args[2] if len(mock_run.call_args.args) > 2 else None)
+        assert timeout_val == TIMEOUT_WEEKLY_SUMMARY
 
 
 # ---------------------------------------------------------------------------

--- a/apps/python/tests/test_weekly_handler.py
+++ b/apps/python/tests/test_weekly_handler.py
@@ -124,58 +124,34 @@ class TestGenerateWeeklySummary:
         with pytest.raises(ValueError, match="見つかりませんでした"):
             generate_weekly_summary([])
 
-    def test_delegates_to_local_ollama_with_cfg_options(self):
-        """週次サマリーはローカル Ollama 経路 (generate_local_briefing) に委譲し、
-        cfg 由来の model/options と注入クライアントを渡す (#193)。"""
+    def test_delegates_to_run_claude(self):
+        """週次サマリーは run_claude 経路に委譲し、プロンプトにページ本文が含まれる。"""
         pages = [{"date": "2026-04-25", "title": "T", "text": "content"}]
-        fake_client = MagicMock()
-        cfg = self._fake_cfg()
 
         with patch(
-            "src.generator.weekly_summary.generate_local_briefing",
+            "src.generator.weekly_summary.run_claude",
             return_value="週次サマリー本文",
-        ) as mock_gen:
-            result = generate_weekly_summary(pages, ollama_client=fake_client, cfg=cfg)
-
-        assert result == "週次サマリー本文"
-        mock_gen.assert_called_once()
-        args, kwargs = mock_gen.call_args
-        prompt = args[0] if args else kwargs["prompt"]
-        assert "content" in prompt  # 前週ブリーフィング本文がプロンプトに反映
-        assert kwargs["ollama_client"] is fake_client
-        assert kwargs["model"] == cfg.model
-        assert kwargs["options"]["num_ctx"] == cfg.num_ctx
-        assert kwargs["options"]["temperature"] == cfg.temperature
-
-    def test_default_path_wires_local_config_and_ollama_client(self):
-        """cfg/client 未注入時は load_local_config → make_ollama_client →
-        generate_local_briefing の順で配線される（ライブ I/O なし）。"""
-        pages = [{"date": "2026-04-25", "title": "T", "text": "content"}]
-        cfg = self._fake_cfg()
-        fake_client = object()
-        order = []
-
-        with (
-            patch(
-                "src.generator.weekly_summary.load_local_config",
-                side_effect=lambda: order.append("cfg") or cfg,
-            ) as mock_cfg,
-            patch(
-                "src.generator.weekly_summary.make_ollama_client",
-                side_effect=lambda c: order.append("client") or fake_client,
-            ) as mock_client,
-            patch(
-                "src.generator.weekly_summary.generate_local_briefing",
-                side_effect=lambda *a, **k: order.append("gen") or "summary",
-            ) as mock_gen,
-        ):
+        ) as mock_run:
             result = generate_weekly_summary(pages)
 
-        assert result == "summary"
-        mock_cfg.assert_called_once_with()
-        mock_client.assert_called_once_with(cfg)
-        assert mock_gen.call_args.kwargs["ollama_client"] is fake_client
-        assert order == ["cfg", "client", "gen"]
+        assert result == "週次サマリー本文"
+        mock_run.assert_called_once()
+        prompt = mock_run.call_args.args[0]
+        assert "content" in prompt
+
+    def test_run_claude_receives_timeout(self):
+        """run_claude に TIMEOUT_WEEKLY_SUMMARY が渡される。"""
+        from src.constants import TIMEOUT_WEEKLY_SUMMARY
+
+        pages = [{"date": "2026-04-25", "title": "T", "text": "content"}]
+
+        with patch(
+            "src.generator.weekly_summary.run_claude",
+            return_value="summary",
+        ) as mock_run:
+            generate_weekly_summary(pages)
+
+        assert mock_run.call_args.args[2] == TIMEOUT_WEEKLY_SUMMARY
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `gemma2:9b` の context window (16,384 tokens) が週次入力 (~67,000 tokens / 16ページ) に対して小さすぎ、出力が `##`（2文字）になる問題を修正
- `generate_local_briefing` → `run_claude()` に切り替え
- 不要になった Ollama 依存（`load_local_config`, `make_ollama_client`）を削除
- テストを `run_claude` 経路に更新

## Test plan

- [x] `pytest tests/ -k "weekly"` が 31 passed であること（確認済み）
- [x] `bin/weekly.sh` 実行後、Notion ページに週次サマリーが正常出力されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Switch weekly summary generation from the local Ollama pipeline to the shared Claude-based run_claude flow.

Bug Fixes:
- Ensure weekly summaries can handle larger weekly inputs by using a model with a sufficient context window.

Enhancements:
- Simplify weekly summary generation by removing injectable Ollama config/client dependencies and using a single Claude entry point.
- Log weekly summary generation without referencing local model details.

Tests:
- Update weekly summary handler tests to assert delegation to run_claude with the composed prompt and the weekly summary timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Weekly summary generation now uses an optimized backend service for improved processing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->