### PR TITLE
feat(api): add GET /api/usage endpoint serving JSONL log data

### DIFF
--- a/apps/python/tests/test_api_usage.py
+++ b/apps/python/tests/test_api_usage.py
@@ -1,0 +1,89 @@
+"""Tests for /api/usage — list available dates + per-day JSONL records.
+
+Contract (#225):
+- ``GET /api/usage/dates`` returns ``{"dates": [...]}`` (newest first).
+- ``GET /api/usage?date=YYYYMMDD`` returns ``{"date", "records": [...]}``.
+- Unknown / malformed date returns 404.
+- Auth is required (Bearer), same as other protected routers.
+"""
+import json
+
+import pytest
+
+from web.routers import usage as usage_router
+
+
+@pytest.fixture
+def usage_dir(tmp_path, monkeypatch):
+    """Point the usage router at a tmp log dir with two sample days."""
+    d = tmp_path / "usage"
+    d.mkdir()
+    day1 = d / "20260619-usage.jsonl"
+    day1.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-06-19T05:05:17",
+                "label": "メイン分析",
+                "input_tokens": 787,
+                "output_tokens": 4546,
+                "cache_read_tokens": 95729,
+                "cache_creation_tokens": 23308,
+                "cost_usd": 0.468,
+                "duration_ms": 113321,
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    day2 = d / "20260620-usage.jsonl"
+    day2.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-06-20T05:06:30",
+                "label": "セクタースイープ",
+                "input_tokens": 3445,
+                "output_tokens": 6061,
+                "cache_read_tokens": 165437,
+                "cache_creation_tokens": 33895,
+                "cost_usd": 0.827,
+                "duration_ms": 186627,
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(usage_router, "USAGE_DIR", d)
+    return d
+
+
+async def test_dates_requires_auth(async_client, usage_dir):
+    response = await async_client.get("/api/usage/dates")
+    assert response.status_code == 401
+
+
+async def test_list_dates_newest_first(authed_client, usage_dir):
+    response = await authed_client.get("/api/usage/dates")
+    assert response.status_code == 200
+    assert response.json()["dates"] == ["20260620", "20260619"]
+
+
+async def test_get_records_for_date(authed_client, usage_dir):
+    response = await authed_client.get("/api/usage?date=20260620")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["date"] == "20260620"
+    assert len(body["records"]) == 1
+    assert body["records"][0]["label"] == "セクタースイープ"
+    assert body["records"][0]["cost_usd"] == 0.827
+
+
+async def test_unknown_date_returns_404(authed_client, usage_dir):
+    response = await authed_client.get("/api/usage?date=20990101")
+    assert response.status_code == 404
+
+
+async def test_malformed_date_returns_404(authed_client, usage_dir):
+    response = await authed_client.get("/api/usage?date=not-a-date")
+    assert response.status_code == 404

--- a/apps/python/tests/test_api_usage.py
+++ b/apps/python/tests/test_api_usage.py
@@ -87,3 +87,9 @@ async def test_unknown_date_returns_404(authed_client, usage_dir):
 async def test_malformed_date_returns_404(authed_client, usage_dir):
     response = await authed_client.get("/api/usage?date=not-a-date")
     assert response.status_code == 404
+
+
+async def test_path_traversal_date_returns_404(authed_client, usage_dir):
+    # ``..`` / パス区切りを含む date はファイルに触れず 404 になること。
+    response = await authed_client.get("/api/usage?date=../../tmp/20260620")
+    assert response.status_code == 404

--- a/apps/python/web/app.py
+++ b/apps/python/web/app.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 
-from web.routers import auth_mode, chat, config, credentials, health, run, state
+from web.routers import auth_mode, chat, config, credentials, health, run, state, usage
 
 app = FastAPI(title="ai-agent Web API", version="0.1.0")
 app.include_router(health.router, prefix="/api")
@@ -10,3 +10,4 @@ app.include_router(auth_mode.router, prefix="/api")
 app.include_router(state.router, prefix="/api")
 app.include_router(run.router, prefix="/api")
 app.include_router(chat.router, prefix="/api")
+app.include_router(usage.router, prefix="/api")

--- a/apps/python/web/routers/usage.py
+++ b/apps/python/web/routers/usage.py
@@ -1,0 +1,69 @@
+"""GET /api/usage — トークン使用量ログ (log/usage/*.jsonl) の閲覧 API。
+
+ダッシュボード (Config > Usage) が日別の生レコードを取得して棒グラフに描画する。
+書き込み側は ``src.usage_logger``、CLI 集計は ``src.usage_report`` と同じ
+ファイル名規約 (``YYYYMMDD-usage.jsonl``) を共有する。
+"""
+import json
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from src.usage_logger import USAGE_DIR, parse_usage_file_date
+from web.auth import require_bearer
+
+router = APIRouter(dependencies=[Depends(require_bearer)])
+
+
+class UsageRecord(BaseModel):
+    timestamp: str
+    label: str
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
+    cost_usd: float | None = None
+    duration_ms: int | None = None
+
+
+class UsageDatesResponse(BaseModel):
+    dates: list[str]
+
+
+class UsageDayResponse(BaseModel):
+    date: str
+    records: list[UsageRecord]
+
+
+@router.get("/usage/dates", response_model=UsageDatesResponse)
+def list_dates() -> UsageDatesResponse:
+    """利用可能な ``YYYYMMDD`` を新しい順で返す。"""
+    if not USAGE_DIR.exists():
+        return UsageDatesResponse(dates=[])
+    dates = []
+    for path in USAGE_DIR.glob("*-usage.jsonl"):
+        file_date = parse_usage_file_date(path)
+        if file_date is not None:
+            dates.append(file_date.strftime("%Y%m%d"))
+    dates.sort(reverse=True)
+    return UsageDatesResponse(dates=dates)
+
+
+@router.get("/usage", response_model=UsageDayResponse)
+def get_usage(date: str = Query(..., description="YYYYMMDD")) -> UsageDayResponse:
+    """指定日の生レコードを配列で返す。存在しない / 不正な日付は 404。"""
+    log_file = USAGE_DIR / f"{date}-usage.jsonl"
+    if parse_usage_file_date(log_file) is None or not log_file.exists():
+        raise HTTPException(status_code=404, detail=f"No usage log for date: {date}")
+
+    records: list[UsageRecord] = []
+    with log_file.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(UsageRecord(**json.loads(line)))
+            except (json.JSONDecodeError, ValueError):
+                continue
+    return UsageDayResponse(date=date, records=records)

--- a/apps/python/web/routers/usage.py
+++ b/apps/python/web/routers/usage.py
@@ -5,14 +5,19 @@
 ファイル名規約 (``YYYYMMDD-usage.jsonl``) を共有する。
 """
 import json
+import re
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from src.usage_logger import USAGE_DIR, parse_usage_file_date
 from web.auth import require_bearer
 
 router = APIRouter(dependencies=[Depends(require_bearer)])
+
+# 厳格な YYYYMMDD のみ許可。``..`` やパス区切りを含む入力を
+# ファイルパス組み立て前に弾き、USAGE_DIR 外への脱出を防ぐ。
+_DATE_RE = re.compile(r"^\d{8}$")
 
 
 class UsageRecord(BaseModel):
@@ -52,6 +57,10 @@ def list_dates() -> UsageDatesResponse:
 @router.get("/usage", response_model=UsageDayResponse)
 def get_usage(date: str = Query(..., description="YYYYMMDD")) -> UsageDayResponse:
     """指定日の生レコードを配列で返す。存在しない / 不正な日付は 404。"""
+    # パス組み立て前に厳格検証。不正な date はファイルに触れず 404。
+    if not _DATE_RE.match(date):
+        raise HTTPException(status_code=404, detail=f"No usage log for date: {date}")
+
     log_file = USAGE_DIR / f"{date}-usage.jsonl"
     if parse_usage_file_date(log_file) is None or not log_file.exists():
         raise HTTPException(status_code=404, detail=f"No usage log for date: {date}")
@@ -62,8 +71,10 @@ def get_usage(date: str = Query(..., description="YYYYMMDD")) -> UsageDayRespons
             line = line.strip()
             if not line:
                 continue
+            # ValidationError は pydantic v2 で ValueError サブクラスだが、
+            # 明示しておき将来の挙動変化にも備える。不正行は読み飛ばす。
             try:
                 records.append(UsageRecord(**json.loads(line)))
-            except (json.JSONDecodeError, ValueError):
+            except (json.JSONDecodeError, ValidationError, ValueError):
                 continue
     return UsageDayResponse(date=date, records=records)


### PR DESCRIPTION
## Summary
- Add `usage` router: `GET /api/usage/dates` (dates newest-first) and `GET /api/usage?date=YYYYMMDD` (per-day records); unknown/malformed date → 404.
- Reuses `usage_logger` filename convention; Bearer-protected.

## Test plan
- [x] `pytest tests/test_api_usage.py` (5 passed)

Closes #225

## Summary by Sourcery

Add a protected API router for exposing per-day token usage logs and wire it into the main FastAPI application.

New Features:
- Expose GET /api/usage/dates to list available usage log dates in newest-first order.
- Expose GET /api/usage to return JSONL-derived usage records for a specified date using the existing usage logging file convention.

Tests:
- Add tests covering authentication requirements, date listing order, per-day record retrieval, and 404 handling for invalid or unknown dates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated API endpoints to list available usage dates and retrieve usage records by date.

* **Tests**
  * Added comprehensive end-to-end tests for the new usage API endpoints, including authentication verification and date-based query handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->