### PR TITLE
feat(web): add Usage menu item under Config in sidebar

### DIFF
--- a/apps/web/app/(main)/config/usage/page.tsx
+++ b/apps/web/app/(main)/config/usage/page.tsx
@@ -1,0 +1,20 @@
+export const dynamic = "force-dynamic"
+
+export default function UsagePage() {
+  return (
+    <div className="space-y-4">
+      <header>
+        <h2 className="text-xl font-semibold">Usage</h2>
+        <p className="text-sm text-muted-foreground">
+          Token usage and cost per Claude run, charted from the daily JSONL logs.
+        </p>
+      </header>
+      <div
+        data-testid="usage-dashboard-placeholder"
+        className="rounded-md border border-dashed p-8 text-center text-sm text-muted-foreground"
+      >
+        Usage dashboard coming soon.
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/Sidebar.tsx
+++ b/apps/web/components/Sidebar.tsx
@@ -131,6 +131,22 @@ export function Sidebar() {
           variant="heading"
         >
           <div className="flex flex-col gap-1">
+            <Link
+              href="/config/usage"
+              title="Usage"
+              aria-label="Usage"
+              data-sidebar-row
+              data-testid="nav-config-usage"
+              className={cn(
+                "flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors",
+                pathname === "/config/usage"
+                  ? "bg-accent font-medium text-accent-foreground"
+                  : "hover:bg-accent/50",
+              )}
+            >
+              <span aria-hidden>📈</span>
+              <span data-sidebar-label>Usage</span>
+            </Link>
             <SidebarDisclosure
               label="Appearance"
               icon="🎨"

--- a/apps/web/tests/sidebar.test.tsx
+++ b/apps/web/tests/sidebar.test.tsx
@@ -88,3 +88,15 @@ describe("Sidebar collapse", () => {
     })
   })
 })
+
+describe("Config > Usage nav", () => {
+  it("renders a Usage link to /config/usage with tooltip attributes", async () => {
+    const user = userEvent.setup()
+    renderSidebar()
+    await user.click(screen.getByTestId("config-toggle"))
+    const link = screen.getByTestId("nav-config-usage")
+    expect(link).toHaveAttribute("href", "/config/usage")
+    expect(link).toHaveAttribute("title", "Usage")
+    expect(link).toHaveAttribute("aria-label", "Usage")
+  })
+})


### PR DESCRIPTION
## Summary
- Add a "Usage" link under the Config section linking to `/config/usage`.
- Scaffold the `/config/usage` page (placeholder; chart lands in #226).

## Test plan
- [x] `vitest run tests/sidebar.test.tsx` (5 passed)
- [x] `eslint` clean

Closes #224

## Summary by Sourcery

Add a new Usage configuration page and expose it via the sidebar navigation.

New Features:
- Add a Usage link under the Config section in the sidebar that navigates to /config/usage.
- Introduce a new /config/usage page with a placeholder Usage dashboard layout.

Tests:
- Add sidebar navigation tests to verify the Config > Usage link target and accessibility attributes.