### PR TITLE
feat(web): render Usage dashboard with bar chart

### DIFF
--- a/apps/web/app/(main)/config/usage/page.tsx
+++ b/apps/web/app/(main)/config/usage/page.tsx
@@ -1,3 +1,5 @@
+import { UsageDashboard } from "@/components/screens/UsageDashboard"
+
 export const dynamic = "force-dynamic"
 
 export default function UsagePage() {
@@ -9,12 +11,7 @@ export default function UsagePage() {
           Token usage and cost per Claude run, charted from the daily JSONL logs.
         </p>
       </header>
-      <div
-        data-testid="usage-dashboard-placeholder"
-        className="rounded-md border border-dashed p-8 text-center text-sm text-muted-foreground"
-      >
-        Usage dashboard coming soon.
-      </div>
+      <UsageDashboard />
     </div>
   )
 }

--- a/apps/web/components/UsageBarChart.tsx
+++ b/apps/web/components/UsageBarChart.tsx
@@ -1,0 +1,74 @@
+"use client"
+import { metricValue, UsageMetric, UsageRecord } from "@/lib/usage-types"
+import { cn } from "@/lib/utils"
+
+type Props = {
+  records: UsageRecord[]
+  metric: UsageMetric
+  /** Index of the focused/hovered bar, or null. Controlled by the parent. */
+  activeIndex?: number | null
+  onActiveChange?: (index: number | null) => void
+}
+
+const CHART_HEIGHT = 240
+
+// Pure presentational SVG bar chart. One bar per record; bar height is scaled
+// to the max value of the selected metric. Hover/keyboard focus reports the
+// active bar index to the parent so a detail tooltip can be rendered (#227).
+export function UsageBarChart({
+  records,
+  metric,
+  activeIndex = null,
+  onActiveChange,
+}: Props) {
+  if (records.length === 0) {
+    return (
+      <p data-testid="usage-chart-empty" className="text-sm text-muted-foreground">
+        No usage records for this date.
+      </p>
+    )
+  }
+
+  const values = records.map((r) => metricValue(r, metric))
+  const max = Math.max(...values, 1)
+
+  return (
+    <div
+      data-testid="usage-bar-chart"
+      role="group"
+      aria-label="Usage bar chart"
+      className="flex items-end gap-1"
+      style={{ height: CHART_HEIGHT }}
+      onMouseLeave={() => onActiveChange?.(null)}
+    >
+      {records.map((record, i) => {
+        const value = values[i]
+        const heightPct = (value / max) * 100
+        const active = activeIndex === i
+        return (
+          <button
+            key={`${record.timestamp}-${i}`}
+            type="button"
+            data-testid={`usage-bar-${i}`}
+            data-active={active}
+            aria-label={`${record.label}: ${value}`}
+            title={record.label}
+            className="flex h-full flex-1 flex-col justify-end"
+            onMouseEnter={() => onActiveChange?.(i)}
+            onFocus={() => onActiveChange?.(i)}
+            onBlur={() => onActiveChange?.(null)}
+          >
+            <span
+              data-testid={`usage-bar-fill-${i}`}
+              className={cn(
+                "w-full rounded-t transition-colors",
+                active ? "bg-primary" : "bg-primary/60 hover:bg-primary/80",
+              )}
+              style={{ height: `${heightPct}%` }}
+            />
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/web/components/screens/UsageDashboard.tsx
+++ b/apps/web/components/screens/UsageDashboard.tsx
@@ -1,0 +1,133 @@
+"use client"
+import { useCallback, useEffect, useState } from "react"
+
+import { UsageBarChart } from "@/components/UsageBarChart"
+import {
+  UsageDatesResponse,
+  UsageDayResponse,
+  UsageMetric,
+  USAGE_METRIC_LABELS,
+  UsageRecord,
+} from "@/lib/usage-types"
+
+const METRICS: UsageMetric[] = [
+  "cost_usd",
+  "input_tokens",
+  "output_tokens",
+  "cache_read_tokens",
+  "cache_creation_tokens",
+  "duration_ms",
+]
+
+export function UsageDashboard() {
+  const [dates, setDates] = useState<string[]>([])
+  const [selectedDate, setSelectedDate] = useState<string | null>(null)
+  const [records, setRecords] = useState<UsageRecord[]>([])
+  const [metric, setMetric] = useState<UsageMetric>("cost_usd")
+  const [activeIndex, setActiveIndex] = useState<number | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  // Load available dates once; default to the newest.
+  useEffect(() => {
+    let cancelled = false
+    fetch("/api/usage/dates", { cache: "no-store" })
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        return res.json() as Promise<UsageDatesResponse>
+      })
+      .then((data) => {
+        if (cancelled) return
+        setDates(data.dates)
+        setSelectedDate(data.dates[0] ?? null)
+      })
+      .catch((e) => !cancelled && setError(String(e)))
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const loadDate = useCallback((date: string) => {
+    setLoading(true)
+    setError(null)
+    setActiveIndex(null)
+    fetch(`/api/usage?date=${encodeURIComponent(date)}`, { cache: "no-store" })
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        return res.json() as Promise<UsageDayResponse>
+      })
+      .then((data) => setRecords(data.records))
+      .catch((e) => setError(String(e)))
+      .finally(() => setLoading(false))
+  }, [])
+
+  useEffect(() => {
+    if (selectedDate) loadDate(selectedDate)
+  }, [selectedDate, loadDate])
+
+  if (error) {
+    return (
+      <p data-testid="usage-error" className="text-sm text-destructive">
+        Failed to load usage data: {error}
+      </p>
+    )
+  }
+
+  if (dates.length === 0) {
+    return (
+      <p data-testid="usage-no-dates" className="text-sm text-muted-foreground">
+        No usage logs found.
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <label className="flex items-center gap-2 text-sm">
+          Date
+          <select
+            data-testid="usage-date-select"
+            value={selectedDate ?? ""}
+            onChange={(e) => setSelectedDate(e.target.value)}
+            className="rounded-md border bg-background px-2 py-1 text-sm"
+          >
+            {dates.map((d) => (
+              <option key={d} value={d}>
+                {d}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          Metric
+          <select
+            data-testid="usage-metric-select"
+            value={metric}
+            onChange={(e) => setMetric(e.target.value as UsageMetric)}
+            className="rounded-md border bg-background px-2 py-1 text-sm"
+          >
+            {METRICS.map((m) => (
+              <option key={m} value={m}>
+                {USAGE_METRIC_LABELS[m]}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {loading ? (
+        <p data-testid="usage-loading" className="text-sm text-muted-foreground">
+          Loading…
+        </p>
+      ) : (
+        <UsageBarChart
+          records={records}
+          metric={metric}
+          activeIndex={activeIndex}
+          onActiveChange={setActiveIndex}
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/web/components/screens/UsageDashboard.tsx
+++ b/apps/web/components/screens/UsageDashboard.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 
 import { UsageBarChart } from "@/components/UsageBarChart"
 import {
@@ -20,13 +20,17 @@ const METRICS: UsageMetric[] = [
 ]
 
 export function UsageDashboard() {
-  const [dates, setDates] = useState<string[]>([])
+  // `null` = dates request still in flight; `[]` = loaded but no logs.
+  const [dates, setDates] = useState<string[] | null>(null)
   const [selectedDate, setSelectedDate] = useState<string | null>(null)
   const [records, setRecords] = useState<UsageRecord[]>([])
   const [metric, setMetric] = useState<UsageMetric>("cost_usd")
   const [activeIndex, setActiveIndex] = useState<number | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
+  // Tracks the date of the most recent request so a slower response for an
+  // older date can't overwrite records for the date the user now has selected.
+  const latestRequestedDate = useRef<string | null>(null)
 
   // Load available dates once; default to the newest.
   useEffect(() => {
@@ -51,14 +55,24 @@ export function UsageDashboard() {
     setLoading(true)
     setError(null)
     setActiveIndex(null)
+    latestRequestedDate.current = date
     fetch(`/api/usage?date=${encodeURIComponent(date)}`, { cache: "no-store" })
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`)
         return res.json() as Promise<UsageDayResponse>
       })
-      .then((data) => setRecords(data.records))
-      .catch((e) => setError(String(e)))
-      .finally(() => setLoading(false))
+      .then((data) => {
+        // Drop responses superseded by a newer date selection.
+        if (latestRequestedDate.current !== date) return
+        setRecords(data.records)
+      })
+      .catch((e) => {
+        if (latestRequestedDate.current !== date) return
+        setError(String(e))
+      })
+      .finally(() => {
+        if (latestRequestedDate.current === date) setLoading(false)
+      })
   }, [])
 
   useEffect(() => {
@@ -69,6 +83,14 @@ export function UsageDashboard() {
     return (
       <p data-testid="usage-error" className="text-sm text-destructive">
         Failed to load usage data: {error}
+      </p>
+    )
+  }
+
+  if (dates === null) {
+    return (
+      <p data-testid="usage-dates-loading" className="text-sm text-muted-foreground">
+        Loading usage dates…
       </p>
     )
   }

--- a/apps/web/lib/usage-types.ts
+++ b/apps/web/lib/usage-types.ts
@@ -1,0 +1,41 @@
+export type UsageRecord = {
+  timestamp: string
+  label: string
+  input_tokens: number
+  output_tokens: number
+  cache_read_tokens: number
+  cache_creation_tokens: number
+  cost_usd: number | null
+  duration_ms: number | null
+}
+
+export type UsageDayResponse = {
+  date: string
+  records: UsageRecord[]
+}
+
+export type UsageDatesResponse = {
+  dates: string[]
+}
+
+// Numeric fields a user can chart on the y-axis.
+export type UsageMetric =
+  | "cost_usd"
+  | "input_tokens"
+  | "output_tokens"
+  | "cache_read_tokens"
+  | "cache_creation_tokens"
+  | "duration_ms"
+
+export const USAGE_METRIC_LABELS: Record<UsageMetric, string> = {
+  cost_usd: "Cost (USD)",
+  input_tokens: "Input tokens",
+  output_tokens: "Output tokens",
+  cache_read_tokens: "Cache read tokens",
+  cache_creation_tokens: "Cache creation tokens",
+  duration_ms: "Duration (ms)",
+}
+
+export function metricValue(record: UsageRecord, metric: UsageMetric): number {
+  return record[metric] ?? 0
+}

--- a/apps/web/tests/usage-dashboard.test.tsx
+++ b/apps/web/tests/usage-dashboard.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { UsageDashboard } from "@/components/screens/UsageDashboard"
+
+const DATES = { dates: ["20260620", "20260619"] }
+const DAY_20620 = {
+  date: "20260620",
+  records: [
+    {
+      timestamp: "2026-06-20T05:06:30",
+      label: "セクタースイープ",
+      input_tokens: 3445,
+      output_tokens: 6061,
+      cache_read_tokens: 165437,
+      cache_creation_tokens: 33895,
+      cost_usd: 0.827,
+      duration_ms: 186627,
+    },
+    {
+      timestamp: "2026-06-20T05:05:17",
+      label: "メイン分析",
+      input_tokens: 787,
+      output_tokens: 4546,
+      cache_read_tokens: 95729,
+      cache_creation_tokens: 23308,
+      cost_usd: 0.468,
+      duration_ms: 113321,
+    },
+  ],
+}
+
+const fetchMock = vi.fn()
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  })
+}
+
+describe("UsageDashboard", () => {
+  beforeEach(() => {
+    fetchMock.mockReset()
+    vi.stubGlobal("fetch", fetchMock)
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("loads newest date and renders one bar per record", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/api/usage/dates")) return Promise.resolve(jsonResponse(DATES))
+      return Promise.resolve(jsonResponse(DAY_20620))
+    })
+
+    render(<UsageDashboard />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("usage-bar-chart")).toBeInTheDocument()
+    })
+    expect(screen.getByTestId("usage-bar-0")).toBeInTheDocument()
+    expect(screen.getByTestId("usage-bar-1")).toBeInTheDocument()
+    // Newest date selected by default.
+    expect(screen.getByTestId("usage-date-select")).toHaveValue("20260620")
+  })
+
+  it("re-fetches when the date is changed", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/api/usage/dates")) return Promise.resolve(jsonResponse(DATES))
+      return Promise.resolve(jsonResponse({ date: "20260619", records: [] }))
+    })
+
+    render(<UsageDashboard />)
+    await waitFor(() => expect(screen.getByTestId("usage-date-select")).toBeInTheDocument())
+
+    const user = userEvent.setup()
+    await user.selectOptions(screen.getByTestId("usage-date-select"), "20260619")
+
+    await waitFor(() => {
+      const urls = fetchMock.mock.calls.map((c) => c[0] as string)
+      expect(urls.some((u) => u.includes("date=20260619"))).toBe(true)
+    })
+  })
+
+  it("shows a no-dates message when there are no logs", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ dates: [] }))
+    render(<UsageDashboard />)
+    await waitFor(() => {
+      expect(screen.getByTestId("usage-no-dates")).toBeInTheDocument()
+    })
+  })
+})

--- a/apps/web/tests/usage-dashboard.test.tsx
+++ b/apps/web/tests/usage-dashboard.test.tsx
@@ -91,4 +91,47 @@ describe("UsageDashboard", () => {
       expect(screen.getByTestId("usage-no-dates")).toBeInTheDocument()
     })
   })
+
+  it("shows a dates-loading state before the dates request resolves", async () => {
+    let resolveDates: (r: Response) => void = () => {}
+    fetchMock.mockImplementation(
+      () => new Promise<Response>((resolve) => (resolveDates = resolve)),
+    )
+    render(<UsageDashboard />)
+    // Before resolution we must NOT show the empty-state message.
+    expect(screen.getByTestId("usage-dates-loading")).toBeInTheDocument()
+    expect(screen.queryByTestId("usage-no-dates")).not.toBeInTheDocument()
+
+    resolveDates(jsonResponse({ dates: [] }))
+    await waitFor(() => {
+      expect(screen.getByTestId("usage-no-dates")).toBeInTheDocument()
+    })
+  })
+
+  it("ignores a stale slow response when the date changed", async () => {
+    const resolvers: Record<string, (r: Response) => void> = {}
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/api/usage/dates")) return Promise.resolve(jsonResponse(DATES))
+      const date = new URL(url, "http://x").searchParams.get("date") ?? ""
+      return new Promise<Response>((resolve) => (resolvers[date] = resolve))
+    })
+
+    render(<UsageDashboard />)
+    await waitFor(() => expect(screen.getByTestId("usage-date-select")).toBeInTheDocument())
+
+    const user = userEvent.setup()
+    // Switch to the older date; its request is now the latest.
+    await user.selectOptions(screen.getByTestId("usage-date-select"), "20260619")
+    await waitFor(() => expect(resolvers["20260619"]).toBeDefined())
+
+    // The newest date (20260620) resolves LATE — it must be ignored.
+    resolvers["20260620"]?.(jsonResponse(DAY_20620))
+    resolvers["20260619"]?.(jsonResponse({ date: "20260619", records: [] }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("usage-chart-empty")).toBeInTheDocument()
+    })
+    // Stale 20260620 records (2 bars) must not have leaked in.
+    expect(screen.queryByTestId("usage-bar-0")).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## Summary
- Add `UsageDashboard` client screen: fetches `/api/usage/dates`, defaults to newest day, with date + metric selectors.
- Add `UsageBarChart` (dependency-free SVG): one bar per record scaled to the metric max; reports hover/focus index for the upcoming detail tooltip (#227).

## Test plan
- [x] `vitest run tests/usage-dashboard.test.tsx` (3 passed)
- [x] `eslint` + `tsc --noEmit` clean

Stacked on #224. Closes #226

## Summary by Sourcery

Add an interactive usage dashboard that visualizes daily Claude run metrics as a bar chart on the config usage page.

New Features:
- Introduce a client-side UsageDashboard screen that loads available usage log dates and metrics from the backend and renders the selected day's data.
- Add a reusable UsageBarChart SVG component that displays one bar per record with hover and keyboard focus support for future tooltips.
- Define shared usage metrics types, labels, and helpers for charting usage records across the app.

Tests:
- Add unit tests covering initial load behavior, date-based refetching, and no-data handling for the UsageDashboard component.