### PR TITLE
feat(web): show key/value detail tooltip on bar chart focus

### DIFF
--- a/apps/web/components/UsageBarChart.tsx
+++ b/apps/web/components/UsageBarChart.tsx
@@ -68,7 +68,13 @@ export function UsageBarChart({
             className="flex h-full flex-1 flex-col justify-end"
             onMouseEnter={() => onActiveChange?.(i)}
             onFocus={() => onActiveChange?.(i)}
-            onBlur={() => onActiveChange?.(null)}
+            onBlur={(e) => {
+              // Keep the active state when focus moves to another bar (arrow
+              // keys), so we don't flicker to null + re-announce via aria-live.
+              const next = e.relatedTarget as Node | null
+              if (next && e.currentTarget.parentElement?.contains(next)) return
+              onActiveChange?.(null)
+            }}
             onKeyDown={(e) => {
               if (e.key === "ArrowRight") {
                 e.preventDefault()

--- a/apps/web/components/UsageBarChart.tsx
+++ b/apps/web/components/UsageBarChart.tsx
@@ -1,4 +1,6 @@
 "use client"
+import { useRef } from "react"
+
 import { metricValue, UsageMetric, UsageRecord } from "@/lib/usage-types"
 import { cn } from "@/lib/utils"
 
@@ -21,6 +23,8 @@ export function UsageBarChart({
   activeIndex = null,
   onActiveChange,
 }: Props) {
+  const barRefs = useRef<(HTMLButtonElement | null)[]>([])
+
   if (records.length === 0) {
     return (
       <p data-testid="usage-chart-empty" className="text-sm text-muted-foreground">
@@ -31,6 +35,11 @@ export function UsageBarChart({
 
   const values = records.map((r) => metricValue(r, metric))
   const max = Math.max(...values, 1)
+
+  const focusBar = (index: number) => {
+    const clamped = Math.max(0, Math.min(records.length - 1, index))
+    barRefs.current[clamped]?.focus()
+  }
 
   return (
     <div
@@ -48,6 +57,9 @@ export function UsageBarChart({
         return (
           <button
             key={`${record.timestamp}-${i}`}
+            ref={(el) => {
+              barRefs.current[i] = el
+            }}
             type="button"
             data-testid={`usage-bar-${i}`}
             data-active={active}
@@ -57,6 +69,15 @@ export function UsageBarChart({
             onMouseEnter={() => onActiveChange?.(i)}
             onFocus={() => onActiveChange?.(i)}
             onBlur={() => onActiveChange?.(null)}
+            onKeyDown={(e) => {
+              if (e.key === "ArrowRight") {
+                e.preventDefault()
+                focusBar(i + 1)
+              } else if (e.key === "ArrowLeft") {
+                e.preventDefault()
+                focusBar(i - 1)
+              }
+            }}
           >
             <span
               data-testid={`usage-bar-fill-${i}`}

--- a/apps/web/components/screens/UsageDashboard.tsx
+++ b/apps/web/components/screens/UsageDashboard.tsx
@@ -7,6 +7,8 @@ import {
   UsageDatesResponse,
   UsageDayResponse,
   UsageMetric,
+  USAGE_FIELD_LABELS,
+  USAGE_FIELD_ORDER,
   USAGE_METRIC_LABELS,
   UsageRecord,
 } from "@/lib/usage-types"
@@ -161,9 +163,9 @@ export function UsageDashboard() {
           aria-live="polite"
           className="grid grid-cols-2 gap-x-4 gap-y-1 rounded-md border p-3 text-sm sm:grid-cols-3"
         >
-          {(Object.keys(activeRecord) as (keyof UsageRecord)[]).map((key) => (
+          {USAGE_FIELD_ORDER.map((key) => (
             <div key={key} className="flex justify-between gap-2">
-              <dt className="text-muted-foreground">{key}</dt>
+              <dt className="text-muted-foreground">{USAGE_FIELD_LABELS[key]}</dt>
               <dd className="font-medium">
                 {formatUsageField(key, activeRecord[key])}
               </dd>

--- a/apps/web/components/screens/UsageDashboard.tsx
+++ b/apps/web/components/screens/UsageDashboard.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react"
 
 import { UsageBarChart } from "@/components/UsageBarChart"
 import {
+  formatUsageField,
   UsageDatesResponse,
   UsageDayResponse,
   UsageMetric,
@@ -103,6 +104,8 @@ export function UsageDashboard() {
     )
   }
 
+  const activeRecord = activeIndex !== null ? records[activeIndex] : null
+
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center gap-3">
@@ -149,6 +152,28 @@ export function UsageDashboard() {
           activeIndex={activeIndex}
           onActiveChange={setActiveIndex}
         />
+      )}
+
+      {activeRecord ? (
+        <dl
+          data-testid="usage-detail"
+          role="status"
+          aria-live="polite"
+          className="grid grid-cols-2 gap-x-4 gap-y-1 rounded-md border p-3 text-sm sm:grid-cols-3"
+        >
+          {(Object.keys(activeRecord) as (keyof UsageRecord)[]).map((key) => (
+            <div key={key} className="flex justify-between gap-2">
+              <dt className="text-muted-foreground">{key}</dt>
+              <dd className="font-medium">
+                {formatUsageField(key, activeRecord[key])}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      ) : (
+        <p data-testid="usage-detail-hint" className="text-sm text-muted-foreground">
+          Hover or focus a bar to see its details.
+        </p>
       )}
     </div>
   )

--- a/apps/web/lib/usage-types.ts
+++ b/apps/web/lib/usage-types.ts
@@ -39,3 +39,19 @@ export const USAGE_METRIC_LABELS: Record<UsageMetric, string> = {
 export function metricValue(record: UsageRecord, metric: UsageMetric): number {
   return record[metric] ?? 0
 }
+
+// Human-readable rendering of a record field for the detail tooltip:
+// cost as currency, duration in seconds, token counts grouped with commas.
+export function formatUsageField(key: keyof UsageRecord, value: unknown): string {
+  if (value === null || value === undefined) return "—"
+  if (key === "cost_usd" && typeof value === "number") {
+    return `$${value.toFixed(4)}`
+  }
+  if (key === "duration_ms" && typeof value === "number") {
+    return `${(value / 1000).toFixed(1)}s`
+  }
+  if (typeof value === "number") {
+    return value.toLocaleString("en-US")
+  }
+  return String(value)
+}

--- a/apps/web/lib/usage-types.ts
+++ b/apps/web/lib/usage-types.ts
@@ -40,18 +40,46 @@ export function metricValue(record: UsageRecord, metric: UsageMetric): number {
   return record[metric] ?? 0
 }
 
+// Human-readable labels for the detail panel, in a fixed display order so the
+// tooltip is predictable regardless of JSON key order.
+export const USAGE_FIELD_LABELS: Record<keyof UsageRecord, string> = {
+  timestamp: "Timestamp",
+  label: "Label",
+  cost_usd: "Cost (USD)",
+  input_tokens: "Input tokens",
+  output_tokens: "Output tokens",
+  cache_read_tokens: "Cache read tokens",
+  cache_creation_tokens: "Cache creation tokens",
+  duration_ms: "Duration",
+}
+
+export const USAGE_FIELD_ORDER = Object.keys(
+  USAGE_FIELD_LABELS,
+) as (keyof UsageRecord)[]
+
+const _currencyFmt = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 4,
+  maximumFractionDigits: 4,
+})
+const _numberFmt = new Intl.NumberFormat("en-US")
+
 // Human-readable rendering of a record field for the detail tooltip:
 // cost as currency, duration in seconds, token counts grouped with commas.
-export function formatUsageField(key: keyof UsageRecord, value: unknown): string {
+export function formatUsageField<K extends keyof UsageRecord>(
+  key: K,
+  value: UsageRecord[K],
+): string {
   if (value === null || value === undefined) return "—"
   if (key === "cost_usd" && typeof value === "number") {
-    return `$${value.toFixed(4)}`
+    return _currencyFmt.format(value)
   }
   if (key === "duration_ms" && typeof value === "number") {
     return `${(value / 1000).toFixed(1)}s`
   }
   if (typeof value === "number") {
-    return value.toLocaleString("en-US")
+    return _numberFmt.format(value)
   }
   return String(value)
 }

--- a/apps/web/tests/usage-dashboard.test.tsx
+++ b/apps/web/tests/usage-dashboard.test.tsx
@@ -84,6 +84,41 @@ describe("UsageDashboard", () => {
     })
   })
 
+  it("shows formatted key/value detail when a bar is hovered", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/api/usage/dates")) return Promise.resolve(jsonResponse(DATES))
+      return Promise.resolve(jsonResponse(DAY_20620))
+    })
+
+    render(<UsageDashboard />)
+    await waitFor(() => expect(screen.getByTestId("usage-bar-0")).toBeInTheDocument())
+
+    const user = userEvent.setup()
+    await user.hover(screen.getByTestId("usage-bar-0"))
+
+    const detail = await screen.findByTestId("usage-detail")
+    expect(detail).toHaveTextContent("セクタースイープ")
+    expect(detail).toHaveTextContent("$0.8270") // cost formatted as currency
+    expect(detail).toHaveTextContent("186.6s") // duration formatted in seconds
+  })
+
+  it("moves focus between bars with arrow keys", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/api/usage/dates")) return Promise.resolve(jsonResponse(DATES))
+      return Promise.resolve(jsonResponse(DAY_20620))
+    })
+
+    render(<UsageDashboard />)
+    await waitFor(() => expect(screen.getByTestId("usage-bar-0")).toBeInTheDocument())
+
+    const user = userEvent.setup()
+    screen.getByTestId("usage-bar-0").focus()
+    await user.keyboard("{ArrowRight}")
+    expect(screen.getByTestId("usage-bar-1")).toHaveFocus()
+    await user.keyboard("{ArrowLeft}")
+    expect(screen.getByTestId("usage-bar-0")).toHaveFocus()
+  })
+
   it("shows a no-dates message when there are no logs", async () => {
     fetchMock.mockResolvedValue(jsonResponse({ dates: [] }))
     render(<UsageDashboard />)

--- a/apps/web/tests/usage-dashboard.test.tsx
+++ b/apps/web/tests/usage-dashboard.test.tsx
@@ -119,6 +119,23 @@ describe("UsageDashboard", () => {
     expect(screen.getByTestId("usage-bar-0")).toHaveFocus()
   })
 
+  it("keeps the detail panel visible while arrow-navigating between bars", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/api/usage/dates")) return Promise.resolve(jsonResponse(DATES))
+      return Promise.resolve(jsonResponse(DAY_20620))
+    })
+
+    render(<UsageDashboard />)
+    await waitFor(() => expect(screen.getByTestId("usage-bar-0")).toBeInTheDocument())
+
+    const user = userEvent.setup()
+    screen.getByTestId("usage-bar-0").focus()
+    expect(await screen.findByTestId("usage-detail")).toHaveTextContent("セクタースイープ")
+    await user.keyboard("{ArrowRight}")
+    // Panel stays mounted and now reflects the second record.
+    expect(screen.getByTestId("usage-detail")).toHaveTextContent("メイン分析")
+  })
+
   it("shows a no-dates message when there are no logs", async () => {
     fetchMock.mockResolvedValue(jsonResponse({ dates: [] }))
     render(<UsageDashboard />)

--- a/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,0 +1,1 @@
+{"version":"4.1.9","results":[[":apps/web/tests/usage-dashboard.test.tsx",{"duration":0,"failed":true}]]}

--- a/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,1 +1,0 @@
-{"version":"4.1.9","results":[[":apps/web/tests/usage-dashboard.test.tsx",{"duration":0,"failed":true}]]}


### PR DESCRIPTION
## Summary
- Render an ordered key/value detail panel for the hovered/focused bar with human-readable formatting (Intl currency/decimal, duration in seconds).
- ArrowLeft/ArrowRight keyboard navigation between bars; `onBlur` keeps the active bar when focus moves to a sibling (no aria-live flicker).
- `formatUsageField` is generic over `keyof UsageRecord`.

## Test plan
- [x] `vitest run tests/usage-dashboard.test.tsx` (8 passed)
- [x] `eslint` + `tsc --noEmit` clean

Recreated from #232 (auto-closed when its base branch was deleted on merge). Rebased onto `dev`. Closes #227

## Summary by Sourcery

Add an accessible bar chart detail tooltip with keyboard navigation and human-readable formatting for usage records.

New Features:
- Show a key/value detail panel for the active usage bar with ordered, human-readable fields.
- Enable left/right arrow key navigation between bars in the usage bar chart while preserving the active state and detail panel.

Enhancements:
- Introduce shared usage field labels, ordering, and formatting helpers for consistent display of usage record data.

Tests:
- Extend UsageDashboard tests to cover detail panel rendering, formatting, keyboard navigation, and focus behavior.