### PR TITLE
chore: ignore node_modules and remove committed vitest cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ htmlcov/
 
 # Local LLM RAG persistent store
 apps/python/.chroma_db/
+
+# Dependencies / build caches (never commit)
+/node_modules
+apps/*/node_modules

--- a/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,1 +1,0 @@
-{"version":"4.1.9","results":[[":apps/web/tests/usage-dashboard.test.tsx",{"duration":0,"failed":true}]]}


### PR DESCRIPTION
## Summary
- Root `.gitignore` did not ignore `node_modules`, so a vitest cache file got committed (`node_modules/.vite/.../results.json`).
- Add `/node_modules` + `apps/*/node_modules` to `.gitignore` and untrack the stray file.

## Test plan
- [x] `git ls-files | grep node_modules` returns nothing after this change

## Summary by Sourcery

Update repository ignore rules to prevent committing node_modules artifacts and remove an already committed Vitest cache file.

Chores:
- Add node_modules and app-specific node_modules directories to the root .gitignore.
- Delete previously committed Vitest cache file under node_modules/.vite.