### PR TITLE
feat(web): add daily summary line chart to Usage dashboard

### DIFF
--- a/apps/python/tests/test_api_usage.py
+++ b/apps/python/tests/test_api_usage.py
@@ -79,6 +79,22 @@ async def test_get_records_for_date(authed_client, usage_dir):
     assert body["records"][0]["cost_usd"] == 0.827
 
 
+async def test_summary_requires_auth(async_client, usage_dir):
+    response = await async_client.get("/api/usage/summary")
+    assert response.status_code == 401
+
+
+async def test_summary_aggregates_per_day_oldest_first(authed_client, usage_dir):
+    response = await authed_client.get("/api/usage/summary")
+    assert response.status_code == 200
+    summary = response.json()["summary"]
+    assert [s["date"] for s in summary] == ["2026-06-19", "2026-06-20"]
+    day = summary[1]
+    assert day["calls"] == 1
+    assert day["output_tokens"] == 6061
+    assert day["cost_usd"] == 0.827
+
+
 async def test_unknown_date_returns_404(authed_client, usage_dir):
     response = await authed_client.get("/api/usage?date=20990101")
     assert response.status_code == 404

--- a/apps/python/web/routers/usage.py
+++ b/apps/python/web/routers/usage.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, ValidationError
 
 from src.usage_logger import USAGE_DIR, parse_usage_file_date
+from src.usage_report import build_summary
 from web.auth import require_bearer
 
 router = APIRouter(dependencies=[Depends(require_bearer)])
@@ -40,6 +41,22 @@ class UsageDayResponse(BaseModel):
     records: list[UsageRecord]
 
 
+class UsageDailySummary(BaseModel):
+    """1 日分の全 run を合算した集計 (折れ線グラフ用)。"""
+
+    date: str  # ISO ``YYYY-MM-DD``
+    calls: int
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    cache_creation_tokens: int
+    cost_usd: float
+
+
+class UsageSummaryResponse(BaseModel):
+    summary: list[UsageDailySummary]
+
+
 @router.get("/usage/dates", response_model=UsageDatesResponse)
 def list_dates() -> UsageDatesResponse:
     """利用可能な ``YYYYMMDD`` を新しい順で返す。"""
@@ -52,6 +69,41 @@ def list_dates() -> UsageDatesResponse:
             dates.append(file_date.strftime("%Y%m%d"))
     dates.sort(reverse=True)
     return UsageDatesResponse(dates=dates)
+
+
+@router.get("/usage/summary", response_model=UsageSummaryResponse)
+def get_summary() -> UsageSummaryResponse:
+    """日別の全 run 合算を古い順 (時系列) で返す。
+
+    ``usage_report.build_summary`` は ``(day, label)`` 単位なので、ここで
+    ``day`` 単位に畳み込み直す。
+    """
+    if not USAGE_DIR.exists():
+        return UsageSummaryResponse(summary=[])
+
+    per_day: dict[str, UsageDailySummary] = {}
+    for (day, _label), agg in build_summary(USAGE_DIR, days=None).items():
+        entry = per_day.get(day)
+        if entry is None:
+            entry = UsageDailySummary(
+                date=day,
+                calls=0,
+                input_tokens=0,
+                output_tokens=0,
+                cache_read_tokens=0,
+                cache_creation_tokens=0,
+                cost_usd=0.0,
+            )
+            per_day[day] = entry
+        entry.calls += agg["calls"]
+        entry.input_tokens += agg["input_tokens"]
+        entry.output_tokens += agg["output_tokens"]
+        entry.cache_read_tokens += agg["cache_read_tokens"]
+        entry.cache_creation_tokens += agg["cache_creation_tokens"]
+        entry.cost_usd += agg["cost_usd"]
+
+    summary = sorted(per_day.values(), key=lambda s: s.date)
+    return UsageSummaryResponse(summary=summary)
 
 
 @router.get("/usage", response_model=UsageDayResponse)

--- a/apps/web/components/UsageTrendChart.tsx
+++ b/apps/web/components/UsageTrendChart.tsx
@@ -1,0 +1,134 @@
+"use client"
+import { useId } from "react"
+
+import {
+  niceScale,
+  summaryMetricValue,
+  UsageDailySummary,
+  UsageMetric,
+} from "@/lib/usage-types"
+
+type Props = {
+  summary: UsageDailySummary[]
+  metric: UsageMetric
+}
+
+const CHART_HEIGHT = 200
+const Y_AXIS_WIDTH = 48
+const PLOT_PADDING = 8
+
+function formatTick(value: number): string {
+  return Number(value.toFixed(4)).toLocaleString("en-US")
+}
+
+// Dependency-free SVG line chart of per-day totals, styled to match
+// UsageBarChart (axis frame + nice gridlines). One point per day.
+export function UsageTrendChart({ summary, metric }: Props) {
+  const gradientId = useId()
+
+  if (summary.length === 0) {
+    return (
+      <p data-testid="usage-trend-empty" className="text-sm text-muted-foreground">
+        No daily summary available yet.
+      </p>
+    )
+  }
+
+  const values = summary.map((d) => summaryMetricValue(d, metric))
+  const max = Math.max(...values, 1)
+  const { niceMax, ticks } = niceScale(max)
+
+  // Single-point series can't form a line; render points only.
+  const n = summary.length
+  const xFor = (i: number) =>
+    n === 1 ? 50 : PLOT_PADDING + (i / (n - 1)) * (100 - 2 * PLOT_PADDING)
+  const yFor = (v: number) => (1 - v / niceMax) * 100
+
+  const points = values.map((v, i) => ({ x: xFor(i), y: yFor(v), v, day: summary[i].date }))
+  const linePath = points.map((p, i) => `${i === 0 ? "M" : "L"} ${p.x} ${p.y}`).join(" ")
+
+  return (
+    <div
+      data-testid="usage-trend-chart"
+      role="group"
+      aria-label="Usage daily trend chart"
+      className="flex"
+    >
+      {/* Y-axis tick labels (visual only; values are in the title tooltips). */}
+      <div
+        aria-hidden
+        className="relative shrink-0"
+        style={{ height: CHART_HEIGHT, width: Y_AXIS_WIDTH }}
+      >
+        {ticks.map((t) => (
+          <span
+            key={t}
+            className="absolute right-2 -translate-y-1/2 text-[11px] tabular-nums text-muted-foreground"
+            style={{ bottom: `${(t / niceMax) * 100}%` }}
+          >
+            {formatTick(t)}
+          </span>
+        ))}
+      </div>
+
+      <div
+        data-testid="usage-trend-plot"
+        className="relative flex-1 border-b border-l border-border"
+        style={{ height: CHART_HEIGHT }}
+      >
+        {ticks.map((t) =>
+          t === 0 ? null : (
+            <div
+              key={t}
+              aria-hidden
+              className="pointer-events-none absolute inset-x-0 border-t border-muted-foreground/60"
+              style={{ bottom: `${(t / niceMax) * 100}%` }}
+            />
+          ),
+        )}
+
+        <svg
+          className="absolute inset-0 h-full w-full overflow-visible"
+          viewBox="0 0 100 100"
+          preserveAspectRatio="none"
+          aria-hidden
+        >
+          <defs>
+            <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="rgb(37 99 235)" stopOpacity="0.3" />
+              <stop offset="100%" stopColor="rgb(37 99 235)" stopOpacity="0" />
+            </linearGradient>
+          </defs>
+          {n > 1 && (
+            <path
+              d={`${linePath} L ${points[n - 1].x} 100 L ${points[0].x} 100 Z`}
+              fill={`url(#${gradientId})`}
+              stroke="none"
+            />
+          )}
+          {n > 1 && (
+            <path
+              data-testid="usage-trend-line"
+              d={linePath}
+              fill="none"
+              stroke="rgb(37 99 235)"
+              strokeWidth={1.5}
+              vectorEffect="non-scaling-stroke"
+            />
+          )}
+        </svg>
+
+        {/* Point markers as positioned dots, with a native tooltip per day. */}
+        {points.map((p, i) => (
+          <span
+            key={p.day}
+            data-testid={`usage-trend-point-${i}`}
+            title={`${p.day}: ${formatTick(p.v)}`}
+            className="absolute h-2 w-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-blue-600"
+            style={{ left: `${p.x}%`, top: `${p.y}%` }}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/screens/UsageDashboard.tsx
+++ b/apps/web/components/screens/UsageDashboard.tsx
@@ -2,8 +2,10 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 
 import { UsageBarChart } from "@/components/UsageBarChart"
+import { UsageTrendChart } from "@/components/UsageTrendChart"
 import {
   formatUsageField,
+  UsageDailySummary,
   UsageDatesResponse,
   UsageDayResponse,
   UsageMetric,
@@ -11,6 +13,7 @@ import {
   USAGE_FIELD_ORDER,
   USAGE_METRIC_LABELS,
   UsageRecord,
+  UsageSummaryResponse,
 } from "@/lib/usage-types"
 
 const METRICS: UsageMetric[] = [
@@ -28,6 +31,7 @@ export function UsageDashboard() {
   const [selectedDate, setSelectedDate] = useState<string | null>(null)
   const [records, setRecords] = useState<UsageRecord[]>([])
   const [metric, setMetric] = useState<UsageMetric>("cost_usd")
+  const [summary, setSummary] = useState<UsageDailySummary[]>([])
   const [activeIndex, setActiveIndex] = useState<number | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
@@ -49,6 +53,14 @@ export function UsageDashboard() {
         setSelectedDate(data.dates[0] ?? null)
       })
       .catch((e) => !cancelled && setError(String(e)))
+    // Daily summary for the trend chart; failure here is non-fatal (the
+    // per-day bar chart still works), so we only log it.
+    fetch("/api/usage/summary", { cache: "no-store" })
+      .then((res) => (res.ok ? (res.json() as Promise<UsageSummaryResponse>) : null))
+      .then((data) => {
+        if (!cancelled && Array.isArray(data?.summary)) setSummary(data.summary)
+      })
+      .catch(() => {})
     return () => {
       cancelled = true
     }
@@ -143,17 +155,31 @@ export function UsageDashboard() {
         </label>
       </div>
 
-      {loading ? (
-        <p data-testid="usage-loading" className="text-sm text-muted-foreground">
-          Loading…
-        </p>
-      ) : (
-        <UsageBarChart
-          records={records}
-          metric={metric}
-          activeIndex={activeIndex}
-          onActiveChange={setActiveIndex}
-        />
+      <section className="space-y-1">
+        <h3 className="text-sm font-medium text-muted-foreground">
+          Per run — {USAGE_METRIC_LABELS[metric]}
+        </h3>
+        {loading ? (
+          <p data-testid="usage-loading" className="text-sm text-muted-foreground">
+            Loading…
+          </p>
+        ) : (
+          <UsageBarChart
+            records={records}
+            metric={metric}
+            activeIndex={activeIndex}
+            onActiveChange={setActiveIndex}
+          />
+        )}
+      </section>
+
+      {summary.length > 0 && (
+        <section className="space-y-1">
+          <h3 className="text-sm font-medium text-muted-foreground">
+            Daily trend — {USAGE_METRIC_LABELS[metric]}
+          </h3>
+          <UsageTrendChart summary={summary} metric={metric} />
+        </section>
       )}
 
       {activeRecord ? (

--- a/apps/web/components/screens/UsageDashboard.tsx
+++ b/apps/web/components/screens/UsageDashboard.tsx
@@ -60,7 +60,10 @@ export function UsageDashboard() {
       .then((data) => {
         if (!cancelled && Array.isArray(data?.summary)) setSummary(data.summary)
       })
-      .catch(() => {})
+      .catch((e) => {
+        // Non-fatal: the per-day bar chart still works without the trend.
+        if (!cancelled) console.error("Failed to load usage summary:", e)
+      })
     return () => {
       cancelled = true
     }

--- a/apps/web/lib/usage-types.ts
+++ b/apps/web/lib/usage-types.ts
@@ -18,6 +18,20 @@ export type UsageDatesResponse = {
   dates: string[]
 }
 
+export type UsageDailySummary = {
+  date: string // ISO YYYY-MM-DD
+  calls: number
+  input_tokens: number
+  output_tokens: number
+  cache_read_tokens: number
+  cache_creation_tokens: number
+  cost_usd: number
+}
+
+export type UsageSummaryResponse = {
+  summary: UsageDailySummary[]
+}
+
 // Numeric fields a user can chart on the y-axis.
 export type UsageMetric =
   | "cost_usd"
@@ -38,6 +52,15 @@ export const USAGE_METRIC_LABELS: Record<UsageMetric, string> = {
 
 export function metricValue(record: UsageRecord, metric: UsageMetric): number {
   return record[metric] ?? 0
+}
+
+// Daily summaries omit duration; treat missing metrics as 0 for the trend line.
+export function summaryMetricValue(
+  day: UsageDailySummary,
+  metric: UsageMetric,
+): number {
+  const value = (day as unknown as Record<string, unknown>)[metric]
+  return typeof value === "number" ? value : 0
 }
 
 export type NiceScale = {

--- a/apps/web/tests/usage-dashboard.test.tsx
+++ b/apps/web/tests/usage-dashboard.test.tsx
@@ -31,6 +31,29 @@ const DAY_20620 = {
   ],
 }
 
+const SUMMARY = {
+  summary: [
+    {
+      date: "2026-06-19",
+      calls: 3,
+      input_tokens: 100,
+      output_tokens: 2000,
+      cache_read_tokens: 5000,
+      cache_creation_tokens: 1000,
+      cost_usd: 0.5,
+    },
+    {
+      date: "2026-06-20",
+      calls: 2,
+      input_tokens: 200,
+      output_tokens: 10607,
+      cache_read_tokens: 9000,
+      cache_creation_tokens: 2000,
+      cost_usd: 1.3,
+    },
+  ],
+}
+
 const fetchMock = vi.fn()
 
 function jsonResponse(body: unknown) {
@@ -82,6 +105,24 @@ describe("UsageDashboard", () => {
       const urls = fetchMock.mock.calls.map((c) => c[0] as string)
       expect(urls.some((u) => u.includes("date=20260619"))).toBe(true)
     })
+  })
+
+  it("renders the daily trend chart from the summary endpoint", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/api/usage/summary")) return Promise.resolve(jsonResponse(SUMMARY))
+      if (url.includes("/api/usage/dates")) return Promise.resolve(jsonResponse(DATES))
+      return Promise.resolve(jsonResponse(DAY_20620))
+    })
+
+    render(<UsageDashboard />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("usage-trend-chart")).toBeInTheDocument()
+    })
+    // One point per summary day; line drawn for >1 point.
+    expect(screen.getByTestId("usage-trend-point-0")).toBeInTheDocument()
+    expect(screen.getByTestId("usage-trend-point-1")).toBeInTheDocument()
+    expect(screen.getByTestId("usage-trend-line")).toBeInTheDocument()
   })
 
   it("shows formatted key/value detail when a bar is hovered", async () => {
@@ -146,9 +187,13 @@ describe("UsageDashboard", () => {
 
   it("shows a dates-loading state before the dates request resolves", async () => {
     let resolveDates: (r: Response) => void = () => {}
-    fetchMock.mockImplementation(
-      () => new Promise<Response>((resolve) => (resolveDates = resolve)),
-    )
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/api/usage/dates")) {
+        return new Promise<Response>((resolve) => (resolveDates = resolve))
+      }
+      // Summary (and any other) endpoint: leave pending so it can't interfere.
+      return new Promise<Response>(() => {})
+    })
     render(<UsageDashboard />)
     // Before resolution we must NOT show the empty-state message.
     expect(screen.getByTestId("usage-dates-loading")).toBeInTheDocument()


### PR DESCRIPTION
## Summary
- Backend: `GET /api/usage/summary` aggregates per-day totals (reuses `usage_report.build_summary`), oldest-first.
- Frontend: `UsageTrendChart` (dependency-free SVG line + area, same axis/gridline style as the bar chart). Dashboard now shows "Per run" bars + "Daily trend" line, both driven by the metric selector.

## Test plan
- [x] `pytest tests/test_api_usage.py` (8 passed)
- [x] `vitest run` (125 passed) + `eslint`/`tsc` clean

Closes #237

## Summary by Sourcery

Add backend daily usage summary endpoint and wire it into the web usage dashboard with a new daily trend chart driven by existing metrics.

New Features:
- Expose a /usage/summary API that returns per-day aggregated usage totals ordered chronologically for charting.
- Add a UsageTrendChart component and display a daily trend line alongside the existing per-run bar chart on the Usage dashboard.

Enhancements:
- Extend usage type definitions and helpers to support daily summary data and metric extraction across both charts.
- Adjust UsageDashboard layout and loading behavior to handle the new summary fetch without impacting existing date loading UX.

Tests:
- Add backend tests covering authentication and ordering/aggregation semantics of the new summary endpoint.
- Add frontend tests to verify the daily trend chart renders from the summary data and to keep date-loading behavior stable with the new request.