### PR TITLE
feat(usage): stacked bar chart for all-token metric and fix title spacing

### DIFF
--- a/apps/web/components/UsageBarChart.tsx
+++ b/apps/web/components/UsageBarChart.tsx
@@ -1,12 +1,19 @@
 "use client"
 import { useRef } from "react"
 
-import { metricValue, niceScale, UsageMetric, UsageRecord } from "@/lib/usage-types"
+import {
+  metricValue,
+  niceScale,
+  stackedTotal,
+  TOKEN_SEGMENTS,
+  UsageChartMetric,
+  UsageRecord,
+} from "@/lib/usage-types"
 import { cn } from "@/lib/utils"
 
 type Props = {
   records: UsageRecord[]
-  metric: UsageMetric
+  metric: UsageChartMetric
   /** Index of the focused/hovered bar, or null. Controlled by the parent. */
   activeIndex?: number | null
   onActiveChange?: (index: number | null) => void
@@ -40,7 +47,10 @@ export function UsageBarChart({
     )
   }
 
-  const values = records.map((r) => metricValue(r, metric))
+  const stacked = metric === "all"
+  const values = records.map((r) =>
+    stacked ? stackedTotal(r) : metricValue(r, metric),
+  )
   const max = Math.max(...values, 1)
   const { niceMax, ticks } = niceScale(max)
 
@@ -68,7 +78,12 @@ export function UsageBarChart({
   }
 
   return (
-    <div data-testid="usage-bar-chart" role="group" aria-label="Usage bar chart" className="flex">
+    <div
+      data-testid="usage-bar-chart"
+      role="group"
+      aria-label="Usage bar chart"
+      className="flex pt-3"
+    >
       {/* Y-axis tick labels, aligned to the gridlines by bottom-offset %.
           aria-hidden: each bar already announces its value, so these would be
           redundant noise for screen readers. */}
@@ -132,21 +147,56 @@ export function UsageBarChart({
                 onBlur={handleBarBlur}
                 onKeyDown={(e) => handleBarKeyDown(i, e)}
               >
-                <span
-                  data-testid={`usage-bar-fill-${i}`}
-                  className={cn(
-                    "w-full rounded-t bg-gradient-to-t transition-colors",
-                    active
-                      ? "from-blue-700 to-blue-400"
-                      : "from-blue-600 to-blue-300 hover:from-blue-700 hover:to-blue-400",
-                  )}
-                  style={{ height: `${heightPct}%` }}
-                />
+                {stacked ? (
+                  <span
+                    data-testid={`usage-bar-fill-${i}`}
+                    className="flex w-full flex-col-reverse overflow-hidden rounded-t"
+                    style={{ height: `${heightPct}%` }}
+                  >
+                    {TOKEN_SEGMENTS.map((seg) => {
+                      const segValue = record[seg.key] ?? 0
+                      const total = value || 1
+                      return (
+                        <span
+                          key={seg.key}
+                          data-testid={`usage-bar-segment-${i}-${seg.key}`}
+                          className={cn("w-full", seg.className)}
+                          style={{ height: `${(segValue / total) * 100}%` }}
+                        />
+                      )
+                    })}
+                  </span>
+                ) : (
+                  <span
+                    data-testid={`usage-bar-fill-${i}`}
+                    className={cn(
+                      "w-full rounded-t bg-gradient-to-t transition-colors",
+                      active
+                        ? "from-blue-700 to-blue-400"
+                        : "from-blue-600 to-blue-300 hover:from-blue-700 hover:to-blue-400",
+                    )}
+                    style={{ height: `${heightPct}%` }}
+                  />
+                )}
               </button>
             )
           })}
         </div>
       </div>
+
+      {stacked && (
+        <ul
+          data-testid="usage-stack-legend"
+          className="ml-2 flex shrink-0 flex-col justify-start gap-1 self-center text-xs text-muted-foreground"
+        >
+          {TOKEN_SEGMENTS.map((seg) => (
+            <li key={seg.key} className="flex items-center gap-1.5">
+              <span className={cn("h-2.5 w-2.5 rounded-sm", seg.className)} aria-hidden />
+              {seg.label}
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   )
 }

--- a/apps/web/components/UsageBarChart.tsx
+++ b/apps/web/components/UsageBarChart.tsx
@@ -150,7 +150,10 @@ export function UsageBarChart({
                 {stacked ? (
                   <span
                     data-testid={`usage-bar-fill-${i}`}
-                    className="flex w-full flex-col-reverse overflow-hidden rounded-t"
+                    className={cn(
+                      "flex w-full flex-col-reverse overflow-hidden rounded-t transition-all",
+                      active ? "brightness-110" : "brightness-100",
+                    )}
                     style={{ height: `${heightPct}%` }}
                   >
                     {TOKEN_SEGMENTS.map((seg) => {

--- a/apps/web/components/screens/UsageDashboard.tsx
+++ b/apps/web/components/screens/UsageDashboard.tsx
@@ -9,7 +9,6 @@ import {
   UsageDailySummary,
   UsageDatesResponse,
   UsageDayResponse,
-  UsageMetric,
   USAGE_CHART_METRIC_LABELS,
   USAGE_FIELD_LABELS,
   USAGE_FIELD_ORDER,
@@ -183,7 +182,7 @@ export function UsageDashboard() {
           <h3 className="text-sm font-medium text-muted-foreground">
             Daily trend — {USAGE_CHART_METRIC_LABELS[metric]}
           </h3>
-          <UsageTrendChart summary={summary} metric={metric as UsageMetric} />
+          <UsageTrendChart summary={summary} metric={metric} />
         </section>
       )}
 

--- a/apps/web/components/screens/UsageDashboard.tsx
+++ b/apps/web/components/screens/UsageDashboard.tsx
@@ -5,24 +5,26 @@ import { UsageBarChart } from "@/components/UsageBarChart"
 import { UsageTrendChart } from "@/components/UsageTrendChart"
 import {
   formatUsageField,
+  UsageChartMetric,
   UsageDailySummary,
   UsageDatesResponse,
   UsageDayResponse,
   UsageMetric,
+  USAGE_CHART_METRIC_LABELS,
   USAGE_FIELD_LABELS,
   USAGE_FIELD_ORDER,
-  USAGE_METRIC_LABELS,
   UsageRecord,
   UsageSummaryResponse,
 } from "@/lib/usage-types"
 
-const METRICS: UsageMetric[] = [
+const METRICS: UsageChartMetric[] = [
   "cost_usd",
   "input_tokens",
   "output_tokens",
   "cache_read_tokens",
   "cache_creation_tokens",
   "duration_ms",
+  "all",
 ]
 
 export function UsageDashboard() {
@@ -30,7 +32,7 @@ export function UsageDashboard() {
   const [dates, setDates] = useState<string[] | null>(null)
   const [selectedDate, setSelectedDate] = useState<string | null>(null)
   const [records, setRecords] = useState<UsageRecord[]>([])
-  const [metric, setMetric] = useState<UsageMetric>("cost_usd")
+  const [metric, setMetric] = useState<UsageChartMetric>("cost_usd")
   const [summary, setSummary] = useState<UsageDailySummary[]>([])
   const [activeIndex, setActiveIndex] = useState<number | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -146,12 +148,12 @@ export function UsageDashboard() {
           <select
             data-testid="usage-metric-select"
             value={metric}
-            onChange={(e) => setMetric(e.target.value as UsageMetric)}
+            onChange={(e) => setMetric(e.target.value as UsageChartMetric)}
             className="rounded-md border bg-background px-2 py-1 text-sm"
           >
             {METRICS.map((m) => (
               <option key={m} value={m}>
-                {USAGE_METRIC_LABELS[m]}
+                {USAGE_CHART_METRIC_LABELS[m]}
               </option>
             ))}
           </select>
@@ -160,7 +162,7 @@ export function UsageDashboard() {
 
       <section className="space-y-1">
         <h3 className="text-sm font-medium text-muted-foreground">
-          Per run — {USAGE_METRIC_LABELS[metric]}
+          Per run — {USAGE_CHART_METRIC_LABELS[metric]}
         </h3>
         {loading ? (
           <p data-testid="usage-loading" className="text-sm text-muted-foreground">
@@ -176,12 +178,12 @@ export function UsageDashboard() {
         )}
       </section>
 
-      {summary.length > 0 && (
+      {summary.length > 0 && metric !== "all" && (
         <section className="space-y-1">
           <h3 className="text-sm font-medium text-muted-foreground">
-            Daily trend — {USAGE_METRIC_LABELS[metric]}
+            Daily trend — {USAGE_CHART_METRIC_LABELS[metric]}
           </h3>
-          <UsageTrendChart summary={summary} metric={metric} />
+          <UsageTrendChart summary={summary} metric={metric as UsageMetric} />
         </section>
       )}
 

--- a/apps/web/lib/usage-types.ts
+++ b/apps/web/lib/usage-types.ts
@@ -50,6 +50,34 @@ export const USAGE_METRIC_LABELS: Record<UsageMetric, string> = {
   duration_ms: "Duration (ms)",
 }
 
+// Chart metric adds a synthetic "all" option that stacks the token segments.
+export type UsageChartMetric = UsageMetric | "all"
+
+export const USAGE_CHART_METRIC_LABELS: Record<UsageChartMetric, string> = {
+  ...USAGE_METRIC_LABELS,
+  all: "All tokens (stacked)",
+}
+
+// Token fields stacked when the chart metric is "all". `cost_usd` / `duration_ms`
+// are excluded — different units can't share a stack. Colors are blue-family
+// shades so the chart stays in the requested palette.
+export type TokenSegment = {
+  key: "input_tokens" | "output_tokens" | "cache_read_tokens" | "cache_creation_tokens"
+  label: string
+  className: string
+}
+
+export const TOKEN_SEGMENTS: TokenSegment[] = [
+  { key: "input_tokens", label: "Input", className: "bg-blue-700" },
+  { key: "output_tokens", label: "Output", className: "bg-blue-500" },
+  { key: "cache_read_tokens", label: "Cache read", className: "bg-blue-400" },
+  { key: "cache_creation_tokens", label: "Cache creation", className: "bg-blue-300" },
+]
+
+export function stackedTotal(record: UsageRecord): number {
+  return TOKEN_SEGMENTS.reduce((sum, seg) => sum + (record[seg.key] ?? 0), 0)
+}
+
 export function metricValue(record: UsageRecord, metric: UsageMetric): number {
   return record[metric] ?? 0
 }

--- a/apps/web/tests/usage-dashboard.test.tsx
+++ b/apps/web/tests/usage-dashboard.test.tsx
@@ -205,6 +205,29 @@ describe("UsageDashboard", () => {
     })
   })
 
+  it("renders stacked segments and legend when metric is 'all'", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/api/usage/dates")) return Promise.resolve(jsonResponse(DATES))
+      return Promise.resolve(jsonResponse(DAY_20620))
+    })
+
+    render(<UsageDashboard />)
+    await waitFor(() => expect(screen.getByTestId("usage-bar-0")).toBeInTheDocument())
+
+    const user = userEvent.setup()
+    await user.selectOptions(screen.getByTestId("usage-metric-select"), "all")
+
+    await waitFor(() => {
+      // Stacked fill spans with segment testids.
+      expect(screen.getByTestId("usage-bar-segment-0-input_tokens")).toBeInTheDocument()
+      expect(screen.getByTestId("usage-bar-segment-0-output_tokens")).toBeInTheDocument()
+      // Color legend is visible.
+      expect(screen.getByTestId("usage-stack-legend")).toBeInTheDocument()
+      // Trend chart is hidden when metric is "all".
+      expect(screen.queryByTestId("usage-trend-chart")).not.toBeInTheDocument()
+    })
+  })
+
   it("ignores a stale slow response when the date changed", async () => {
     const resolvers: Record<string, (r: Response) => void> = {}
     fetchMock.mockImplementation((url: string) => {

--- a/apps/web/tests/usage-dashboard.test.tsx
+++ b/apps/web/tests/usage-dashboard.test.tsx
@@ -205,13 +205,16 @@ describe("UsageDashboard", () => {
     })
   })
 
-  it("renders stacked segments and legend when metric is 'all'", async () => {
+  it("renders stacked segments and legend when metric is 'all'; restores trend on switch back", async () => {
     fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/api/usage/summary")) return Promise.resolve(jsonResponse(SUMMARY))
       if (url.includes("/api/usage/dates")) return Promise.resolve(jsonResponse(DATES))
       return Promise.resolve(jsonResponse(DAY_20620))
     })
 
     render(<UsageDashboard />)
+    // Trend chart should be visible before switching to stacked mode.
+    await waitFor(() => expect(screen.getByTestId("usage-trend-chart")).toBeInTheDocument())
     await waitFor(() => expect(screen.getByTestId("usage-bar-0")).toBeInTheDocument())
 
     const user = userEvent.setup()
@@ -223,8 +226,14 @@ describe("UsageDashboard", () => {
       expect(screen.getByTestId("usage-bar-segment-0-output_tokens")).toBeInTheDocument()
       // Color legend is visible.
       expect(screen.getByTestId("usage-stack-legend")).toBeInTheDocument()
-      // Trend chart is hidden when metric is "all".
+      // Trend chart is hidden while in stacked "all" metric mode.
       expect(screen.queryByTestId("usage-trend-chart")).not.toBeInTheDocument()
+    })
+
+    // Switch back to a single metric and ensure the trend chart is restored.
+    await user.selectOptions(screen.getByTestId("usage-metric-select"), "cost_usd")
+    await waitFor(() => {
+      expect(screen.getByTestId("usage-trend-chart")).toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
## Summary
- Add `Metric: All tokens (stacked)` option to the Usage bar chart; bars render as stacked blue-family segments (input / output / cache read / cache creation)
- Hide the daily trend chart when metric is `all` (different unit stacks can't share a line axis)
- Fix section heading overlapping the top y-axis tick label (`pt-3` on chart wrapper)

## Test plan
- [ ] `npx vitest run` — 126 tests pass
- [ ] `npx tsc --noEmit` — no type errors
- [ ] Select "All tokens (stacked)" in metric dropdown → stacked bars + color legend visible, trend chart hidden
- [ ] Switch back to any single metric → gradient bars + trend chart restored, overlap resolved

Closes #238

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Add a new stacked-token metric option to the usage dashboard bar chart, update labels and metric types to support it, hide the daily trend chart for the stacked view, and adjust chart spacing and tests accordingly.

New Features:
- Introduce an 'All tokens (stacked)' usage metric option that renders bar chart runs as stacked token segments with a color legend.

Bug Fixes:
- Prevent section heading text from overlapping the top y-axis tick label by adding padding to the bar chart wrapper.
- Hide the daily trend chart when the stacked 'all' metric is selected to avoid mixing incompatible units on a single axis.

Enhancements:
- Extend usage metric types and labels to include a chart-specific metric union and token segment metadata for reuse across charts.

Tests:
- Add a dashboard test that verifies stacked bar segments, the legend, and hiding of the trend chart when the 'all' metric is selected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stacked bar chart visualization for viewing all token types together in a single view.
  * Introduced "All tokens" option in the metric selector to display aggregated token usage.
  * Daily trend chart now hides when viewing the stacked all-tokens visualization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->