### PR TITLE
feat(web): add Briefing viewer (sidebar, API, table, markdown)

### DIFF
--- a/apps/python/tests/test_api_briefing.py
+++ b/apps/python/tests/test_api_briefing.py
@@ -1,0 +1,106 @@
+"""Tests for /api/briefing — file list + markdown content.
+
+Contract (#239):
+- ``GET /api/briefing`` returns newest-first list of {name, type, date, size}.
+- ``GET /api/briefing/{name}`` returns {name, content} (raw markdown).
+- Unknown / invalid / traversal name returns 404.
+- Auth is required (Bearer) on both endpoints.
+"""
+import pytest
+
+from web.routers import briefing as briefing_router
+
+
+@pytest.fixture
+def briefing_dir(tmp_path, monkeypatch):
+    """Point the briefing router at a tmp dir with sample files."""
+    d = tmp_path / "briefing"
+    d.mkdir()
+    (d / "briefing_2026-06-20.md").write_text("# Briefing 2026-06-20\nContent A.", encoding="utf-8")
+    (d / "briefing_2026-06-19.md").write_text("# Briefing 2026-06-19\nContent B.", encoding="utf-8")
+    (d / "local_2026-06-18.md").write_text("# Local 2026-06-18\nContent C.", encoding="utf-8")
+    (d / "briefing_2026-06-16-001.md").write_text("Numbered.", encoding="utf-8")
+    (d / "ignored.txt").write_text("not a briefing", encoding="utf-8")
+    monkeypatch.setattr(briefing_router, "BRIEFING_DIR", d)
+    return d
+
+
+async def test_list_requires_auth(async_client, briefing_dir):
+    response = await async_client.get("/api/briefing")
+    assert response.status_code == 401
+
+
+async def test_list_newest_first(authed_client, briefing_dir):
+    response = await authed_client.get("/api/briefing")
+    assert response.status_code == 200
+    files = response.json()["files"]
+    names = [f["name"] for f in files]
+    # .txt is excluded; newest first by date DESC
+    assert names == [
+        "briefing_2026-06-20.md",
+        "briefing_2026-06-19.md",
+        "local_2026-06-18.md",
+        "briefing_2026-06-16-001.md",
+    ]
+
+
+async def test_list_parses_type_and_date(authed_client, briefing_dir):
+    response = await authed_client.get("/api/briefing")
+    assert response.status_code == 200
+    files = {f["name"]: f for f in response.json()["files"]}
+    assert files["briefing_2026-06-20.md"]["type"] == "briefing"
+    assert files["briefing_2026-06-20.md"]["date"] == "2026-06-20"
+    assert files["local_2026-06-18.md"]["type"] == "local"
+    assert files["local_2026-06-18.md"]["date"] == "2026-06-18"
+    assert files["briefing_2026-06-16-001.md"]["date"] == "2026-06-16"
+
+
+async def test_list_includes_size(authed_client, briefing_dir):
+    response = await authed_client.get("/api/briefing")
+    assert response.status_code == 200
+    f = next(f for f in response.json()["files"] if f["name"] == "briefing_2026-06-20.md")
+    assert f["size"] > 0
+
+
+async def test_list_empty_when_dir_missing(authed_client, tmp_path, monkeypatch):
+    monkeypatch.setattr(briefing_router, "BRIEFING_DIR", tmp_path / "nonexistent")
+    response = await authed_client.get("/api/briefing")
+    assert response.status_code == 200
+    assert response.json()["files"] == []
+
+
+async def test_get_requires_auth(async_client, briefing_dir):
+    response = await async_client.get("/api/briefing/briefing_2026-06-20.md")
+    assert response.status_code == 401
+
+
+async def test_get_returns_markdown(authed_client, briefing_dir):
+    response = await authed_client.get("/api/briefing/briefing_2026-06-20.md")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["name"] == "briefing_2026-06-20.md"
+    assert "Briefing 2026-06-20" in body["content"]
+
+
+async def test_get_unknown_file_returns_404(authed_client, briefing_dir):
+    response = await authed_client.get("/api/briefing/briefing_9999-01-01.md")
+    assert response.status_code == 404
+
+
+async def test_get_path_traversal_returns_404(authed_client, briefing_dir):
+    response = await authed_client.get("/api/briefing/..%2Fapp.py")
+    assert response.status_code == 404
+
+
+async def test_get_invalid_extension_returns_404(authed_client, briefing_dir):
+    response = await authed_client.get("/api/briefing/ignored.txt")
+    assert response.status_code == 404
+
+
+async def test_list_newest_first_sorted_correctly(authed_client, briefing_dir):
+    """Ensure sort order: briefing_2026-06-20 > briefing_2026-06-19 > briefing_2026-06-16-001."""
+    response = await authed_client.get("/api/briefing")
+    names = [f["name"] for f in response.json()["files"]]
+    briefing_names = [n for n in names if n.startswith("briefing_")]
+    # briefing files sorted newest-first by date
+    assert briefing_names == ["briefing_2026-06-20.md", "briefing_2026-06-19.md", "briefing_2026-06-16-001.md"]

--- a/apps/python/web/app.py
+++ b/apps/python/web/app.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 
-from web.routers import auth_mode, chat, config, credentials, health, run, state, usage
+from web.routers import auth_mode, briefing, chat, config, credentials, health, run, state, usage
 
 app = FastAPI(title="ai-agent Web API", version="0.1.0")
 app.include_router(health.router, prefix="/api")
@@ -11,3 +11,4 @@ app.include_router(state.router, prefix="/api")
 app.include_router(run.router, prefix="/api")
 app.include_router(chat.router, prefix="/api")
 app.include_router(usage.router, prefix="/api")
+app.include_router(briefing.router, prefix="/api")

--- a/apps/python/web/routers/briefing.py
+++ b/apps/python/web/routers/briefing.py
@@ -1,0 +1,76 @@
+"""GET /api/briefing — apps/python/output/briefing/*.md のリスト・内容取得 API。
+
+ブリーフィングビューア (Sidebar > Briefing) がファイル一覧を取得して
+一覧表示し、選択されたファイルの Markdown 本文を返す。
+
+ファイル名規約: ``{type}_{YYYY-MM-DD}[-NNN].md``
+type は ``briefing`` または ``local`` の 2 種。
+"""
+import re
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from web.auth import require_bearer
+
+router = APIRouter(dependencies=[Depends(require_bearer)])
+
+BRIEFING_DIR = Path(__file__).parents[2] / "output" / "briefing"
+
+# filename: briefing_YYYY-MM-DD[-NNN].md  or  local_YYYY-MM-DD[-NNN].md
+_FILE_RE = re.compile(r"^(briefing|local)_(\d{4}-\d{2}-\d{2})(?:-\d+)?\.md$")
+# safe-name guard: only alphanum / underscore / hyphen + .md — no path separators
+_SAFE_NAME_RE = re.compile(r"^[\w-]+\.md$")
+
+
+class BriefingFile(BaseModel):
+    name: str
+    type: str  # "briefing" | "local"
+    date: str  # YYYY-MM-DD
+    size: int  # bytes
+
+
+class BriefingListResponse(BaseModel):
+    files: list[BriefingFile]
+
+
+class BriefingFileResponse(BaseModel):
+    name: str
+    content: str
+
+
+@router.get("/briefing", response_model=BriefingListResponse)
+def list_briefings() -> BriefingListResponse:
+    """利用可能なブリーフィングファイルを新しい順で返す。"""
+    if not BRIEFING_DIR.exists():
+        return BriefingListResponse(files=[])
+
+    files: list[BriefingFile] = []
+    for path in BRIEFING_DIR.glob("*.md"):
+        m = _FILE_RE.match(path.name)
+        if m is None:
+            continue
+        files.append(
+            BriefingFile(
+                name=path.name,
+                type=m.group(1),
+                date=m.group(2),
+                size=path.stat().st_size,
+            )
+        )
+    files.sort(key=lambda f: (f.date, f.name), reverse=True)
+    return BriefingListResponse(files=files)
+
+
+@router.get("/briefing/{name}", response_model=BriefingFileResponse)
+def get_briefing(name: str) -> BriefingFileResponse:
+    """指定ファイルの Markdown 本文を返す。不正名やディレクトリ外は 404。"""
+    if not _SAFE_NAME_RE.match(name) or _FILE_RE.match(name) is None:
+        raise HTTPException(status_code=404, detail=f"Briefing not found: {name}")
+
+    path = BRIEFING_DIR / name
+    if not path.exists() or not path.is_file():
+        raise HTTPException(status_code=404, detail=f"Briefing not found: {name}")
+
+    return BriefingFileResponse(name=name, content=path.read_text(encoding="utf-8"))

--- a/apps/web/app/(main)/briefing/page.tsx
+++ b/apps/web/app/(main)/briefing/page.tsx
@@ -1,0 +1,14 @@
+export const dynamic = "force-dynamic"
+
+import { BriefingDashboard } from "@/components/screens/BriefingDashboard"
+
+export default function BriefingPage() {
+  return (
+    <div className="flex h-full flex-col gap-4 p-6">
+      <h1 className="text-lg font-semibold">Briefing</h1>
+      <div className="flex-1 overflow-hidden">
+        <BriefingDashboard />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/Sidebar.tsx
+++ b/apps/web/components/Sidebar.tsx
@@ -23,6 +23,7 @@ const ITEMS: Item[] = [
   { href: "/auth", label: "Auth", icon: "🔑" },
   { href: "/run", label: "Run", icon: "▶️" },
   { href: "/chat", label: "Q&A Chat", icon: "💬" },
+  { href: "/briefing", label: "Briefing", icon: "📚" },
 ]
 
 export function Sidebar() {

--- a/apps/web/components/screens/BriefingDashboard.tsx
+++ b/apps/web/components/screens/BriefingDashboard.tsx
@@ -1,0 +1,138 @@
+"use client"
+import { useEffect, useState } from "react"
+import ReactMarkdown from "react-markdown"
+import rehypeSanitize from "rehype-sanitize"
+import remarkGfm from "remark-gfm"
+
+import {
+  BriefingFile,
+  BriefingFileResponse,
+  BriefingListResponse,
+  BRIEFING_TYPE_LABELS,
+} from "@/lib/briefing-types"
+import { cn } from "@/lib/utils"
+
+export function BriefingDashboard() {
+  const [files, setFiles] = useState<BriefingFile[] | null>(null)
+  const [selected, setSelected] = useState<BriefingFile | null>(null)
+  const [content, setContent] = useState<string | null>(null)
+  const [loadingContent, setLoadingContent] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetch("/api/briefing", { cache: "no-store" })
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        return res.json() as Promise<BriefingListResponse>
+      })
+      .then((data) => {
+        setFiles(data.files)
+        if (data.files.length > 0) setSelected(data.files[0])
+      })
+      .catch((e) => setError(String(e)))
+  }, [])
+
+  useEffect(() => {
+    if (!selected) return
+    let cancelled = false
+    setLoadingContent(true)
+    setContent(null)
+    fetch(`/api/briefing/${encodeURIComponent(selected.name)}`, { cache: "no-store" })
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        return res.json() as Promise<BriefingFileResponse>
+      })
+      .then((data) => {
+        if (!cancelled) setContent(data.content)
+      })
+      .catch((e) => {
+        if (!cancelled) setError(String(e))
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingContent(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [selected])
+
+  if (error) {
+    return (
+      <p data-testid="briefing-error" className="text-sm text-destructive">
+        Failed to load briefings: {error}
+      </p>
+    )
+  }
+
+  if (files === null) {
+    return (
+      <p data-testid="briefing-loading" className="text-sm text-muted-foreground">
+        Loading briefings…
+      </p>
+    )
+  }
+
+  if (files.length === 0) {
+    return (
+      <p data-testid="briefing-empty" className="text-sm text-muted-foreground">
+        No briefing files found.
+      </p>
+    )
+  }
+
+  return (
+    <div data-testid="briefing-dashboard" className="flex h-full gap-4">
+      {/* File list */}
+      <aside className="w-64 shrink-0 overflow-y-auto rounded-md border">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b bg-muted/50 text-left text-xs text-muted-foreground">
+              <th className="px-3 py-2">Name</th>
+              <th className="px-3 py-2">Type</th>
+              <th className="px-3 py-2">Date</th>
+            </tr>
+          </thead>
+          <tbody>
+            {files.map((file) => (
+              <tr
+                key={file.name}
+                data-testid={`briefing-row-${file.name}`}
+                onClick={() => setSelected(file)}
+                className={cn(
+                  "cursor-pointer border-b text-xs transition-colors last:border-0",
+                  selected?.name === file.name
+                    ? "bg-accent font-medium text-accent-foreground"
+                    : "hover:bg-accent/50",
+                )}
+              >
+                <td className="max-w-[120px] truncate px-3 py-2" title={file.name}>
+                  {file.name}
+                </td>
+                <td className="px-3 py-2">{BRIEFING_TYPE_LABELS[file.type]}</td>
+                <td className="px-3 py-2 tabular-nums">{file.date}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </aside>
+
+      {/* Markdown detail */}
+      <main className="min-w-0 flex-1 overflow-y-auto">
+        {loadingContent ? (
+          <p data-testid="briefing-content-loading" className="text-sm text-muted-foreground">
+            Loading…
+          </p>
+        ) : content !== null ? (
+          <div
+            data-testid="briefing-content"
+            className="prose prose-sm max-w-none dark:prose-invert"
+          >
+            <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]}>
+              {content}
+            </ReactMarkdown>
+          </div>
+        ) : null}
+      </main>
+    </div>
+  )
+}

--- a/apps/web/components/screens/BriefingDashboard.tsx
+++ b/apps/web/components/screens/BriefingDashboard.tsx
@@ -17,7 +17,8 @@ export function BriefingDashboard() {
   const [selected, setSelected] = useState<BriefingFile | null>(null)
   const [content, setContent] = useState<string | null>(null)
   const [loadingContent, setLoadingContent] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [listError, setListError] = useState<string | null>(null)
+  const [contentError, setContentError] = useState<string | null>(null)
 
   // In-memory cache so revisiting a row is instant (no re-fetch).
   const contentCache = useRef(new Map<string, string>())
@@ -36,6 +37,7 @@ export function BriefingDashboard() {
     setSelected(file)
     setLoadingContent(true)
     setContent(null)
+    setContentError(null)
     fetch(`/api/briefing/${encodeURIComponent(file.name)}`, { cache: "no-store" })
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`)
@@ -50,7 +52,7 @@ export function BriefingDashboard() {
       })
       .catch((e) => {
         if (latestFile.current === file.name) {
-          setError(String(e))
+          setContentError(String(e))
           setLoadingContent(false)
         }
       })
@@ -83,17 +85,17 @@ export function BriefingDashboard() {
         }
       })
       .catch((e) => {
-        if (!cancelled) setError(String(e))
+        if (!cancelled) setListError(String(e))
       })
     return () => {
       cancelled = true
     }
   }, [fetchContent])
 
-  if (error) {
+  if (listError) {
     return (
       <p data-testid="briefing-error" className="text-sm text-destructive">
-        Failed to load briefings: {error}
+        Failed to load briefings: {listError}
       </p>
     )
   }
@@ -156,6 +158,10 @@ export function BriefingDashboard() {
         {loadingContent ? (
           <p data-testid="briefing-content-loading" className="text-sm text-muted-foreground">
             Loading…
+          </p>
+        ) : contentError !== null ? (
+          <p data-testid="briefing-content-error" className="text-sm text-destructive">
+            Failed to load content: {contentError}
           </p>
         ) : content !== null ? (
           <div

--- a/apps/web/components/screens/BriefingDashboard.tsx
+++ b/apps/web/components/screens/BriefingDashboard.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import ReactMarkdown from "react-markdown"
 import rehypeSanitize from "rehype-sanitize"
 import remarkGfm from "remark-gfm"
@@ -19,42 +19,76 @@ export function BriefingDashboard() {
   const [loadingContent, setLoadingContent] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  // In-memory cache so revisiting a row is instant (no re-fetch).
+  const contentCache = useRef(new Map<string, string>())
+  // Tracks the most recently requested file to discard stale responses.
+  const latestFile = useRef<string | null>(null)
+
+  const fetchContent = useCallback((file: BriefingFile) => {
+    const cached = contentCache.current.get(file.name)
+    if (cached !== undefined) {
+      setSelected(file)
+      setContent(cached)
+      setLoadingContent(false)
+      return
+    }
+    latestFile.current = file.name
+    setSelected(file)
+    setLoadingContent(true)
+    setContent(null)
+    fetch(`/api/briefing/${encodeURIComponent(file.name)}`, { cache: "no-store" })
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        return res.json() as Promise<BriefingFileResponse>
+      })
+      .then((data) => {
+        contentCache.current.set(file.name, data.content)
+        if (latestFile.current === file.name) {
+          setContent(data.content)
+          setLoadingContent(false)
+        }
+      })
+      .catch((e) => {
+        if (latestFile.current === file.name) {
+          setError(String(e))
+          setLoadingContent(false)
+        }
+      })
+  }, [])
+
+  // Fire-and-forget prefetch on hover; silently populates the cache.
+  const prefetch = useCallback((file: BriefingFile) => {
+    if (contentCache.current.has(file.name)) return
+    fetch(`/api/briefing/${encodeURIComponent(file.name)}`, { cache: "no-store" })
+      .then((res) => (res.ok ? (res.json() as Promise<BriefingFileResponse>) : null))
+      .then((data) => {
+        if (data) contentCache.current.set(file.name, data.content)
+      })
+      .catch(() => {})
+  }, [])
+
   useEffect(() => {
+    let cancelled = false
     fetch("/api/briefing", { cache: "no-store" })
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`)
         return res.json() as Promise<BriefingListResponse>
       })
       .then((data) => {
+        if (cancelled) return
         setFiles(data.files)
-        if (data.files.length > 0) setSelected(data.files[0])
-      })
-      .catch((e) => setError(String(e)))
-  }, [])
-
-  useEffect(() => {
-    if (!selected) return
-    let cancelled = false
-    setLoadingContent(true)
-    setContent(null)
-    fetch(`/api/briefing/${encodeURIComponent(selected.name)}`, { cache: "no-store" })
-      .then((res) => {
-        if (!res.ok) throw new Error(`HTTP ${res.status}`)
-        return res.json() as Promise<BriefingFileResponse>
-      })
-      .then((data) => {
-        if (!cancelled) setContent(data.content)
+        if (data.files.length > 0) {
+          // Start content fetch immediately — no intermediate state-cycle delay.
+          fetchContent(data.files[0])
+        }
       })
       .catch((e) => {
         if (!cancelled) setError(String(e))
       })
-      .finally(() => {
-        if (!cancelled) setLoadingContent(false)
-      })
     return () => {
       cancelled = true
     }
-  }, [selected])
+  }, [fetchContent])
 
   if (error) {
     return (
@@ -97,7 +131,8 @@ export function BriefingDashboard() {
               <tr
                 key={file.name}
                 data-testid={`briefing-row-${file.name}`}
-                onClick={() => setSelected(file)}
+                onClick={() => fetchContent(file)}
+                onMouseEnter={() => prefetch(file)}
                 className={cn(
                   "cursor-pointer border-b text-xs transition-colors last:border-0",
                   selected?.name === file.name

--- a/apps/web/lib/briefing-types.ts
+++ b/apps/web/lib/briefing-types.ts
@@ -1,0 +1,20 @@
+export type BriefingFile = {
+  name: string
+  type: "briefing" | "local"
+  date: string // YYYY-MM-DD
+  size: number // bytes
+}
+
+export type BriefingListResponse = {
+  files: BriefingFile[]
+}
+
+export type BriefingFileResponse = {
+  name: string
+  content: string
+}
+
+export const BRIEFING_TYPE_LABELS: Record<BriefingFile["type"], string> = {
+  briefing: "Briefing",
+  local: "Local",
+}

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -24,6 +24,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.60.0",
+        "@tailwindcss/typography": "^0.5.20",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -1461,6 +1462,33 @@
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.20.tgz",
+      "integrity": "sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",
+    "@tailwindcss/typography": "^0.5.20",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -65,6 +65,6 @@ const config: Config = {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [require("tailwindcss-animate"), require("@tailwindcss/typography")],
 }
 export default config

--- a/apps/web/tests/briefing-dashboard.test.tsx
+++ b/apps/web/tests/briefing-dashboard.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { BriefingDashboard } from "@/components/screens/BriefingDashboard"
+
+const FILES_RESPONSE = {
+  files: [
+    { name: "briefing_2026-06-20.md", type: "briefing", date: "2026-06-20", size: 512 },
+    { name: "briefing_2026-06-19.md", type: "briefing", date: "2026-06-19", size: 256 },
+    { name: "local_2026-06-18.md", type: "local", date: "2026-06-18", size: 128 },
+  ],
+}
+
+const CONTENT_RESPONSE = {
+  name: "briefing_2026-06-20.md",
+  content: "# June 20 Briefing\n\nToday's market summary.",
+}
+
+const fetchMock = vi.fn()
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  })
+}
+
+describe("BriefingDashboard", () => {
+  beforeEach(() => {
+    fetchMock.mockReset()
+    vi.stubGlobal("fetch", fetchMock)
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("shows loading state before files arrive", async () => {
+    fetchMock.mockImplementation(() => new Promise<Response>(() => {}))
+    render(<BriefingDashboard />)
+    expect(screen.getByTestId("briefing-loading")).toBeInTheDocument()
+  })
+
+  it("renders file list as table rows", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/api/briefing/")) return Promise.resolve(jsonResponse(CONTENT_RESPONSE))
+      return Promise.resolve(jsonResponse(FILES_RESPONSE))
+    })
+
+    render(<BriefingDashboard />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("briefing-dashboard")).toBeInTheDocument()
+    })
+    expect(screen.getByTestId("briefing-row-briefing_2026-06-20.md")).toBeInTheDocument()
+    expect(screen.getByTestId("briefing-row-briefing_2026-06-19.md")).toBeInTheDocument()
+    expect(screen.getByTestId("briefing-row-local_2026-06-18.md")).toBeInTheDocument()
+  })
+
+  it("auto-selects and loads the first file on mount", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/api/briefing/")) return Promise.resolve(jsonResponse(CONTENT_RESPONSE))
+      return Promise.resolve(jsonResponse(FILES_RESPONSE))
+    })
+
+    render(<BriefingDashboard />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("briefing-content")).toBeInTheDocument()
+    })
+    expect(screen.getByTestId("briefing-content")).toHaveTextContent("June 20 Briefing")
+  })
+
+  it("loads content when a different row is clicked", async () => {
+    const otherContent = { name: "briefing_2026-06-19.md", content: "# June 19 Briefing" }
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("briefing_2026-06-19")) return Promise.resolve(jsonResponse(otherContent))
+      if (url.includes("/api/briefing/")) return Promise.resolve(jsonResponse(CONTENT_RESPONSE))
+      return Promise.resolve(jsonResponse(FILES_RESPONSE))
+    })
+
+    render(<BriefingDashboard />)
+    await waitFor(() => expect(screen.getByTestId("briefing-dashboard")).toBeInTheDocument())
+
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId("briefing-row-briefing_2026-06-19.md"))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("briefing-content")).toHaveTextContent("June 19 Briefing")
+    })
+  })
+
+  it("renders markdown content (headings, text)", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/api/briefing/")) return Promise.resolve(jsonResponse(CONTENT_RESPONSE))
+      return Promise.resolve(jsonResponse(FILES_RESPONSE))
+    })
+
+    render(<BriefingDashboard />)
+
+    await waitFor(() => {
+      const content = screen.getByTestId("briefing-content")
+      expect(content.querySelector("h1")).toBeTruthy()
+      expect(content).toHaveTextContent("Today's market summary.")
+    })
+  })
+
+  it("shows empty state when no files are returned", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ files: [] }))
+    render(<BriefingDashboard />)
+    await waitFor(() => {
+      expect(screen.getByTestId("briefing-empty")).toBeInTheDocument()
+    })
+  })
+
+  it("shows error state when the list fetch fails", async () => {
+    fetchMock.mockRejectedValue(new Error("Network error"))
+    render(<BriefingDashboard />)
+    await waitFor(() => {
+      expect(screen.getByTestId("briefing-error")).toBeInTheDocument()
+    })
+  })
+})

--- a/apps/web/tests/briefing-dashboard.test.tsx
+++ b/apps/web/tests/briefing-dashboard.test.tsx
@@ -120,4 +120,17 @@ describe("BriefingDashboard", () => {
       expect(screen.getByTestId("briefing-error")).toBeInTheDocument()
     })
   })
+
+  it("shows content error without hiding file list when a file fetch fails", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url === "/api/briefing") return Promise.resolve(jsonResponse(FILES_RESPONSE))
+      return Promise.reject(new Error("content fetch failed"))
+    })
+    render(<BriefingDashboard />)
+    await waitFor(() => {
+      expect(screen.getByTestId("briefing-content-error")).toBeInTheDocument()
+    })
+    // File list must still be visible despite the content error
+    expect(screen.getByTestId("briefing-dashboard")).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## Summary
- `GET /api/briefing` lists `briefing_YYYY-MM-DD[-N].md` / `local_*.md` files newest-first; `GET /api/briefing/{name}` returns raw markdown — both Bearer-protected with path-traversal guard
- `BriefingDashboard`: two-column layout — file table on left, ReactMarkdown-rendered detail on right (reuses `react-markdown` + `remark-gfm` + `rehype-sanitize`)
- Sidebar: Briefing 📚 added as top-level nav → `/briefing`

## Test plan
- [ ] `pytest` 579 passed (11 new briefing tests)
- [ ] `npx vitest run` 133 passed (7 new briefing tests)
- [ ] `npx tsc --noEmit` clean
- [ ] Navigate to `/briefing` → file list appears, click row → markdown renders

Closes #239

## Summary by Sourcery

Add a protected Briefing API and UI to browse and view markdown briefing files in the web app.

New Features:
- Expose authenticated /api/briefing endpoints to list and fetch markdown briefing files from the server.
- Add a Briefing dashboard page with a table of available briefing files and a markdown viewer for the selected file.
- Add a Briefing entry in the main sidebar navigation linking to the new dashboard.

Tests:
- Add backend tests covering briefing listing, metadata parsing, ordering, and content retrieval with auth and path-safety checks.
- Add frontend tests covering briefing dashboard loading states, file selection behavior, markdown rendering, and error and empty states.