### PR TITLE
feat(briefing): Notion-like record viewer UX for BriefingDashboard

### DIFF
--- a/apps/web/components/screens/BriefingDashboard.tsx
+++ b/apps/web/components/screens/BriefingDashboard.tsx
@@ -12,6 +12,113 @@ import {
 } from "@/lib/briefing-types"
 import { cn } from "@/lib/utils"
 
+// ── Panel view ────────────────────────────────────────────────────────────────
+
+interface PanelProps {
+  file: BriefingFile
+  content: string | null
+  loading: boolean
+  error: string | null
+  fullSize: boolean
+  onToggleFullSize: () => void
+  onClose: () => void
+}
+
+function BriefingPanel({
+  file,
+  content,
+  loading,
+  error,
+  fullSize,
+  onToggleFullSize,
+  onClose,
+}: PanelProps) {
+  return (
+    <div
+      data-testid="briefing-panel"
+      className={cn(
+        "flex flex-col overflow-hidden border-l bg-background transition-all",
+        fullSize ? "fixed inset-0 z-50" : "relative",
+      )}
+    >
+      {/* Panel header */}
+      <div className="flex items-center justify-between border-b px-4 py-2">
+        <div className="flex gap-3 text-xs text-muted-foreground">
+          <span data-testid="panel-type">{BRIEFING_TYPE_LABELS[file.type]}</span>
+          <span data-testid="panel-date">{file.date}</span>
+          <span data-testid="panel-size">{(file.size / 1024).toFixed(1)} KB</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            data-testid="panel-fullsize-btn"
+            onClick={onToggleFullSize}
+            aria-label={fullSize ? "Collapse" : "Full size"}
+            className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+          >
+            {fullSize ? (
+              // Compress icon
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M8 3v3a2 2 0 0 1-2 2H3" />
+                <path d="M21 8h-3a2 2 0 0 1-2-2V3" />
+                <path d="M3 16h3a2 2 0 0 1 2 2v3" />
+                <path d="M16 21v-3a2 2 0 0 1 2-2h3" />
+              </svg>
+            ) : (
+              // Expand icon
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M15 3h6v6" />
+                <path d="M9 21H3v-6" />
+                <path d="M21 3l-7 7" />
+                <path d="M3 21l7-7" />
+              </svg>
+            )}
+          </button>
+          <button
+            data-testid="panel-close-btn"
+            onClick={onClose}
+            aria-label="Close panel"
+            className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {/* Panel title */}
+      <div className="border-b px-4 py-3">
+        <h2 className="text-sm font-semibold" data-testid="panel-title">{file.name}</h2>
+      </div>
+
+      {/* Panel body */}
+      <div className="flex-1 overflow-y-auto px-4 py-4">
+        {loading ? (
+          <p data-testid="briefing-content-loading" className="text-sm text-muted-foreground">
+            Loading…
+          </p>
+        ) : error !== null ? (
+          <p data-testid="briefing-content-error" className="text-sm text-destructive">
+            Failed to load content: {error}
+          </p>
+        ) : content !== null ? (
+          <div
+            data-testid="briefing-content"
+            className="prose prose-sm max-w-none dark:prose-invert"
+          >
+            <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]}>
+              {content}
+            </ReactMarkdown>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+// ── Main dashboard ─────────────────────────────────────────────────────────────
+
 export function BriefingDashboard() {
   const [files, setFiles] = useState<BriefingFile[] | null>(null)
   const [selected, setSelected] = useState<BriefingFile | null>(null)
@@ -19,10 +126,9 @@ export function BriefingDashboard() {
   const [loadingContent, setLoadingContent] = useState(false)
   const [listError, setListError] = useState<string | null>(null)
   const [contentError, setContentError] = useState<string | null>(null)
+  const [fullSize, setFullSize] = useState(false)
 
-  // In-memory cache so revisiting a row is instant (no re-fetch).
   const contentCache = useRef(new Map<string, string>())
-  // Tracks the most recently requested file to discard stale responses.
   const latestFile = useRef<string | null>(null)
 
   const fetchContent = useCallback((file: BriefingFile) => {
@@ -58,7 +164,6 @@ export function BriefingDashboard() {
       })
   }, [])
 
-  // Fire-and-forget prefetch on hover; silently populates the cache.
   const prefetch = useCallback((file: BriefingFile) => {
     if (contentCache.current.has(file.name)) return
     fetch(`/api/briefing/${encodeURIComponent(file.name)}`, { cache: "no-store" })
@@ -79,10 +184,6 @@ export function BriefingDashboard() {
       .then((data) => {
         if (cancelled) return
         setFiles(data.files)
-        if (data.files.length > 0) {
-          // Start content fetch immediately — no intermediate state-cycle delay.
-          fetchContent(data.files[0])
-        }
       })
       .catch((e) => {
         if (!cancelled) setListError(String(e))
@@ -90,7 +191,14 @@ export function BriefingDashboard() {
     return () => {
       cancelled = true
     }
-  }, [fetchContent])
+  }, [])
+
+  const handleClose = useCallback(() => {
+    setSelected(null)
+    setContent(null)
+    setContentError(null)
+    setFullSize(false)
+  }, [])
 
   if (listError) {
     return (
@@ -117,70 +225,110 @@ export function BriefingDashboard() {
   }
 
   return (
-    <div data-testid="briefing-dashboard" className="flex h-full gap-4">
-      {/* File list */}
-      <aside className="w-64 shrink-0 overflow-y-auto rounded-md border">
+    <div data-testid="briefing-dashboard" className="flex h-full">
+      {/* Records list */}
+      <div
+        className={cn(
+          "flex-shrink-0 overflow-y-auto border-r transition-all",
+          selected && !fullSize ? "w-72" : "flex-1",
+          fullSize && "hidden",
+        )}
+      >
         <table className="w-full text-sm">
           <thead>
             <tr className="border-b bg-muted/50 text-left text-xs text-muted-foreground">
               <th className="px-3 py-2">Name</th>
               <th className="px-3 py-2">Type</th>
               <th className="px-3 py-2">Date</th>
+              <th className="w-8 px-3 py-2" />
             </tr>
           </thead>
           <tbody>
             {files.map((file) => (
-              <tr
+              <BriefingRow
                 key={file.name}
-                data-testid={`briefing-row-${file.name}`}
-                tabIndex={0}
-                onClick={() => fetchContent(file)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault()
-                    fetchContent(file)
-                  }
-                }}
-                onMouseEnter={() => prefetch(file)}
-                className={cn(
-                  "cursor-pointer border-b text-xs transition-colors last:border-0",
-                  selected?.name === file.name
-                    ? "bg-accent font-medium text-accent-foreground"
-                    : "hover:bg-accent/50",
-                )}
-              >
-                <td className="max-w-[120px] truncate px-3 py-2" title={file.name}>
-                  {file.name}
-                </td>
-                <td className="px-3 py-2">{BRIEFING_TYPE_LABELS[file.type]}</td>
-                <td className="px-3 py-2 tabular-nums">{file.date}</td>
-              </tr>
+                file={file}
+                selected={selected?.name === file.name}
+                onOpen={fetchContent}
+                onHover={prefetch}
+              />
             ))}
           </tbody>
         </table>
-      </aside>
+      </div>
 
-      {/* Markdown detail */}
-      <main className="min-w-0 flex-1 overflow-y-auto">
-        {loadingContent ? (
-          <p data-testid="briefing-content-loading" className="text-sm text-muted-foreground">
-            Loading…
-          </p>
-        ) : contentError !== null ? (
-          <p data-testid="briefing-content-error" className="text-sm text-destructive">
-            Failed to load content: {contentError}
-          </p>
-        ) : content !== null ? (
-          <div
-            data-testid="briefing-content"
-            className="prose prose-sm max-w-none dark:prose-invert"
-          >
-            <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]}>
-              {content}
-            </ReactMarkdown>
-          </div>
-        ) : null}
-      </main>
+      {/* Side panel */}
+      {selected && (
+        <div className={cn("flex-1 overflow-hidden", fullSize && "flex-1")}>
+          <BriefingPanel
+            file={selected}
+            content={content}
+            loading={loadingContent}
+            error={contentError}
+            fullSize={fullSize}
+            onToggleFullSize={() => setFullSize((v) => !v)}
+            onClose={handleClose}
+          />
+        </div>
+      )}
     </div>
+  )
+}
+
+// ── Row with hover open icon ───────────────────────────────────────────────────
+
+interface RowProps {
+  file: BriefingFile
+  selected: boolean
+  onOpen: (file: BriefingFile) => void
+  onHover: (file: BriefingFile) => void
+}
+
+function BriefingRow({ file, selected, onOpen, onHover }: RowProps) {
+  const [hovered, setHovered] = useState(false)
+
+  return (
+    <tr
+      data-testid={`briefing-row-${file.name}`}
+      tabIndex={0}
+      onMouseEnter={() => {
+        setHovered(true)
+        onHover(file)
+      }}
+      onMouseLeave={() => setHovered(false)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault()
+          onOpen(file)
+        }
+      }}
+      className={cn(
+        "group border-b text-xs transition-colors last:border-0",
+        selected ? "bg-accent font-medium text-accent-foreground" : "hover:bg-accent/50",
+      )}
+    >
+      <td className="max-w-[160px] truncate px-3 py-2" title={file.name}>
+        {file.name}
+      </td>
+      <td className="px-3 py-2">{BRIEFING_TYPE_LABELS[file.type]}</td>
+      <td className="px-3 py-2 tabular-nums">{file.date}</td>
+      <td className="px-2 py-2">
+        <button
+          data-testid={`briefing-open-${file.name}`}
+          onClick={() => onOpen(file)}
+          aria-label={`Open ${file.name}`}
+          className={cn(
+            "rounded p-0.5 text-muted-foreground transition-opacity hover:bg-accent hover:text-accent-foreground",
+            hovered ? "opacity-100" : "opacity-0",
+          )}
+        >
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+            <polyline points="15 3 21 3 21 9" />
+            <line x1="10" y1="14" x2="21" y2="3" />
+          </svg>
+        </button>
+      </td>
+    </tr>
   )
 }

--- a/apps/web/components/screens/BriefingDashboard.tsx
+++ b/apps/web/components/screens/BriefingDashboard.tsx
@@ -38,7 +38,7 @@ function BriefingPanel({
       data-testid="briefing-panel"
       className={cn(
         "flex flex-col overflow-hidden border-l bg-background transition-all",
-        fullSize ? "fixed inset-0 z-50" : "relative",
+        "relative",
       )}
     >
       {/* Panel header */}
@@ -225,7 +225,7 @@ export function BriefingDashboard() {
   }
 
   return (
-    <div data-testid="briefing-dashboard" className="flex h-full">
+    <div data-testid="briefing-dashboard" className="relative flex h-full">
       {/* Records list */}
       <div
         className={cn(
@@ -257,18 +257,35 @@ export function BriefingDashboard() {
         </table>
       </div>
 
-      {/* Side panel */}
-      {selected && (
-        <div className={cn("flex-1 overflow-hidden", fullSize && "flex-1")}>
+      {/* Side panel — normal mode */}
+      {selected && !fullSize && (
+        <div className="flex-1 overflow-hidden">
           <BriefingPanel
             file={selected}
             content={content}
             loading={loadingContent}
             error={contentError}
-            fullSize={fullSize}
-            onToggleFullSize={() => setFullSize((v) => !v)}
+            fullSize={false}
+            onToggleFullSize={() => setFullSize(true)}
             onClose={handleClose}
           />
+        </div>
+      )}
+
+      {/* Full-size overlay within main content area (sidebar stays visible) */}
+      {selected && fullSize && (
+        <div className="absolute inset-0 grid grid-cols-[1fr_8fr_1fr] bg-background">
+          <div />
+          <BriefingPanel
+            file={selected}
+            content={content}
+            loading={loadingContent}
+            error={contentError}
+            fullSize={true}
+            onToggleFullSize={() => setFullSize(false)}
+            onClose={handleClose}
+          />
+          <div />
         </div>
       )}
     </div>

--- a/apps/web/components/screens/BriefingDashboard.tsx
+++ b/apps/web/components/screens/BriefingDashboard.tsx
@@ -408,6 +408,7 @@ export function BriefingDashboard() {
     <div data-testid="briefing-dashboard" className="flex h-full">
       {/* Records list */}
       <div
+        data-testid="briefing-records-list"
         className={cn(
           "flex-shrink-0 overflow-y-auto border-r transition-all",
           selected && !fullSize ? "w-72" : "flex-1",
@@ -439,7 +440,7 @@ export function BriefingDashboard() {
 
       {/* Side panel */}
       {selected && (
-        <div className={cn("overflow-hidden", fullSize ? "flex-1" : "flex-1")}>
+        <div className="flex-1 overflow-hidden">
           <BriefingPanel
             file={selected}
             content={content}
@@ -465,17 +466,12 @@ interface RowProps {
 }
 
 function BriefingRow({ file, selected, onOpen, onHover }: RowProps) {
-  const [hovered, setHovered] = useState(false)
-
   return (
     <tr
       data-testid={`briefing-row-${file.name}`}
       tabIndex={0}
-      onMouseEnter={() => {
-        setHovered(true)
-        onHover(file)
-      }}
-      onMouseLeave={() => setHovered(false)}
+      aria-selected={selected}
+      onMouseEnter={() => onHover(file)}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault()
@@ -497,10 +493,7 @@ function BriefingRow({ file, selected, onOpen, onHover }: RowProps) {
           data-testid={`briefing-open-${file.name}`}
           onClick={() => onOpen(file)}
           aria-label={`Open ${file.name}`}
-          className={cn(
-            "rounded p-0.5 text-muted-foreground transition-opacity hover:bg-accent hover:text-accent-foreground",
-            hovered ? "opacity-100" : "opacity-0",
-          )}
+          className="rounded p-0.5 text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-accent-foreground focus:opacity-100 group-hover:opacity-100"
         >
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
             <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />

--- a/apps/web/components/screens/BriefingDashboard.tsx
+++ b/apps/web/components/screens/BriefingDashboard.tsx
@@ -1,8 +1,11 @@
 "use client"
-import { useCallback, useEffect, useRef, useState } from "react"
+import type { Element, Nodes, Root } from "hast"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import ReactMarkdown from "react-markdown"
+import { defaultSchema } from "rehype-sanitize"
 import rehypeSanitize from "rehype-sanitize"
 import remarkGfm from "remark-gfm"
+import { visit } from "unist-util-visit"
 
 import {
   BriefingFile,
@@ -11,6 +14,132 @@ import {
   BRIEFING_TYPE_LABELS,
 } from "@/lib/briefing-types"
 import { cn } from "@/lib/utils"
+
+// ── TOC helpers ───────────────────────────────────────────────────────────────
+
+interface TocEntry {
+  id: string
+  text: string
+  level: number
+}
+
+// Slug used for heading ids. It only needs to be identical between extractToc
+// and the rehype plugin (CSS.escape handles any leftover characters at query
+// time), so we avoid \p{…} unicode escapes for broad target compatibility.
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[\s]+/g, "-")
+    .replace(/["'`()[\]{}<>（）「」、。,.!?！？:：;；/\\|#*~]/g, "")
+}
+
+// Extract text from a hast node recursively
+function hastText(node: Nodes): string {
+  if (node.type === "text") return node.value
+  if ("children" in node) return node.children.map(hastText).join("")
+  return ""
+}
+
+// rehype plugin: attach id to h1/h2/h3 before sanitization
+function rehypeHeadingIds() {
+  return (tree: Root) => {
+    const seen = new Map<string, number>()
+    visit(tree, "element", (node: Element) => {
+      if (!/^h[1-3]$/.test(node.tagName)) return
+      const text = hastText(node)
+      const base = slugify(text)
+      const count = seen.get(base) ?? 0
+      const id = count === 0 ? base : `${base}-${count}`
+      seen.set(base, count + 1)
+      node.properties = { ...node.properties, id }
+    })
+  }
+}
+
+// Allow id on heading elements so TOC scroll targets survive sanitization.
+// clobberPrefix is cleared so heading ids match the slugs computed in extractToc
+// (default prefixes them with "user-content-", breaking querySelector lookups).
+const sanitizeSchema = {
+  ...defaultSchema,
+  clobberPrefix: "",
+  attributes: {
+    ...defaultSchema.attributes,
+    h1: [...(defaultSchema.attributes?.h1 ?? []), "id"],
+    h2: [...(defaultSchema.attributes?.h2 ?? []), "id"],
+    h3: [...(defaultSchema.attributes?.h3 ?? []), "id"],
+  },
+}
+
+function extractToc(markdown: string): TocEntry[] {
+  const entries: TocEntry[] = []
+  const seen = new Map<string, number>()
+  for (const line of markdown.split("\n")) {
+    const m = line.match(/^(#{1,3})\s+(.+)/)
+    if (!m) continue
+    const level = m[1].length
+    const text = m[2].trim()
+    const base = slugify(text)
+    const count = seen.get(base) ?? 0
+    const id = count === 0 ? base : `${base}-${count}`
+    seen.set(base, count + 1)
+    entries.push({ id, text, level })
+  }
+  return entries
+}
+
+// ── TOC sidebar ───────────────────────────────────────────────────────────────
+
+interface TocProps {
+  entries: TocEntry[]
+  scrollContainer: React.RefObject<HTMLDivElement | null>
+  activeId: string | null
+  onClose: () => void
+}
+
+function Toc({ entries, scrollContainer, activeId, onClose }: TocProps) {
+  if (entries.length === 0) return null
+
+  const scrollTo = (id: string) => {
+    const root = scrollContainer.current
+    const el = root?.querySelector<HTMLElement>(`[id="${CSS.escape(id)}"]`)
+    if (el) {
+      // scrollIntoView walks every scrollable ancestor and brings the heading to
+      // the top. scroll-margin-top (set in the className below) keeps it clear of
+      // the sticky header.
+      el.scrollIntoView({ behavior: "smooth", block: "start" })
+    }
+    onClose()
+  }
+
+  return (
+    <nav
+      data-testid="briefing-toc"
+      className="absolute right-0 top-0 bottom-0 w-56 overflow-y-auto border-l bg-background/30 px-3 py-4 backdrop-blur-sm"
+    >
+      <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        目次
+      </p>
+      <ul className="space-y-0.5">
+        {entries.map((entry) => (
+          <li key={entry.id}>
+            <button
+              onClick={() => scrollTo(entry.id)}
+              className={cn(
+                "w-full rounded px-2 py-1 text-left text-xs transition-colors hover:bg-accent hover:text-accent-foreground",
+                entry.level === 1 && "font-medium",
+                entry.level === 2 && "pl-4 text-muted-foreground",
+                entry.level === 3 && "pl-6 text-muted-foreground/70",
+                activeId === entry.id && "bg-accent/60 text-accent-foreground",
+              )}
+            >
+              {entry.text}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}
 
 // ── Panel view ────────────────────────────────────────────────────────────────
 
@@ -33,12 +162,37 @@ function BriefingPanel({
   onToggleFullSize,
   onClose,
 }: PanelProps) {
+  const [tocVisible, setTocVisible] = useState(false)
+  const [activeId, setActiveId] = useState<string | null>(null)
+  const bodyRef = useRef<HTMLDivElement>(null)
+
+  const toc = useMemo(() => (content ? extractToc(content) : []), [content])
+
+  // Track which heading is in view
+  useEffect(() => {
+    if (!bodyRef.current || toc.length === 0 || typeof IntersectionObserver === "undefined") return
+    const container = bodyRef.current
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setActiveId(entry.target.getAttribute("id"))
+            break
+          }
+        }
+      },
+      { root: container, rootMargin: "0px 0px -80% 0px", threshold: 0 },
+    )
+    container.querySelectorAll("h1[id], h2[id], h3[id]").forEach((el) => observer.observe(el))
+    return () => observer.disconnect()
+  }, [toc, content])
+
   return (
     <div
       data-testid="briefing-panel"
       className={cn(
-        "flex flex-col overflow-hidden border-l bg-background transition-all",
-        "relative",
+        "flex flex-col overflow-hidden bg-background transition-all",
+        fullSize ? "rounded-lg border" : "border-l",
       )}
     >
       {/* Panel header */}
@@ -49,6 +203,19 @@ function BriefingPanel({
           <span data-testid="panel-size">{(file.size / 1024).toFixed(1)} KB</span>
         </div>
         <div className="flex items-center gap-1">
+          {toc.length > 0 && (
+            <button
+              data-testid="panel-toc-btn"
+              onClick={() => setTocVisible((v) => !v)}
+              aria-label="Toggle table of contents"
+              className={cn(
+                "rounded p-1 text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+                tocVisible && "bg-accent text-accent-foreground",
+              )}
+            >
+              目次
+            </button>
+          )}
           <button
             data-testid="panel-fullsize-btn"
             onClick={onToggleFullSize}
@@ -56,7 +223,6 @@ function BriefingPanel({
             className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
           >
             {fullSize ? (
-              // Compress icon
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                 <path d="M8 3v3a2 2 0 0 1-2 2H3" />
                 <path d="M21 8h-3a2 2 0 0 1-2-2V3" />
@@ -64,7 +230,6 @@ function BriefingPanel({
                 <path d="M16 21v-3a2 2 0 0 1 2-2h3" />
               </svg>
             ) : (
-              // Expand icon
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                 <path d="M15 3h6v6" />
                 <path d="M9 21H3v-6" />
@@ -92,26 +257,41 @@ function BriefingPanel({
         <h2 className="text-sm font-semibold" data-testid="panel-title">{file.name}</h2>
       </div>
 
-      {/* Panel body */}
-      <div className="flex-1 overflow-y-auto px-4 py-4">
-        {loading ? (
-          <p data-testid="briefing-content-loading" className="text-sm text-muted-foreground">
-            Loading…
-          </p>
-        ) : error !== null ? (
-          <p data-testid="briefing-content-error" className="text-sm text-destructive">
-            Failed to load content: {error}
-          </p>
-        ) : content !== null ? (
-          <div
-            data-testid="briefing-content"
-            className="prose prose-sm max-w-none dark:prose-invert"
-          >
-            <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]}>
-              {content}
-            </ReactMarkdown>
-          </div>
-        ) : null}
+      {/* Panel body + TOC overlay */}
+      <div className="relative flex-1 overflow-hidden">
+        <div ref={bodyRef} className="h-full overflow-y-auto px-4 py-4 pr-6">
+          {loading ? (
+            <p data-testid="briefing-content-loading" className="text-sm text-muted-foreground">
+              Loading…
+            </p>
+          ) : error !== null ? (
+            <p data-testid="briefing-content-error" className="text-sm text-destructive">
+              Failed to load content: {error}
+            </p>
+          ) : content !== null ? (
+            <div
+              data-testid="briefing-content"
+              className="prose prose-sm max-w-none dark:prose-invert prose-headings:scroll-mt-4 prose-a:text-blue-600 prose-a:no-underline hover:prose-a:underline dark:prose-a:text-blue-400"
+            >
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeHeadingIds, [rehypeSanitize, sanitizeSchema]]}
+              >
+                {content}
+              </ReactMarkdown>
+            </div>
+          ) : null}
+        </div>
+
+        {/* TOC — appears on hover */}
+        <div
+          className={cn(
+            "pointer-events-none absolute inset-y-0 right-0 transition-opacity duration-200",
+            tocVisible ? "pointer-events-auto opacity-100" : "opacity-0",
+          )}
+        >
+          <Toc entries={toc} scrollContainer={bodyRef} activeId={activeId} onClose={() => setTocVisible(false)} />
+        </div>
       </div>
     </div>
   )
@@ -225,7 +405,7 @@ export function BriefingDashboard() {
   }
 
   return (
-    <div data-testid="briefing-dashboard" className="relative flex h-full">
+    <div data-testid="briefing-dashboard" className="flex h-full">
       {/* Records list */}
       <div
         className={cn(
@@ -257,35 +437,18 @@ export function BriefingDashboard() {
         </table>
       </div>
 
-      {/* Side panel — normal mode */}
-      {selected && !fullSize && (
-        <div className="flex-1 overflow-hidden">
+      {/* Side panel */}
+      {selected && (
+        <div className={cn("overflow-hidden", fullSize ? "flex-1" : "flex-1")}>
           <BriefingPanel
             file={selected}
             content={content}
             loading={loadingContent}
             error={contentError}
-            fullSize={false}
-            onToggleFullSize={() => setFullSize(true)}
+            fullSize={fullSize}
+            onToggleFullSize={() => setFullSize((v) => !v)}
             onClose={handleClose}
           />
-        </div>
-      )}
-
-      {/* Full-size overlay within main content area (sidebar stays visible) */}
-      {selected && fullSize && (
-        <div className="absolute inset-0 grid grid-cols-[1fr_8fr_1fr] bg-background">
-          <div />
-          <BriefingPanel
-            file={selected}
-            content={content}
-            loading={loadingContent}
-            error={contentError}
-            fullSize={true}
-            onToggleFullSize={() => setFullSize(false)}
-            onClose={handleClose}
-          />
-          <div />
         </div>
       )}
     </div>

--- a/apps/web/tests/briefing-dashboard.test.tsx
+++ b/apps/web/tests/briefing-dashboard.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { BriefingDashboard } from "@/components/screens/BriefingDashboard"
 
+
 const FILES_RESPONSE = {
   files: [
     { name: "briefing_2026-06-20.md", type: "briefing", date: "2026-06-20", size: 5120 },
@@ -139,7 +140,10 @@ describe("BriefingDashboard", () => {
 
     await waitFor(() => {
       const content = screen.getByTestId("briefing-content")
-      expect(content.querySelector("h1")).toBeTruthy()
+      const h1 = content.querySelector("h1")
+      expect(h1).toBeTruthy()
+      // rehypeHeadingIds must attach a slug id that survives sanitization
+      expect(h1?.getAttribute("id")).toBe("june-20-briefing")
       expect(content).toHaveTextContent("Today's market summary.")
     })
   })
@@ -197,5 +201,52 @@ describe("BriefingDashboard", () => {
       expect(screen.getByTestId("briefing-panel")).toBeInTheDocument()
       expect(screen.getByTestId("briefing-content")).toHaveTextContent("June 19 via keyboard")
     })
+  })
+})
+
+describe("TOC navigation", () => {
+  beforeEach(() => {
+    fetchMock.mockReset()
+    vi.stubGlobal("fetch", fetchMock)
+  })
+
+  it("gives Japanese headings ids that match the TOC slugs and scrolls on click", async () => {
+    const jp = {
+      name: "briefing_2026-06-20.md",
+      content: "## 今日のサマリー（1文）\n\n本文A\n\n## なぜ動いたか（ストーリー）\n\n本文B",
+    }
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/api/briefing/")) return Promise.resolve(jsonResponse(jp))
+      return Promise.resolve(jsonResponse(FILES_RESPONSE))
+    })
+    render(<BriefingDashboard />)
+    await waitFor(() => expect(screen.getByTestId("briefing-dashboard")).toBeInTheDocument())
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId("briefing-open-briefing_2026-06-20.md"))
+
+    let h2s: HTMLElement[] = []
+    await waitFor(() => {
+      const content = screen.getByTestId("briefing-content")
+      h2s = Array.from(content.querySelectorAll("h2")) as HTMLElement[]
+      // ids must NOT carry sanitize's "user-content-" prefix, so they match extractToc slugs
+      expect(h2s.map((h) => h.getAttribute("id"))).toEqual([
+        "今日のサマリー1文",
+        "なぜ動いたかストーリー",
+      ])
+    })
+
+    // scrollIntoView is the scroll mechanism; jsdom doesn't implement it
+    const scrollIntoView = vi.fn()
+    h2s[1].scrollIntoView = scrollIntoView
+
+    await user.click(screen.getByTestId("panel-toc-btn"))
+    const target = screen
+      .getAllByRole("button")
+      .find((b) => b.textContent === "なぜ動いたか（ストーリー）") as HTMLElement
+    await user.click(target)
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" })
+    // clicking a TOC entry closes the TOC
+    expect(screen.queryByTestId("briefing-toc")?.closest(".opacity-0")).toBeTruthy()
   })
 })

--- a/apps/web/tests/briefing-dashboard.test.tsx
+++ b/apps/web/tests/briefing-dashboard.test.tsx
@@ -6,9 +6,9 @@ import { BriefingDashboard } from "@/components/screens/BriefingDashboard"
 
 const FILES_RESPONSE = {
   files: [
-    { name: "briefing_2026-06-20.md", type: "briefing", date: "2026-06-20", size: 512 },
-    { name: "briefing_2026-06-19.md", type: "briefing", date: "2026-06-19", size: 256 },
-    { name: "local_2026-06-18.md", type: "local", date: "2026-06-18", size: 128 },
+    { name: "briefing_2026-06-20.md", type: "briefing", date: "2026-06-20", size: 5120 },
+    { name: "briefing_2026-06-19.md", type: "briefing", date: "2026-06-19", size: 2560 },
+    { name: "local_2026-06-18.md", type: "local", date: "2026-06-18", size: 1280 },
   ],
 }
 
@@ -41,12 +41,8 @@ describe("BriefingDashboard", () => {
     expect(screen.getByTestId("briefing-loading")).toBeInTheDocument()
   })
 
-  it("renders file list as table rows", async () => {
-    fetchMock.mockImplementation((url: string) => {
-      if (url.includes("/api/briefing/")) return Promise.resolve(jsonResponse(CONTENT_RESPONSE))
-      return Promise.resolve(jsonResponse(FILES_RESPONSE))
-    })
-
+  it("renders file list as table rows without auto-opening panel", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(FILES_RESPONSE))
     render(<BriefingDashboard />)
 
     await waitFor(() => {
@@ -55,26 +51,11 @@ describe("BriefingDashboard", () => {
     expect(screen.getByTestId("briefing-row-briefing_2026-06-20.md")).toBeInTheDocument()
     expect(screen.getByTestId("briefing-row-briefing_2026-06-19.md")).toBeInTheDocument()
     expect(screen.getByTestId("briefing-row-local_2026-06-18.md")).toBeInTheDocument()
+    expect(screen.queryByTestId("briefing-panel")).not.toBeInTheDocument()
   })
 
-  it("auto-selects and loads the first file on mount", async () => {
+  it("opens side panel when the open icon is clicked", async () => {
     fetchMock.mockImplementation((url: string) => {
-      if (url.includes("/api/briefing/")) return Promise.resolve(jsonResponse(CONTENT_RESPONSE))
-      return Promise.resolve(jsonResponse(FILES_RESPONSE))
-    })
-
-    render(<BriefingDashboard />)
-
-    await waitFor(() => {
-      expect(screen.getByTestId("briefing-content")).toBeInTheDocument()
-    })
-    expect(screen.getByTestId("briefing-content")).toHaveTextContent("June 20 Briefing")
-  })
-
-  it("loads content when a different row is clicked", async () => {
-    const otherContent = { name: "briefing_2026-06-19.md", content: "# June 19 Briefing" }
-    fetchMock.mockImplementation((url: string) => {
-      if (url.includes("briefing_2026-06-19")) return Promise.resolve(jsonResponse(otherContent))
       if (url.includes("/api/briefing/")) return Promise.resolve(jsonResponse(CONTENT_RESPONSE))
       return Promise.resolve(jsonResponse(FILES_RESPONSE))
     })
@@ -83,20 +64,77 @@ describe("BriefingDashboard", () => {
     await waitFor(() => expect(screen.getByTestId("briefing-dashboard")).toBeInTheDocument())
 
     const user = userEvent.setup()
-    await user.click(screen.getByTestId("briefing-row-briefing_2026-06-19.md"))
+    await user.click(screen.getByTestId("briefing-open-briefing_2026-06-20.md"))
 
     await waitFor(() => {
-      expect(screen.getByTestId("briefing-content")).toHaveTextContent("June 19 Briefing")
+      expect(screen.getByTestId("briefing-panel")).toBeInTheDocument()
     })
+    expect(screen.getByTestId("briefing-content")).toHaveTextContent("June 20 Briefing")
   })
 
-  it("renders markdown content (headings, text)", async () => {
+  it("shows properties (type, date, size) in the panel header", async () => {
     fetchMock.mockImplementation((url: string) => {
       if (url.includes("/api/briefing/")) return Promise.resolve(jsonResponse(CONTENT_RESPONSE))
       return Promise.resolve(jsonResponse(FILES_RESPONSE))
     })
 
     render(<BriefingDashboard />)
+    await waitFor(() => expect(screen.getByTestId("briefing-dashboard")).toBeInTheDocument())
+
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId("briefing-open-briefing_2026-06-20.md"))
+
+    await waitFor(() => expect(screen.getByTestId("briefing-panel")).toBeInTheDocument())
+    expect(screen.getByTestId("panel-date")).toHaveTextContent("2026-06-20")
+    expect(screen.getByTestId("panel-size")).toBeInTheDocument()
+  })
+
+  it("closes the panel when the close button is clicked", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/api/briefing/")) return Promise.resolve(jsonResponse(CONTENT_RESPONSE))
+      return Promise.resolve(jsonResponse(FILES_RESPONSE))
+    })
+
+    render(<BriefingDashboard />)
+    await waitFor(() => expect(screen.getByTestId("briefing-dashboard")).toBeInTheDocument())
+
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId("briefing-open-briefing_2026-06-20.md"))
+    await waitFor(() => expect(screen.getByTestId("briefing-panel")).toBeInTheDocument())
+
+    await user.click(screen.getByTestId("panel-close-btn"))
+    expect(screen.queryByTestId("briefing-panel")).not.toBeInTheDocument()
+  })
+
+  it("toggles full-size view", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/api/briefing/")) return Promise.resolve(jsonResponse(CONTENT_RESPONSE))
+      return Promise.resolve(jsonResponse(FILES_RESPONSE))
+    })
+
+    render(<BriefingDashboard />)
+    await waitFor(() => expect(screen.getByTestId("briefing-dashboard")).toBeInTheDocument())
+
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId("briefing-open-briefing_2026-06-20.md"))
+    await waitFor(() => expect(screen.getByTestId("briefing-panel")).toBeInTheDocument())
+
+    const fullSizeBtn = screen.getByTestId("panel-fullsize-btn")
+    await user.click(fullSizeBtn)
+    expect(screen.getByTestId("briefing-panel")).toHaveClass("fixed")
+  })
+
+  it("renders markdown content in the panel", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/api/briefing/")) return Promise.resolve(jsonResponse(CONTENT_RESPONSE))
+      return Promise.resolve(jsonResponse(FILES_RESPONSE))
+    })
+
+    render(<BriefingDashboard />)
+    await waitFor(() => expect(screen.getByTestId("briefing-dashboard")).toBeInTheDocument())
+
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId("briefing-open-briefing_2026-06-20.md"))
 
     await waitFor(() => {
       const content = screen.getByTestId("briefing-content")
@@ -126,7 +164,13 @@ describe("BriefingDashboard", () => {
       if (url === "/api/briefing") return Promise.resolve(jsonResponse(FILES_RESPONSE))
       return Promise.reject(new Error("content fetch failed"))
     })
+
     render(<BriefingDashboard />)
+    await waitFor(() => expect(screen.getByTestId("briefing-dashboard")).toBeInTheDocument())
+
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId("briefing-open-briefing_2026-06-20.md"))
+
     await waitFor(() => {
       expect(screen.getByTestId("briefing-content-error")).toBeInTheDocument()
     })
@@ -149,6 +193,7 @@ describe("BriefingDashboard", () => {
     await user.type(row, "{Enter}")
 
     await waitFor(() => {
+      expect(screen.getByTestId("briefing-panel")).toBeInTheDocument()
       expect(screen.getByTestId("briefing-content")).toHaveTextContent("June 19 via keyboard")
     })
   })

--- a/apps/web/tests/briefing-dashboard.test.tsx
+++ b/apps/web/tests/briefing-dashboard.test.tsx
@@ -86,8 +86,11 @@ describe("BriefingDashboard", () => {
     await user.click(screen.getByTestId("briefing-open-briefing_2026-06-20.md"))
 
     await waitFor(() => expect(screen.getByTestId("briefing-panel")).toBeInTheDocument())
+    // type shows the mapped label, not the raw enum
+    expect(screen.getByTestId("panel-type")).toHaveTextContent("Briefing")
     expect(screen.getByTestId("panel-date")).toHaveTextContent("2026-06-20")
-    expect(screen.getByTestId("panel-size")).toBeInTheDocument()
+    // 5120 bytes formats to "5.0 KB"
+    expect(screen.getByTestId("panel-size")).toHaveTextContent("5.0 KB")
   })
 
   it("closes the panel when the close button is clicked", async () => {
@@ -120,10 +123,19 @@ describe("BriefingDashboard", () => {
     await user.click(screen.getByTestId("briefing-open-briefing_2026-06-20.md"))
     await waitFor(() => expect(screen.getByTestId("briefing-panel")).toBeInTheDocument())
 
+    const recordsList = screen.getByTestId("briefing-records-list")
+    expect(recordsList).not.toHaveClass("hidden")
+
     const fullSizeBtn = screen.getByTestId("panel-fullsize-btn")
+
+    // Expand: records list is hidden, panel stays mounted
     await user.click(fullSizeBtn)
-    // Full-size renders panel inside an absolute grid overlay (sidebar stays visible)
+    await waitFor(() => expect(screen.getByTestId("briefing-records-list")).toHaveClass("hidden"))
     expect(screen.getByTestId("briefing-panel")).toBeInTheDocument()
+
+    // Collapse: records list visible again
+    await user.click(screen.getByTestId("panel-fullsize-btn"))
+    await waitFor(() => expect(screen.getByTestId("briefing-records-list")).not.toHaveClass("hidden"))
   })
 
   it("renders markdown content in the panel", async () => {

--- a/apps/web/tests/briefing-dashboard.test.tsx
+++ b/apps/web/tests/briefing-dashboard.test.tsx
@@ -121,7 +121,8 @@ describe("BriefingDashboard", () => {
 
     const fullSizeBtn = screen.getByTestId("panel-fullsize-btn")
     await user.click(fullSizeBtn)
-    expect(screen.getByTestId("briefing-panel")).toHaveClass("fixed")
+    // Full-size renders panel inside an absolute grid overlay (sidebar stays visible)
+    expect(screen.getByTestId("briefing-panel")).toBeInTheDocument()
   })
 
   it("renders markdown content in the panel", async () => {


### PR DESCRIPTION
## Summary

- Replace two-column layout with records-list + side-panel pattern (Notion-style)
- Hover on row reveals open icon; clicking it slides in a right panel with properties + markdown
- Full-size toggle expands panel to fixed overlay; close button returns to the list
- Keyboard: Enter/Space on row opens the panel

## Test plan

- [x] 11 Vitest tests pass (panel open/close, full-size toggle, properties display, content error, keyboard nav)

Closes #246

## Summary by Sourcery

Adopt a records-list and side-panel layout for the Briefing dashboard, with an openable markdown viewer panel that supports full-size mode and can be closed.

New Features:
- Add a BriefingPanel component that displays selected briefing metadata and markdown content in a side panel with optional full-screen overlay.
- Introduce a hover-activated open icon on briefing rows and keyboard interactions to open the panel from the list view.

Enhancements:
- Refine the BriefingDashboard layout to decouple file selection from initial load and avoid auto-opening the first file.
- Update briefing file size handling and display to show human-readable sizes in the panel header.

Tests:
- Expand BriefingDashboard Vitest coverage to cover panel open/close behavior, full-size toggling, property display, markdown rendering, error handling, and keyboard navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clickable table of contents sidebar for navigating briefing headings
  * Redesigned layout with dedicated side panel for viewing briefing content
  * Added full-size view toggle to expand content panel
  * Improved keyboard navigation and heading scroll behavior with intelligent spacing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->