### PR TITLE
fix(briefing): keep panel header fixed, scroll regions independently

### DIFF
--- a/apps/web/app/(main)/briefing/page.tsx
+++ b/apps/web/app/(main)/briefing/page.tsx
@@ -6,7 +6,7 @@ export default function BriefingPage() {
   return (
     <div className="flex h-full flex-col gap-4 p-6">
       <h1 className="text-lg font-semibold">Briefing</h1>
-      <div className="flex-1 overflow-hidden">
+      <div className="min-h-0 flex-1 overflow-hidden">
         <BriefingDashboard />
       </div>
     </div>

--- a/apps/web/app/(main)/layout.tsx
+++ b/apps/web/app/(main)/layout.tsx
@@ -30,9 +30,9 @@ export default async function MainLayout({
     <JobStateProvider>
       <ChatStateProvider>
         <ChatJobStateProvider>
-          <div className="flex min-h-screen">
+          <div className="flex h-screen overflow-hidden">
             <Sidebar />
-            <main className="flex-1 p-8">{children}</main>
+            <main className="flex-1 overflow-y-auto p-8">{children}</main>
           </div>
         </ChatJobStateProvider>
       </ChatStateProvider>

--- a/apps/web/app/(main)/layout.tsx
+++ b/apps/web/app/(main)/layout.tsx
@@ -30,7 +30,7 @@ export default async function MainLayout({
     <JobStateProvider>
       <ChatStateProvider>
         <ChatJobStateProvider>
-          <div className="flex h-screen overflow-hidden">
+          <div className="flex h-dvh overflow-hidden">
             <Sidebar />
             <main className="flex-1 overflow-y-auto p-8">{children}</main>
           </div>

--- a/apps/web/components/Sidebar.tsx
+++ b/apps/web/components/Sidebar.tsx
@@ -67,7 +67,7 @@ export function Sidebar() {
       data-sidebar-rail
       data-testid="sidebar"
       data-collapsed={collapsed}
-      className="flex flex-col gap-4 border-r bg-card p-4"
+      className="flex shrink-0 flex-col gap-4 overflow-y-auto border-r bg-card p-4"
     >
       <div data-sidebar-header className="flex items-center justify-between">
         <span data-sidebar-brand className="px-2 text-base font-semibold">

--- a/apps/web/components/Sidebar.tsx
+++ b/apps/web/components/Sidebar.tsx
@@ -67,9 +67,9 @@ export function Sidebar() {
       data-sidebar-rail
       data-testid="sidebar"
       data-collapsed={collapsed}
-      className="flex shrink-0 flex-col gap-4 overflow-y-auto border-r bg-card p-4"
+      className="flex shrink-0 flex-col gap-4 overflow-hidden border-r bg-card p-4"
     >
-      <div data-sidebar-header className="flex items-center justify-between">
+      <div data-sidebar-header className="flex shrink-0 items-center justify-between">
         <span data-sidebar-brand className="px-2 text-base font-semibold">
           ai-agent
         </span>
@@ -86,6 +86,7 @@ export function Sidebar() {
         </button>
       </div>
 
+      <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto">
       <section className="flex flex-col gap-1">
         <nav className="flex flex-col gap-1">
           {ITEMS.map((item) => {
@@ -165,6 +166,7 @@ export function Sidebar() {
           </div>
         </SidebarDisclosure>
       </section>
+      </div>
     </aside>
   )
 }

--- a/apps/web/components/briefing/BriefingPanel.tsx
+++ b/apps/web/components/briefing/BriefingPanel.tsx
@@ -74,7 +74,7 @@ export function BriefingPanel({
     <div
       data-testid="briefing-panel"
       className={cn(
-        "flex flex-col overflow-hidden bg-background transition-all",
+        "flex h-full flex-col overflow-hidden bg-background transition-all",
         fullSize ? "rounded-lg border" : "border-l",
       )}
     >
@@ -124,7 +124,7 @@ export function BriefingPanel({
       </div>
 
       {/* Panel body + TOC overlay */}
-      <div className="relative flex-1 overflow-hidden">
+      <div className="relative min-h-0 flex-1 overflow-hidden">
         <div ref={bodyRef} className="h-full overflow-y-auto px-4 py-4 pr-6">
           {loading ? (
             <p data-testid="briefing-content-loading" className="text-sm text-muted-foreground">

--- a/apps/web/components/briefing/BriefingRow.tsx
+++ b/apps/web/components/briefing/BriefingRow.tsx
@@ -16,6 +16,7 @@ export function BriefingRow({ file, selected, onOpen, onHover }: BriefingRowProp
       data-testid={`briefing-row-${file.name}`}
       tabIndex={0}
       aria-selected={selected}
+      onClick={() => onOpen(file)}
       onMouseEnter={() => onHover(file)}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
@@ -24,7 +25,7 @@ export function BriefingRow({ file, selected, onOpen, onHover }: BriefingRowProp
         }
       }}
       className={cn(
-        "group border-b text-xs transition-colors last:border-0",
+        "group cursor-pointer border-b text-xs transition-colors last:border-0",
         selected ? "bg-accent font-medium text-accent-foreground" : "hover:bg-accent/50",
       )}
     >

--- a/apps/web/components/screens/BriefingDashboard.tsx
+++ b/apps/web/components/screens/BriefingDashboard.tsx
@@ -85,7 +85,7 @@ export function BriefingDashboard() {
 
       {/* Side panel */}
       {selected && (
-        <div className="flex-1 overflow-hidden">
+        <div className="min-w-0 flex-1 overflow-hidden">
           <BriefingPanel
             file={selected}
             content={content}

--- a/apps/web/tests/briefing-dashboard.test.tsx
+++ b/apps/web/tests/briefing-dashboard.test.tsx
@@ -73,6 +73,22 @@ describe("BriefingDashboard", () => {
     expect(screen.getByTestId("briefing-content")).toHaveTextContent("June 20 Briefing")
   })
 
+  it("opens side panel when the row itself is clicked", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/api/briefing/")) return Promise.resolve(jsonResponse(CONTENT_RESPONSE))
+      return Promise.resolve(jsonResponse(FILES_RESPONSE))
+    })
+
+    render(<BriefingDashboard />)
+    await waitFor(() => expect(screen.getByTestId("briefing-dashboard")).toBeInTheDocument())
+
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId("briefing-row-briefing_2026-06-20.md"))
+
+    await waitFor(() => expect(screen.getByTestId("briefing-panel")).toBeInTheDocument())
+    expect(screen.getByTestId("briefing-content")).toHaveTextContent("June 20 Briefing")
+  })
+
   it("shows properties (type, date, size) in the panel header", async () => {
     fetchMock.mockImplementation((url: string) => {
       if (url.includes("/api/briefing/")) return Promise.resolve(jsonResponse(CONTENT_RESPONSE))


### PR DESCRIPTION
## Summary
Fixes the Briefing screen so the panel header/title stays put and the records list and body scroll separately.

Root cause: `(main)/layout.tsx` used `min-h-screen` with no definite height, so the page's inner `overflow-y-auto` regions never clipped and the whole page scrolled.

- `(main)/layout.tsx`: `min-h-screen` → `h-screen overflow-hidden`; `<main>` becomes the scroll container (`overflow-y-auto`)
- `Sidebar`: `shrink-0` + `overflow-y-auto` so the nav scrolls independently

## Test plan
- [x] tsc + eslint clean
- [x] 143 web tests pass
- [ ] Manual: panel header fixed while body scrolls; records list / body independent; other screens still scroll

Closes #249

## Summary by Sourcery

Adjust main layout and sidebar scrolling so content areas scroll independently while headers remain fixed.

Enhancements:
- Set the main layout container to a fixed viewport height with hidden overflow and make the main content area the vertical scroll container.
- Make the sidebar a non-shrinking, vertically scrollable column so its navigation can scroll independently from the main content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed layout height behavior to properly utilize viewport dimensions
  * Improved sidebar scrolling when content exceeds available space
  * Optimized main content area overflow handling for better content visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->