### PR TITLE
fix(briefing): use white prose body text in dark mode

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -82,6 +82,12 @@
 
 }
 
+/* Dark mode prose body text — override Tailwind Typography's default gray-300
+   to plain white for legibility on the dark background. */
+.dark .prose {
+  --tw-prose-invert-body: rgb(255 255 255);
+}
+
 /* Sidebar collapsed mode — kept OUTSIDE @layer base so Tailwind utilities
    can't outrank the cascade. The flag is set on <html> by the pre-hydration
    script (see app/layout.tsx / themeBootScript) so the rail starts in the


### PR DESCRIPTION
## Summary

- ダークモード時のブリーフィング本文が Tailwind Typography のデフォルト gray-300（輝度65%）で読みにくかった
- `globals.css` に `.dark .prose` の CSS 変数オーバーライドを追加し、本文色を白（`rgb(255 255 255)`）に変更

## Test plan

- [x] ダークモードでブリーフィングを開き、本文テキストが白色になっていることを確認
- [x] ライトモードでは影響なしを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GumZPcL564mLUQ5Spa7U2

## Summary by Sourcery

Enhancements:
- Override Tailwind Typography's dark mode prose body color variable to render body text as white for better readability on dark backgrounds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dark mode experience by improving typography rendering and text visibility for better contrast in dark-themed interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->