### PR TITLE
feat(briefing): dynamic Type tab filter from file list

### DIFF
--- a/apps/python/tests/test_api_briefing.py
+++ b/apps/python/tests/test_api_briefing.py
@@ -97,6 +97,32 @@ async def test_get_invalid_extension_returns_404(authed_client, briefing_dir):
     assert response.status_code == 404
 
 
+async def test_list_accepts_custom_type_prefix(authed_client, briefing_dir):
+    """A non-briefing/local type prefix (e.g. market_) is listed with its type."""
+    (briefing_dir / "market_2026-06-21.md").write_text("# Market", encoding="utf-8")
+    response = await authed_client.get("/api/briefing")
+    files = {f["name"]: f for f in response.json()["files"]}
+    assert files["market_2026-06-21.md"]["type"] == "market"
+    assert files["market_2026-06-21.md"]["date"] == "2026-06-21"
+
+
+async def test_list_ignores_non_lowercase_type_prefix(authed_client, briefing_dir):
+    """Type must start lowercase; uppercase-led names are rejected by the regex."""
+    (briefing_dir / "Market_2026-06-21.md").write_text("nope", encoding="utf-8")
+    (briefing_dir / "_2026-06-21.md").write_text("nope", encoding="utf-8")
+    response = await authed_client.get("/api/briefing")
+    names = [f["name"] for f in response.json()["files"]]
+    assert "Market_2026-06-21.md" not in names
+    assert "_2026-06-21.md" not in names
+
+
+async def test_get_accepts_custom_type_prefix(authed_client, briefing_dir):
+    (briefing_dir / "market_2026-06-21.md").write_text("# Market body", encoding="utf-8")
+    response = await authed_client.get("/api/briefing/market_2026-06-21.md")
+    assert response.status_code == 200
+    assert "Market body" in response.json()["content"]
+
+
 async def test_list_newest_first_sorted_correctly(authed_client, briefing_dir):
     """Ensure sort order: briefing_2026-06-20 > briefing_2026-06-19 > briefing_2026-06-16-001."""
     response = await authed_client.get("/api/briefing")

--- a/apps/python/web/routers/briefing.py
+++ b/apps/python/web/routers/briefing.py
@@ -4,11 +4,10 @@
 一覧表示し、選択されたファイルの Markdown 本文を返す。
 
 ファイル名規約: ``{type}_{YYYY-MM-DD}[-NNN].md``
-type は ``briefing`` または ``local`` の 2 種。
+type は任意の小文字始まりプレフィックス (``briefing`` / ``local`` / ``market`` ...)。
 """
 import re
 from pathlib import Path
-from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
@@ -19,15 +18,15 @@ router = APIRouter(dependencies=[Depends(require_bearer)])
 
 BRIEFING_DIR = Path(__file__).parents[2] / "output" / "briefing"
 
-# filename: briefing_YYYY-MM-DD[-NNN].md  or  local_YYYY-MM-DD[-NNN].md
-_FILE_RE = re.compile(r"^(briefing|local)_(\d{4}-\d{2}-\d{2})(?:-\d+)?\.md$")
+# filename: <type>_YYYY-MM-DD[-NNN].md — type is any lowercase-led prefix.
+_FILE_RE = re.compile(r"^([a-z][\w-]*?)_(\d{4}-\d{2}-\d{2})(?:-\d+)?\.md$")
 # safe-name guard: only alphanum / underscore / hyphen + .md — no path separators
 _SAFE_NAME_RE = re.compile(r"^[\w-]+\.md$")
 
 
 class BriefingFile(BaseModel):
     name: str
-    type: Literal["briefing", "local"]
+    type: str
     date: str  # YYYY-MM-DD
     size: int  # bytes
 

--- a/apps/web/components/briefing/BriefingPanel.tsx
+++ b/apps/web/components/briefing/BriefingPanel.tsx
@@ -4,7 +4,7 @@ import rehypeSanitize from "rehype-sanitize"
 import remarkGfm from "remark-gfm"
 
 import { extractToc, rehypeHeadingIds, sanitizeSchema } from "@/lib/briefing-toc"
-import { BriefingFile, BRIEFING_TYPE_LABELS } from "@/lib/briefing-types"
+import { BriefingFile, briefingTypeLabel } from "@/lib/briefing-types"
 import { cn } from "@/lib/utils"
 
 import { BriefingToc } from "./BriefingToc"
@@ -81,7 +81,7 @@ export function BriefingPanel({
       {/* Panel header */}
       <div className="flex items-center justify-between border-b px-4 py-2">
         <div className="flex gap-3 text-xs text-muted-foreground">
-          <span data-testid="panel-type">{BRIEFING_TYPE_LABELS[file.type]}</span>
+          <span data-testid="panel-type">{briefingTypeLabel(file.type)}</span>
           <span data-testid="panel-date">{file.date}</span>
           <span data-testid="panel-size">{(file.size / 1024).toFixed(1)} KB</span>
         </div>

--- a/apps/web/components/briefing/BriefingRow.tsx
+++ b/apps/web/components/briefing/BriefingRow.tsx
@@ -1,4 +1,4 @@
-import { BriefingFile, BRIEFING_TYPE_LABELS } from "@/lib/briefing-types"
+import { BriefingFile, briefingTypeLabel } from "@/lib/briefing-types"
 import { cn } from "@/lib/utils"
 
 import { ExternalLinkIcon } from "./icons"
@@ -32,7 +32,7 @@ export function BriefingRow({ file, selected, onOpen, onHover }: BriefingRowProp
       <td className="max-w-[160px] truncate px-3 py-2" title={file.name}>
         {file.name}
       </td>
-      <td className="px-3 py-2">{BRIEFING_TYPE_LABELS[file.type]}</td>
+      <td className="px-3 py-2">{briefingTypeLabel(file.type)}</td>
       <td className="px-3 py-2 tabular-nums">{file.date}</td>
       <td className="px-2 py-2">
         <button

--- a/apps/web/components/briefing/BriefingTabs.tsx
+++ b/apps/web/components/briefing/BriefingTabs.tsx
@@ -1,0 +1,49 @@
+import { BriefingFile, briefingTypeLabel } from "@/lib/briefing-types"
+import { cn } from "@/lib/utils"
+
+export const ALL_TAB = "all"
+
+interface BriefingTabsProps {
+  files: BriefingFile[]
+  selected: string
+  onSelect: (type: string) => void
+}
+
+/** Unique types present in `files`, in first-seen order. */
+export function tabTypes(files: BriefingFile[]): string[] {
+  const seen = new Set<string>()
+  const types: string[] = []
+  for (const f of files) {
+    if (!seen.has(f.type)) {
+      seen.add(f.type)
+      types.push(f.type)
+    }
+  }
+  return types
+}
+
+/** Notion-like Type filter tabs: `All` first, then one tab per type present. */
+export function BriefingTabs({ files, selected, onSelect }: BriefingTabsProps) {
+  const types = tabTypes(files)
+
+  return (
+    <div data-testid="briefing-tabs" className="flex gap-1 border-b px-2 py-1">
+      {[ALL_TAB, ...types].map((type) => (
+        <button
+          key={type}
+          data-testid={`briefing-tab-${type}`}
+          onClick={() => onSelect(type)}
+          aria-selected={selected === type}
+          className={cn(
+            "rounded px-3 py-1 text-xs transition-colors",
+            selected === type
+              ? "bg-accent font-medium text-accent-foreground"
+              : "text-muted-foreground hover:bg-accent/50",
+          )}
+        >
+          {type === ALL_TAB ? "All" : briefingTypeLabel(type)}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/apps/web/components/briefing/BriefingTabs.tsx
+++ b/apps/web/components/briefing/BriefingTabs.tsx
@@ -1,7 +1,8 @@
 import { BriefingFile, briefingTypeLabel } from "@/lib/briefing-types"
 import { cn } from "@/lib/utils"
 
-export const ALL_TAB = "all"
+// Sentinel for the "All" tab — must not collide with any real file type prefix.
+export const ALL_TAB = "__all__"
 
 interface BriefingTabsProps {
   files: BriefingFile[]

--- a/apps/web/components/screens/BriefingDashboard.tsx
+++ b/apps/web/components/screens/BriefingDashboard.tsx
@@ -1,10 +1,16 @@
 "use client"
-import { useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 
 import { BriefingPanel } from "@/components/briefing/BriefingPanel"
 import { BriefingRow } from "@/components/briefing/BriefingRow"
+import { ALL_TAB, BriefingTabs } from "@/components/briefing/BriefingTabs"
 import { useBriefingData } from "@/lib/hooks/useBriefingData"
 import { cn } from "@/lib/utils"
+
+function initialTab(): string {
+  if (typeof window === "undefined") return ALL_TAB
+  return new URLSearchParams(window.location.search).get("type") ?? ALL_TAB
+}
 
 export function BriefingDashboard() {
   const {
@@ -19,6 +25,21 @@ export function BriefingDashboard() {
     close,
   } = useBriefingData()
   const [fullSize, setFullSize] = useState(false)
+  const [tab, setTab] = useState<string>(initialTab)
+
+  // Persist the selected tab to the ?type= URL query.
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    const url = new URL(window.location.href)
+    if (tab === ALL_TAB) url.searchParams.delete("type")
+    else url.searchParams.set("type", tab)
+    window.history.replaceState(null, "", url.toString())
+  }, [tab])
+
+  const visibleFiles = useMemo(
+    () => (files ?? []).filter((f) => tab === ALL_TAB || f.type === tab),
+    [files, tab],
+  )
 
   const handleClose = () => {
     setFullSize(false)
@@ -60,6 +81,7 @@ export function BriefingDashboard() {
           fullSize && "hidden",
         )}
       >
+        <BriefingTabs files={files} selected={tab} onSelect={setTab} />
         <table className="w-full text-sm">
           <thead>
             <tr className="border-b bg-muted/50 text-left text-xs text-muted-foreground">
@@ -70,7 +92,7 @@ export function BriefingDashboard() {
             </tr>
           </thead>
           <tbody>
-            {files.map((file) => (
+            {visibleFiles.map((file) => (
               <BriefingRow
                 key={file.name}
                 file={file}

--- a/apps/web/lib/briefing-types.ts
+++ b/apps/web/lib/briefing-types.ts
@@ -1,6 +1,6 @@
 export type BriefingFile = {
   name: string
-  type: "briefing" | "local"
+  type: string
   date: string // YYYY-MM-DD
   size: number // bytes
 }
@@ -14,7 +14,12 @@ export type BriefingFileResponse = {
   content: string
 }
 
-export const BRIEFING_TYPE_LABELS: Record<BriefingFile["type"], string> = {
+const KNOWN_TYPE_LABELS: Record<string, string> = {
   briefing: "Briefing",
   local: "Local",
+}
+
+/** Map a type prefix to a display label: known → mapped, unknown → capitalized. */
+export function briefingTypeLabel(type: string): string {
+  return KNOWN_TYPE_LABELS[type] ?? (type ? type[0].toUpperCase() + type.slice(1) : type)
 }

--- a/apps/web/tests/briefing-dashboard.test.tsx
+++ b/apps/web/tests/briefing-dashboard.test.tsx
@@ -210,6 +210,51 @@ describe("BriefingDashboard", () => {
     expect(screen.getByTestId("briefing-dashboard")).toBeInTheDocument()
   })
 
+  it("renders a Type tab per type present and filters the list on select", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(FILES_RESPONSE))
+    render(<BriefingDashboard />)
+    await waitFor(() => expect(screen.getByTestId("briefing-dashboard")).toBeInTheDocument())
+
+    expect(screen.getByTestId("briefing-tab-all")).toBeInTheDocument()
+    expect(screen.getByTestId("briefing-tab-briefing")).toBeInTheDocument()
+    expect(screen.getByTestId("briefing-tab-local")).toBeInTheDocument()
+
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId("briefing-tab-local"))
+
+    // local-only after filtering
+    expect(screen.getByTestId("briefing-row-local_2026-06-18.md")).toBeInTheDocument()
+    expect(screen.queryByTestId("briefing-row-briefing_2026-06-20.md")).not.toBeInTheDocument()
+
+    // All restores everything
+    await user.click(screen.getByTestId("briefing-tab-all"))
+    expect(screen.getByTestId("briefing-row-briefing_2026-06-20.md")).toBeInTheDocument()
+  })
+
+  it("persists the selected tab to the ?type= URL query", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(FILES_RESPONSE))
+    render(<BriefingDashboard />)
+    await waitFor(() => expect(screen.getByTestId("briefing-dashboard")).toBeInTheDocument())
+
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId("briefing-tab-local"))
+    expect(new URLSearchParams(window.location.search).get("type")).toBe("local")
+
+    await user.click(screen.getByTestId("briefing-tab-all"))
+    expect(new URLSearchParams(window.location.search).get("type")).toBeNull()
+  })
+
+  it("restores the selected tab from ?type= on load", async () => {
+    window.history.replaceState(null, "", "/?type=local")
+    fetchMock.mockResolvedValue(jsonResponse(FILES_RESPONSE))
+    render(<BriefingDashboard />)
+    await waitFor(() => expect(screen.getByTestId("briefing-dashboard")).toBeInTheDocument())
+
+    expect(screen.getByTestId("briefing-row-local_2026-06-18.md")).toBeInTheDocument()
+    expect(screen.queryByTestId("briefing-row-briefing_2026-06-20.md")).not.toBeInTheDocument()
+    window.history.replaceState(null, "", "/")
+  })
+
   it("activates row on Enter key press", async () => {
     const otherContent = { name: "briefing_2026-06-19.md", content: "# June 19 via keyboard" }
     fetchMock.mockImplementation((url: string) => {

--- a/apps/web/tests/briefing-dashboard.test.tsx
+++ b/apps/web/tests/briefing-dashboard.test.tsx
@@ -34,6 +34,8 @@ describe("BriefingDashboard", () => {
   })
   afterEach(() => {
     vi.unstubAllGlobals()
+    // Reset the ?type= URL so tab state never leaks across tests, even on failure.
+    window.history.replaceState(null, "", "/")
   })
 
   it("shows loading state before files arrive", async () => {
@@ -215,7 +217,7 @@ describe("BriefingDashboard", () => {
     render(<BriefingDashboard />)
     await waitFor(() => expect(screen.getByTestId("briefing-dashboard")).toBeInTheDocument())
 
-    expect(screen.getByTestId("briefing-tab-all")).toBeInTheDocument()
+    expect(screen.getByTestId("briefing-tab-__all__")).toBeInTheDocument()
     expect(screen.getByTestId("briefing-tab-briefing")).toBeInTheDocument()
     expect(screen.getByTestId("briefing-tab-local")).toBeInTheDocument()
 
@@ -227,7 +229,7 @@ describe("BriefingDashboard", () => {
     expect(screen.queryByTestId("briefing-row-briefing_2026-06-20.md")).not.toBeInTheDocument()
 
     // All restores everything
-    await user.click(screen.getByTestId("briefing-tab-all"))
+    await user.click(screen.getByTestId("briefing-tab-__all__"))
     expect(screen.getByTestId("briefing-row-briefing_2026-06-20.md")).toBeInTheDocument()
   })
 
@@ -240,7 +242,7 @@ describe("BriefingDashboard", () => {
     await user.click(screen.getByTestId("briefing-tab-local"))
     expect(new URLSearchParams(window.location.search).get("type")).toBe("local")
 
-    await user.click(screen.getByTestId("briefing-tab-all"))
+    await user.click(screen.getByTestId("briefing-tab-__all__"))
     expect(new URLSearchParams(window.location.search).get("type")).toBeNull()
   })
 
@@ -252,7 +254,6 @@ describe("BriefingDashboard", () => {
 
     expect(screen.getByTestId("briefing-row-local_2026-06-18.md")).toBeInTheDocument()
     expect(screen.queryByTestId("briefing-row-briefing_2026-06-20.md")).not.toBeInTheDocument()
-    window.history.replaceState(null, "", "/")
   })
 
   it("activates row on Enter key press", async () => {

--- a/apps/web/tests/briefing-tabs.test.tsx
+++ b/apps/web/tests/briefing-tabs.test.tsx
@@ -27,12 +27,12 @@ describe("briefingTypeLabel", () => {
 })
 
 describe("BriefingTabs", () => {
-  it("renders All first, then one tab per type present", () => {
+  it("renders All first, then one tab per type present, in order", () => {
     render(<BriefingTabs files={FILES} selected={ALL_TAB} onSelect={() => {}} />)
-    expect(screen.getByTestId("briefing-tab-all")).toHaveTextContent("All")
-    expect(screen.getByTestId("briefing-tab-market")).toHaveTextContent("Market")
-    expect(screen.getByTestId("briefing-tab-briefing")).toHaveTextContent("Briefing")
-    expect(screen.getByTestId("briefing-tab-local")).toHaveTextContent("Local")
+    const labels = Array.from(
+      screen.getByTestId("briefing-tabs").querySelectorAll("button"),
+    ).map((el) => el.textContent)
+    expect(labels).toEqual(["All", "Market", "Briefing", "Local"])
   })
 
   it("calls onSelect with the clicked type", async () => {

--- a/apps/web/tests/briefing-tabs.test.tsx
+++ b/apps/web/tests/briefing-tabs.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { ALL_TAB, BriefingTabs, tabTypes } from "@/components/briefing/BriefingTabs"
+import { briefingTypeLabel, BriefingFile } from "@/lib/briefing-types"
+
+const FILES: BriefingFile[] = [
+  { name: "market_2026-06-21.md", type: "market", date: "2026-06-21", size: 10 },
+  { name: "briefing_2026-06-20.md", type: "briefing", date: "2026-06-20", size: 10 },
+  { name: "market_2026-06-19.md", type: "market", date: "2026-06-19", size: 10 },
+  { name: "local_2026-06-18.md", type: "local", date: "2026-06-18", size: 10 },
+]
+
+describe("tabTypes", () => {
+  it("returns unique types in first-seen order", () => {
+    expect(tabTypes(FILES)).toEqual(["market", "briefing", "local"])
+  })
+})
+
+describe("briefingTypeLabel", () => {
+  it("maps known types and capitalizes unknown ones", () => {
+    expect(briefingTypeLabel("briefing")).toBe("Briefing")
+    expect(briefingTypeLabel("local")).toBe("Local")
+    expect(briefingTypeLabel("market")).toBe("Market")
+  })
+})
+
+describe("BriefingTabs", () => {
+  it("renders All first, then one tab per type present", () => {
+    render(<BriefingTabs files={FILES} selected={ALL_TAB} onSelect={() => {}} />)
+    expect(screen.getByTestId("briefing-tab-all")).toHaveTextContent("All")
+    expect(screen.getByTestId("briefing-tab-market")).toHaveTextContent("Market")
+    expect(screen.getByTestId("briefing-tab-briefing")).toHaveTextContent("Briefing")
+    expect(screen.getByTestId("briefing-tab-local")).toHaveTextContent("Local")
+  })
+
+  it("calls onSelect with the clicked type", async () => {
+    const onSelect = vi.fn()
+    render(<BriefingTabs files={FILES} selected={ALL_TAB} onSelect={onSelect} />)
+    await userEvent.setup().click(screen.getByTestId("briefing-tab-market"))
+    expect(onSelect).toHaveBeenCalledWith("market")
+  })
+})


### PR DESCRIPTION
## Summary
- Relax backend `_FILE_RE` to accept any lowercase-led type prefix; `BriefingFile.type` is now `str`.
- Add `briefingTypeLabel()` (known → mapped, unknown → capitalized) and new `BriefingTabs` component (All + one tab per type present).
- Dashboard holds tab state, filters the list, and persists via `?type=` URL query.

## Test plan
- [x] Backend pytest: relaxed regex boundaries (custom prefix accepted, non-lowercase rejected)
- [x] Frontend: tab generation, filtering, `?type=` persist/restore
- [x] `tsc --noEmit` passes

Closes #254

## Summary by Sourcery

Add support for arbitrary lowercase-led briefing file types and expose them via a new type-based tab filter in the dashboard.

New Features:
- Allow briefing API to list and serve files with custom lowercase-led type prefixes beyond the previous fixed set.
- Add dynamic Type filter tabs to the briefing dashboard, including an All tab and one tab per type present, with list filtering driven by the selected tab.
- Persist and restore the selected briefing type filter via the ?type= URL query parameter.

Enhancements:
- Generalize briefing file type handling across backend and frontend by treating type as a free-form string and deriving display labels from it.

Tests:
- Add backend tests covering acceptance of custom lowercase type prefixes and rejection of invalid filenames for list and get endpoints.
- Add frontend tests for tab generation, filtering behavior, and URL query persistence/restoration of the selected type.
- Add unit tests for the new BriefingTabs component and briefingTypeLabel helper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Briefing files now support custom type prefixes in addition to default types.
  * Added type-based filtering tabs to the briefing dashboard.
  * Tab selections synchronize with URL query parameters and persist across page reloads.

* **Tests**
  * Added comprehensive test coverage for custom type prefixes and tab filtering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->