### PR TITLE
feat(briefing): fuzzy full-text search over name and body

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,10 @@ bin/chat.sh   # Launch chat session
 - CI and local `pytest` always load `apps/python/tests/config/briefing.json` — `conftest.py` sets `BRIEFING_CONFIG_PATH` before any import of `src.config`.
 - When adding or changing config schema, update both `.example` and `tests/config/briefing.json`.
 
+## Code Style
+
+- **Code comments and docstrings must be written in English** (both Python and TypeScript), unified across the codebase. User-facing chat responses stay in Japanese, but in-code documentation is English only — do not mix languages within a file.
+
 ## Git Conventions
 
 Branch naming: `feat/` `fix/` `refactor/` `docs/` `chore/`

--- a/apps/python/tests/test_api_briefing.py
+++ b/apps/python/tests/test_api_briefing.py
@@ -123,6 +123,46 @@ async def test_get_accepts_custom_type_prefix(authed_client, briefing_dir):
     assert "Market body" in response.json()["content"]
 
 
+async def test_search_requires_auth(async_client, briefing_dir):
+    response = await async_client.get("/api/briefing/search?q=06-20")
+    assert response.status_code == 401
+
+
+async def test_search_matches_name_newest_first(authed_client, briefing_dir):
+    response = await authed_client.get("/api/briefing/search?q=2026-06")
+    assert response.status_code == 200
+    names = [f["name"] for f in response.json()["files"]]
+    assert names == [
+        "briefing_2026-06-20.md",
+        "briefing_2026-06-19.md",
+        "local_2026-06-18.md",
+        "briefing_2026-06-16-001.md",
+    ]
+
+
+async def test_search_matches_body_case_insensitive(authed_client, briefing_dir):
+    # "Content C." only appears in the local file body.
+    response = await authed_client.get("/api/briefing/search?q=content+c")
+    names = [f["name"] for f in response.json()["files"]]
+    assert names == ["local_2026-06-18.md"]
+
+
+async def test_search_empty_query_returns_all(authed_client, briefing_dir):
+    response = await authed_client.get("/api/briefing/search?q=")
+    names = [f["name"] for f in response.json()["files"]]
+    assert names == [
+        "briefing_2026-06-20.md",
+        "briefing_2026-06-19.md",
+        "local_2026-06-18.md",
+        "briefing_2026-06-16-001.md",
+    ]
+
+
+async def test_search_no_match_returns_empty(authed_client, briefing_dir):
+    response = await authed_client.get("/api/briefing/search?q=zzzznomatch")
+    assert response.json()["files"] == []
+
+
 async def test_list_newest_first_sorted_correctly(authed_client, briefing_dir):
     """Ensure sort order: briefing_2026-06-20 > briefing_2026-06-19 > briefing_2026-06-16-001."""
     response = await authed_client.get("/api/briefing")

--- a/apps/python/web/routers/briefing.py
+++ b/apps/python/web/routers/briefing.py
@@ -1,10 +1,10 @@
-"""GET /api/briefing — apps/python/output/briefing/*.md のリスト・内容取得 API。
+"""GET /api/briefing — list and read apps/python/output/briefing/*.md.
 
-ブリーフィングビューア (Sidebar > Briefing) がファイル一覧を取得して
-一覧表示し、選択されたファイルの Markdown 本文を返す。
+The briefing viewer (Sidebar > Briefing) fetches the file list to render the
+record list, then fetches the selected file's Markdown body.
 
-ファイル名規約: ``{type}_{YYYY-MM-DD}[-NNN].md``
-type は任意の小文字始まりプレフィックス (``briefing`` / ``local`` / ``market`` ...)。
+Filename convention: ``{type}_{YYYY-MM-DD}[-NNN].md``
+``type`` is any lowercase-led prefix (``briefing`` / ``local`` / ``market`` ...).
 """
 import re
 from pathlib import Path
@@ -42,9 +42,14 @@ class BriefingFileResponse(BaseModel):
 
 @router.get("/briefing", response_model=BriefingListResponse)
 def list_briefings() -> BriefingListResponse:
-    """利用可能なブリーフィングファイルを新しい順で返す。"""
+    """Return available briefing files, newest first."""
+    return BriefingListResponse(files=_scan_files())
+
+
+def _scan_files() -> list[BriefingFile]:
+    """Return convention-matching md files in BRIEFING_DIR, newest first (date, name DESC)."""
     if not BRIEFING_DIR.exists():
-        return BriefingListResponse(files=[])
+        return []
 
     files: list[BriefingFile] = []
     for path in BRIEFING_DIR.glob("*.md"):
@@ -62,12 +67,34 @@ def list_briefings() -> BriefingListResponse:
             )
         )
     files.sort(key=lambda f: (f.date, f.name), reverse=True)
-    return BriefingListResponse(files=files)
+    return files
+
+
+@router.get("/briefing/search", response_model=BriefingListResponse)
+def search_briefings(q: str = "") -> BriefingListResponse:
+    """Return files whose name or body contains ``q`` (case-insensitive, substring), newest first.
+
+    An empty query returns all files. Must be registered before ``/briefing/{name}``.
+    """
+    needle = q.strip().lower()
+    files = _scan_files()
+    if not needle:
+        return BriefingListResponse(files=files)
+
+    matched: list[BriefingFile] = []
+    for f in files:
+        if needle in f.name.lower():
+            matched.append(f)
+            continue
+        body = (BRIEFING_DIR / f.name).read_text(encoding="utf-8")
+        if needle in body.lower():
+            matched.append(f)
+    return BriefingListResponse(files=matched)
 
 
 @router.get("/briefing/{name}", response_model=BriefingFileResponse)
 def get_briefing(name: str) -> BriefingFileResponse:
-    """指定ファイルの Markdown 本文を返す。不正名やディレクトリ外は 404。"""
+    """Return the Markdown body of the named file. Invalid names or paths outside the dir 404."""
     if not _SAFE_NAME_RE.match(name) or _FILE_RE.match(name) is None:
         raise HTTPException(status_code=404, detail=f"Briefing not found: {name}")
 

--- a/apps/web/components/briefing/BriefingSearch.tsx
+++ b/apps/web/components/briefing/BriefingSearch.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useRef, useState } from "react"
+
+import { CloseIcon } from "./icons"
+
+interface BriefingSearchProps {
+  onSearch: (q: string) => void
+  debounceMs?: number
+}
+
+/** Debounced search box over briefing name + body, with a clear button. */
+export function BriefingSearch({ onSearch, debounceMs = 250 }: BriefingSearchProps) {
+  const [value, setValue] = useState("")
+  const onSearchRef = useRef(onSearch)
+  onSearchRef.current = onSearch
+
+  useEffect(() => {
+    const id = setTimeout(() => onSearchRef.current(value.trim()), debounceMs)
+    return () => clearTimeout(id)
+  }, [value, debounceMs])
+
+  return (
+    <div className="relative flex items-center px-2 py-1">
+      <input
+        data-testid="briefing-search-input"
+        type="search"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder="Search name or content…"
+        aria-label="Search briefings"
+        className="w-full rounded border bg-background px-2 py-1 pr-7 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
+      />
+      {value && (
+        <button
+          data-testid="briefing-search-clear"
+          onClick={() => setValue("")}
+          aria-label="Clear search"
+          className="absolute right-3 rounded p-0.5 text-muted-foreground hover:text-foreground"
+        >
+          <CloseIcon />
+        </button>
+      )}
+    </div>
+  )
+}

--- a/apps/web/components/screens/BriefingDashboard.tsx
+++ b/apps/web/components/screens/BriefingDashboard.tsx
@@ -31,6 +31,7 @@ export function BriefingDashboard() {
   const [query, setQuery] = useState("")
   const [searchResults, setSearchResults] = useState<BriefingFile[] | null>(null)
   const [searching, setSearching] = useState(false)
+  const [searchError, setSearchError] = useState<string | null>(null)
 
   // Persist the selected tab to the ?type= URL query.
   useEffect(() => {
@@ -46,17 +47,22 @@ export function BriefingDashboard() {
     if (query === "") {
       setSearchResults(null)
       setSearching(false)
+      setSearchError(null)
       return
     }
     let cancelled = false
     setSearching(true)
+    setSearchError(null)
     fetch(`/api/briefing/search?q=${encodeURIComponent(query)}`, { cache: "no-store" })
       .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
       .then((data: BriefingListResponse) => {
         if (!cancelled) setSearchResults(data.files)
       })
-      .catch(() => {
-        if (!cancelled) setSearchResults([])
+      .catch((e) => {
+        if (cancelled) return
+        // Keep search errors distinct from a legitimate zero-result search.
+        setSearchResults([])
+        setSearchError(String(e))
       })
       .finally(() => {
         if (!cancelled) setSearching(false)
@@ -143,7 +149,15 @@ export function BriefingDashboard() {
             Searching…
           </p>
         )}
-        {!searching && visibleFiles.length === 0 && (
+        {!searching && searchError && (
+          <p
+            data-testid="briefing-search-error"
+            className="px-3 py-2 text-xs text-destructive"
+          >
+            Search failed: {searchError}
+          </p>
+        )}
+        {!searching && !searchError && visibleFiles.length === 0 && (
           <p
             data-testid="briefing-no-results"
             className="px-3 py-2 text-xs text-muted-foreground"

--- a/apps/web/components/screens/BriefingDashboard.tsx
+++ b/apps/web/components/screens/BriefingDashboard.tsx
@@ -3,7 +3,9 @@ import { useEffect, useMemo, useState } from "react"
 
 import { BriefingPanel } from "@/components/briefing/BriefingPanel"
 import { BriefingRow } from "@/components/briefing/BriefingRow"
+import { BriefingSearch } from "@/components/briefing/BriefingSearch"
 import { ALL_TAB, BriefingTabs } from "@/components/briefing/BriefingTabs"
+import { BriefingFile, BriefingListResponse } from "@/lib/briefing-types"
 import { useBriefingData } from "@/lib/hooks/useBriefingData"
 import { cn } from "@/lib/utils"
 
@@ -26,6 +28,9 @@ export function BriefingDashboard() {
   } = useBriefingData()
   const [fullSize, setFullSize] = useState(false)
   const [tab, setTab] = useState<string>(initialTab)
+  const [query, setQuery] = useState("")
+  const [searchResults, setSearchResults] = useState<BriefingFile[] | null>(null)
+  const [searching, setSearching] = useState(false)
 
   // Persist the selected tab to the ?type= URL query.
   useEffect(() => {
@@ -36,10 +41,36 @@ export function BriefingDashboard() {
     window.history.replaceState(null, "", url.toString())
   }, [tab])
 
-  const visibleFiles = useMemo(
-    () => (files ?? []).filter((f) => tab === ALL_TAB || f.type === tab),
-    [files, tab],
-  )
+  // Fetch server-side search results when the (debounced) query changes.
+  useEffect(() => {
+    if (query === "") {
+      setSearchResults(null)
+      setSearching(false)
+      return
+    }
+    let cancelled = false
+    setSearching(true)
+    fetch(`/api/briefing/search?q=${encodeURIComponent(query)}`, { cache: "no-store" })
+      .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
+      .then((data: BriefingListResponse) => {
+        if (!cancelled) setSearchResults(data.files)
+      })
+      .catch(() => {
+        if (!cancelled) setSearchResults([])
+      })
+      .finally(() => {
+        if (!cancelled) setSearching(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [query])
+
+  // Search (when active) and Type tab combine as an AND filter.
+  const visibleFiles = useMemo(() => {
+    const base = query !== "" ? (searchResults ?? []) : (files ?? [])
+    return base.filter((f) => tab === ALL_TAB || f.type === tab)
+  }, [files, tab, query, searchResults])
 
   const handleClose = () => {
     setFullSize(false)
@@ -81,6 +112,7 @@ export function BriefingDashboard() {
           fullSize && "hidden",
         )}
       >
+        <BriefingSearch onSearch={setQuery} />
         <BriefingTabs files={files} selected={tab} onSelect={setTab} />
         <table className="w-full text-sm">
           <thead>
@@ -103,6 +135,22 @@ export function BriefingDashboard() {
             ))}
           </tbody>
         </table>
+        {searching && (
+          <p
+            data-testid="briefing-search-loading"
+            className="px-3 py-2 text-xs text-muted-foreground"
+          >
+            Searching…
+          </p>
+        )}
+        {!searching && visibleFiles.length === 0 && (
+          <p
+            data-testid="briefing-no-results"
+            className="px-3 py-2 text-xs text-muted-foreground"
+          >
+            No matching briefings.
+          </p>
+        )}
       </div>
 
       {/* Side panel */}

--- a/apps/web/tests/briefing-dashboard.test.tsx
+++ b/apps/web/tests/briefing-dashboard.test.tsx
@@ -327,6 +327,22 @@ describe("BriefingDashboard", () => {
     await waitFor(() => expect(screen.getByTestId("briefing-no-results")).toBeInTheDocument())
   })
 
+  it("shows a distinct error state (not zero-result) when search fails", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/api/briefing/search")) return Promise.reject(new Error("Network down"))
+      return Promise.resolve(jsonResponse(FILES_RESPONSE))
+    })
+
+    render(<BriefingDashboard />)
+    await waitFor(() => expect(screen.getByTestId("briefing-dashboard")).toBeInTheDocument())
+
+    const user = userEvent.setup()
+    await user.type(screen.getByTestId("briefing-search-input"), "nvda")
+    await waitFor(() => expect(screen.getByTestId("briefing-search-error")).toBeInTheDocument())
+    // error is shown instead of the zero-result message
+    expect(screen.queryByTestId("briefing-no-results")).not.toBeInTheDocument()
+  })
+
   it("activates row on Enter key press", async () => {
     const otherContent = { name: "briefing_2026-06-19.md", content: "# June 19 via keyboard" }
     fetchMock.mockImplementation((url: string) => {

--- a/apps/web/tests/briefing-dashboard.test.tsx
+++ b/apps/web/tests/briefing-dashboard.test.tsx
@@ -256,6 +256,77 @@ describe("BriefingDashboard", () => {
     expect(screen.queryByTestId("briefing-row-briefing_2026-06-20.md")).not.toBeInTheDocument()
   })
 
+  it("filters via server search and combines with the Type tab (AND)", async () => {
+    const searchResponse = {
+      files: [
+        { name: "briefing_2026-06-20.md", type: "briefing", date: "2026-06-20", size: 5120 },
+        { name: "local_2026-06-18.md", type: "local", date: "2026-06-18", size: 1280 },
+      ],
+    }
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/api/briefing/search")) return Promise.resolve(jsonResponse(searchResponse))
+      return Promise.resolve(jsonResponse(FILES_RESPONSE))
+    })
+
+    render(<BriefingDashboard />)
+    await waitFor(() => expect(screen.getByTestId("briefing-dashboard")).toBeInTheDocument())
+
+    const user = userEvent.setup()
+    await user.type(screen.getByTestId("briefing-search-input"), "content")
+
+    // search narrows the list to the two server matches
+    await waitFor(() =>
+      expect(screen.queryByTestId("briefing-row-briefing_2026-06-19.md")).not.toBeInTheDocument(),
+    )
+    expect(screen.getByTestId("briefing-row-briefing_2026-06-20.md")).toBeInTheDocument()
+    expect(screen.getByTestId("briefing-row-local_2026-06-18.md")).toBeInTheDocument()
+    const searchUrl = fetchMock.mock.calls.map((c) => c[0]).find((u: string) => u.includes("/search"))
+    expect(searchUrl).toContain("q=content")
+
+    // AND with Type tab: local-only among the search matches
+    await user.click(screen.getByTestId("briefing-tab-local"))
+    expect(screen.getByTestId("briefing-row-local_2026-06-18.md")).toBeInTheDocument()
+    expect(screen.queryByTestId("briefing-row-briefing_2026-06-20.md")).not.toBeInTheDocument()
+  })
+
+  it("clearing the search returns to tab-only filtering", async () => {
+    const searchResponse = {
+      files: [{ name: "local_2026-06-18.md", type: "local", date: "2026-06-18", size: 1280 }],
+    }
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/api/briefing/search")) return Promise.resolve(jsonResponse(searchResponse))
+      return Promise.resolve(jsonResponse(FILES_RESPONSE))
+    })
+
+    render(<BriefingDashboard />)
+    await waitFor(() => expect(screen.getByTestId("briefing-dashboard")).toBeInTheDocument())
+
+    const user = userEvent.setup()
+    await user.type(screen.getByTestId("briefing-search-input"), "local")
+    await waitFor(() =>
+      expect(screen.queryByTestId("briefing-row-briefing_2026-06-20.md")).not.toBeInTheDocument(),
+    )
+
+    await user.click(screen.getByTestId("briefing-search-clear"))
+    await waitFor(() =>
+      expect(screen.getByTestId("briefing-row-briefing_2026-06-20.md")).toBeInTheDocument(),
+    )
+  })
+
+  it("shows a zero-result state when the search has no matches", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/api/briefing/search")) return Promise.resolve(jsonResponse({ files: [] }))
+      return Promise.resolve(jsonResponse(FILES_RESPONSE))
+    })
+
+    render(<BriefingDashboard />)
+    await waitFor(() => expect(screen.getByTestId("briefing-dashboard")).toBeInTheDocument())
+
+    const user = userEvent.setup()
+    await user.type(screen.getByTestId("briefing-search-input"), "zzz")
+    await waitFor(() => expect(screen.getByTestId("briefing-no-results")).toBeInTheDocument())
+  })
+
   it("activates row on Enter key press", async () => {
     const otherContent = { name: "briefing_2026-06-19.md", content: "# June 19 via keyboard" }
     fetchMock.mockImplementation((url: string) => {

--- a/apps/web/tests/briefing-search.test.tsx
+++ b/apps/web/tests/briefing-search.test.tsx
@@ -1,0 +1,38 @@
+import { act, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { BriefingSearch } from "@/components/briefing/BriefingSearch"
+
+describe("BriefingSearch", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("debounces input before emitting the query", () => {
+    const onSearch = vi.fn()
+    render(<BriefingSearch onSearch={onSearch} debounceMs={250} />)
+
+    fireEvent.change(screen.getByTestId("briefing-search-input"), { target: { value: "nvda" } })
+    onSearch.mockClear()
+    act(() => vi.advanceTimersByTime(249))
+    expect(onSearch).not.toHaveBeenCalled()
+    act(() => vi.advanceTimersByTime(1))
+    expect(onSearch).toHaveBeenCalledWith("nvda")
+  })
+
+  it("clear button resets the input and emits an empty query", () => {
+    const onSearch = vi.fn()
+    render(<BriefingSearch onSearch={onSearch} debounceMs={250} />)
+
+    fireEvent.change(screen.getByTestId("briefing-search-input"), { target: { value: "nvda" } })
+    act(() => vi.advanceTimersByTime(250))
+
+    fireEvent.click(screen.getByTestId("briefing-search-clear"))
+    act(() => vi.advanceTimersByTime(250))
+    expect(onSearch).toHaveBeenLastCalledWith("")
+    expect(screen.getByTestId("briefing-search-input")).toHaveValue("")
+  })
+})


### PR DESCRIPTION
## Summary
- Backend: `GET /api/briefing/search?q=` scans name + body (case-insensitive substring), newest-first; empty `q` returns all. Registered before `/briefing/{name}`.
- New `BriefingSearch` component: debounced (250ms) input with a clear button.
- Dashboard combines search with the Type tab as an AND filter; adds loading and zero-result states.
- Also: unified all code comments/docstrings to English and added a Code Style rule to CLAUDE.md.

## Test plan
- [x] Backend pytest: name/body match, empty query, no-match, auth
- [x] Frontend: debounce + clear, AND with Type tab, clear restores tab-only, zero-result
- [x] `tsc --noEmit` passes

Closes #255

> Rebased onto dev after #258 merged (supersedes the auto-closed #259).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add server-side full-text search for briefings and integrate a debounced search UI into the briefing dashboard, combining with type-based filtering and improving UX around loading and empty states.

New Features:
- Expose /api/briefing/search to return briefing files whose name or body matches a query, ordered newest first.
- Add a debounced BriefingSearch input component with clear functionality to filter briefings by name or content in the dashboard.

Enhancements:
- Refactor briefing file scanning into a reusable helper shared by list and search endpoints.
- Update briefing dashboard to combine server search results with Type tab selection and show loading and zero-result states.
- Standardize Python and TypeScript comments/docstrings to English and document this requirement in the contributor guide.

Tests:
- Add backend tests covering briefing search auth, name/body matching, empty queries, and no-match behavior.
- Add frontend tests verifying server-backed search, interaction with Type tabs, clearing search, and zero-result UI states.