### PR TITLE
feat(briefing): monthly zip archive to Google Drive

### DIFF
--- a/apps/python/bin/archive.sh
+++ b/apps/python/bin/archive.sh
@@ -35,8 +35,11 @@ done
 if [ -z "$MONTH" ]; then
     if date -v-1m +%Y-%m >/dev/null 2>&1; then
         MONTH="$(date -v-1m +%Y-%m)"
-    else
+    elif date -d 'last month' +%Y-%m >/dev/null 2>&1; then
         MONTH="$(date -d 'last month' +%Y-%m)"
+    else
+        echo "error: unsupported 'date' implementation; please supply --month YYYY-MM" >&2
+        exit 1
     fi
 fi
 

--- a/apps/python/bin/archive.sh
+++ b/apps/python/bin/archive.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Archive a month's briefing markdown files into a zip and upload to Google Drive
+# via rclone (zero-cost). Runnable manually, from launchd, or via POST /api/archive.
+#
+# Usage: archive.sh [--month YYYY-MM] [--prune]
+#   --month  Target month (default: previous month).
+#   --prune  Delete local md files after a successful upload (default: keep).
+#
+# Env overrides (mainly for tests):
+#   ARCHIVE_BRIEFING_DIR  Source dir of *_YYYY-MM-*.md (default: apps/python/output/briefing)
+#   ARCHIVE_OUTPUT_DIR    Where the zip is written     (default: apps/python/output/archive)
+#   RCLONE_REMOTE         rclone remote name           (default: gdrive)
+#   RCLONE_PATH           Remote path under the remote (default: ai-agent/briefing)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+BRIEFING_DIR="${ARCHIVE_BRIEFING_DIR:-$PROJECT_ROOT/apps/python/output/briefing}"
+OUTPUT_DIR="${ARCHIVE_OUTPUT_DIR:-$PROJECT_ROOT/apps/python/output/archive}"
+RCLONE_REMOTE="${RCLONE_REMOTE:-gdrive}"
+RCLONE_PATH="${RCLONE_PATH:-ai-agent/briefing}"
+
+MONTH=""
+PRUNE=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --month) MONTH="$2"; shift 2 ;;
+        --prune) PRUNE=1; shift ;;
+        *) echo "error: unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+# Default to the previous month (BSD/macOS and GNU/Linux variants).
+if [ -z "$MONTH" ]; then
+    if date -v-1m +%Y-%m >/dev/null 2>&1; then
+        MONTH="$(date -v-1m +%Y-%m)"
+    else
+        MONTH="$(date -d 'last month' +%Y-%m)"
+    fi
+fi
+
+if ! [[ "$MONTH" =~ ^[0-9]{4}-[0-9]{2}$ ]]; then
+    echo "error: --month must be YYYY-MM, got: $MONTH" >&2
+    exit 2
+fi
+
+# Collect this month's md files; skip (success) when there are none.
+shopt -s nullglob
+files=( "$BRIEFING_DIR"/*_"$MONTH"-*.md )
+shopt -u nullglob
+if [ ${#files[@]} -eq 0 ]; then
+    echo "skip: no briefing files for $MONTH in $BRIEFING_DIR"
+    exit 0
+fi
+
+if ! command -v rclone >/dev/null 2>&1; then
+    echo "error: rclone not found. Install it and configure a remote:" >&2
+    echo "       brew install rclone && rclone config   # create remote '$RCLONE_REMOTE'" >&2
+    exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+ZIP_PATH="$OUTPUT_DIR/briefing_$MONTH.zip"
+rm -f "$ZIP_PATH"
+zip -j "$ZIP_PATH" "${files[@]}"
+echo "created: $ZIP_PATH (${#files[@]} files)"
+
+if ! rclone copy "$ZIP_PATH" "$RCLONE_REMOTE:$RCLONE_PATH/"; then
+    echo "error: rclone upload failed. Check that remote '$RCLONE_REMOTE' is configured:" >&2
+    echo "       rclone config   # then re-run" >&2
+    exit 1
+fi
+echo "uploaded: $RCLONE_REMOTE:$RCLONE_PATH/briefing_$MONTH.zip"
+
+if [ "$PRUNE" -eq 1 ]; then
+    rm -f "${files[@]}"
+    echo "pruned: ${#files[@]} local md files for $MONTH"
+fi

--- a/apps/python/tests/test_api_archive.py
+++ b/apps/python/tests/test_api_archive.py
@@ -1,0 +1,57 @@
+"""Tests for POST /api/archive — runs archive.sh via subprocess.
+
+The subprocess call is patched so these tests stay fast and host-independent.
+"""
+import subprocess
+
+from web.routers import archive as archive_router
+
+
+def _fake_run(returncode=0, stdout="", stderr=""):
+    def _run(cmd, capture_output, text):  # noqa: ANN001 - mirror subprocess.run
+        _run.cmd = cmd
+        return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr=stderr)
+
+    return _run
+
+
+async def test_archive_requires_auth(async_client):
+    response = await async_client.post("/api/archive")
+    assert response.status_code == 401
+
+
+async def test_archive_success_returns_stdout(authed_client, monkeypatch):
+    fake = _fake_run(returncode=0, stdout="created: briefing_2026-05.zip\n")
+    monkeypatch.setattr(subprocess, "run", fake)
+
+    response = await authed_client.post("/api/archive")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["exit_code"] == 0
+    assert "briefing_2026-05.zip" in body["stdout"]
+    # default invocation has no --month flag
+    assert "--month" not in fake.cmd
+
+
+async def test_archive_passes_month_and_prune(authed_client, monkeypatch):
+    fake = _fake_run(returncode=0, stdout="ok")
+    monkeypatch.setattr(subprocess, "run", fake)
+
+    response = await authed_client.post("/api/archive?month=2026-05&prune=true")
+    assert response.status_code == 200
+    assert "--month" in fake.cmd and "2026-05" in fake.cmd
+    assert "--prune" in fake.cmd
+
+
+async def test_archive_rejects_bad_month(authed_client):
+    response = await authed_client.post("/api/archive?month=2026/05")
+    assert response.status_code == 422
+
+
+async def test_archive_failure_returns_500_with_stderr(authed_client, monkeypatch):
+    fake = _fake_run(returncode=1, stderr="error: rclone not found")
+    monkeypatch.setattr(subprocess, "run", fake)
+
+    response = await authed_client.post("/api/archive")
+    assert response.status_code == 500
+    assert "rclone not found" in response.json()["detail"]

--- a/apps/python/tests/test_archive_script.py
+++ b/apps/python/tests/test_archive_script.py
@@ -1,0 +1,116 @@
+"""Tests for apps/python/bin/archive.sh — target-file selection and rclone errors.
+
+The script is exercised as a subprocess with ``ARCHIVE_*`` env overrides and a
+fake ``rclone`` on PATH so no network or real Drive remote is needed.
+"""
+import os
+import subprocess
+import zipfile
+from pathlib import Path
+
+import pytest
+
+ARCHIVE_SCRIPT = Path(__file__).parents[1] / "bin" / "archive.sh"
+
+
+def _seed_briefings(briefing_dir: Path) -> None:
+    briefing_dir.mkdir(parents=True, exist_ok=True)
+    # Two months plus a non-md file that must never be archived.
+    (briefing_dir / "briefing_2026-05-01.md").write_text("may 1", encoding="utf-8")
+    (briefing_dir / "local_2026-05-15.md").write_text("may 15", encoding="utf-8")
+    (briefing_dir / "briefing_2026-06-01.md").write_text("june 1", encoding="utf-8")
+    (briefing_dir / "notes.txt").write_text("ignore", encoding="utf-8")
+
+
+def _fake_rclone(bin_dir: Path) -> None:
+    """A stub rclone that always succeeds, shadowing any real install."""
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    stub = bin_dir / "rclone"
+    stub.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    stub.chmod(0o755)
+
+
+def _run(tmp_path, *args, env_extra=None):
+    env = os.environ.copy()
+    env["ARCHIVE_BRIEFING_DIR"] = str(tmp_path / "briefing")
+    env["ARCHIVE_OUTPUT_DIR"] = str(tmp_path / "archive")
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        ["/bin/bash", str(ARCHIVE_SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_archives_only_target_month(tmp_path):
+    _seed_briefings(tmp_path / "briefing")
+    fake_bin = tmp_path / "bin"
+    _fake_rclone(fake_bin)
+
+    result = _run(
+        tmp_path, "--month", "2026-05",
+        env_extra={"PATH": f"{fake_bin}:{os.environ['PATH']}"},
+    )
+    assert result.returncode == 0, result.stderr
+
+    zip_path = tmp_path / "archive" / "briefing_2026-05.zip"
+    assert zip_path.exists()
+    names = sorted(zipfile.ZipFile(zip_path).namelist())
+    # Only May md files, not June and not the .txt.
+    assert names == ["briefing_2026-05-01.md", "local_2026-05-15.md"]
+
+
+def test_no_files_skips_with_zero_exit(tmp_path):
+    _seed_briefings(tmp_path / "briefing")
+    fake_bin = tmp_path / "bin"
+    _fake_rclone(fake_bin)
+
+    result = _run(
+        tmp_path, "--month", "2026-01",
+        env_extra={"PATH": f"{fake_bin}:{os.environ['PATH']}"},
+    )
+    assert result.returncode == 0
+    assert "skip" in result.stdout.lower()
+    assert not (tmp_path / "archive" / "briefing_2026-01.zip").exists()
+
+
+def test_local_md_retained_by_default(tmp_path):
+    _seed_briefings(tmp_path / "briefing")
+    fake_bin = tmp_path / "bin"
+    _fake_rclone(fake_bin)
+
+    _run(tmp_path, "--month", "2026-05", env_extra={"PATH": f"{fake_bin}:{os.environ['PATH']}"})
+    assert (tmp_path / "briefing" / "briefing_2026-05-01.md").exists()
+
+
+def test_prune_removes_local_md(tmp_path):
+    _seed_briefings(tmp_path / "briefing")
+    fake_bin = tmp_path / "bin"
+    _fake_rclone(fake_bin)
+
+    _run(
+        tmp_path, "--month", "2026-05", "--prune",
+        env_extra={"PATH": f"{fake_bin}:{os.environ['PATH']}"},
+    )
+    assert not (tmp_path / "briefing" / "briefing_2026-05-01.md").exists()
+    assert not (tmp_path / "briefing" / "local_2026-05-15.md").exists()
+    # June file untouched.
+    assert (tmp_path / "briefing" / "briefing_2026-06-01.md").exists()
+
+
+def test_missing_rclone_exits_nonzero_with_hint(tmp_path):
+    _seed_briefings(tmp_path / "briefing")
+    # Minimal PATH with only the externals the script needs before the rclone
+    # check (dirname), so rclone is genuinely absent regardless of the host.
+    minimal_bin = tmp_path / "minbin"
+    minimal_bin.mkdir()
+    (minimal_bin / "dirname").symlink_to("/usr/bin/dirname")
+
+    result = _run(
+        tmp_path, "--month", "2026-05",
+        env_extra={"PATH": str(minimal_bin)},
+    )
+    assert result.returncode == 1
+    assert "rclone not found" in result.stderr.lower()

--- a/apps/python/tests/test_archive_script.py
+++ b/apps/python/tests/test_archive_script.py
@@ -114,3 +114,19 @@ def test_missing_rclone_exits_nonzero_with_hint(tmp_path):
     )
     assert result.returncode == 1
     assert "rclone not found" in result.stderr.lower()
+
+
+def test_unsupported_date_without_month_exits_with_hint(tmp_path):
+    _seed_briefings(tmp_path / "briefing")
+    # Stub `date` that fails for every form, simulating a minimal/BusyBox host,
+    # and omit --month so the default-month branch is exercised.
+    stub_bin = tmp_path / "stubbin"
+    stub_bin.mkdir()
+    (stub_bin / "dirname").symlink_to("/usr/bin/dirname")
+    date_stub = stub_bin / "date"
+    date_stub.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    date_stub.chmod(0o755)
+
+    result = _run(tmp_path, env_extra={"PATH": str(stub_bin)})
+    assert result.returncode == 1
+    assert "supply --month" in result.stderr.lower()

--- a/apps/python/web/app.py
+++ b/apps/python/web/app.py
@@ -1,6 +1,17 @@
 from fastapi import FastAPI
 
-from web.routers import auth_mode, briefing, chat, config, credentials, health, run, state, usage
+from web.routers import (
+    archive,
+    auth_mode,
+    briefing,
+    chat,
+    config,
+    credentials,
+    health,
+    run,
+    state,
+    usage,
+)
 
 app = FastAPI(title="ai-agent Web API", version="0.1.0")
 app.include_router(health.router, prefix="/api")
@@ -12,3 +23,4 @@ app.include_router(run.router, prefix="/api")
 app.include_router(chat.router, prefix="/api")
 app.include_router(usage.router, prefix="/api")
 app.include_router(briefing.router, prefix="/api")
+app.include_router(archive.router, prefix="/api")

--- a/apps/python/web/routers/archive.py
+++ b/apps/python/web/routers/archive.py
@@ -1,0 +1,49 @@
+"""POST /api/archive — run the monthly briefing archive script.
+
+Invokes ``apps/python/bin/archive.sh`` via subprocess. The target month is
+optional and defaults to the previous month (decided by the script). On a
+non-zero exit the endpoint returns 500 with an excerpt of stderr.
+"""
+import re
+import subprocess
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from web.auth import require_bearer
+
+router = APIRouter(dependencies=[Depends(require_bearer)])
+
+ARCHIVE_SCRIPT = Path(__file__).parents[2] / "bin" / "archive.sh"
+_MONTH_RE = re.compile(r"^\d{4}-\d{2}$")
+_STDERR_EXCERPT = 2000
+
+
+class ArchiveResponse(BaseModel):
+    exit_code: int
+    stdout: str
+
+
+@router.post("/archive", response_model=ArchiveResponse)
+def post_archive(
+    month: str | None = Query(default=None, description="Target month YYYY-MM (default: previous)"),
+    prune: bool = Query(default=False),
+) -> ArchiveResponse:
+    if month is not None and not _MONTH_RE.match(month):
+        raise HTTPException(status_code=422, detail=f"month must be YYYY-MM, got: {month}")
+
+    cmd = [str(ARCHIVE_SCRIPT)]
+    if month is not None:
+        cmd += ["--month", month]
+    if prune:
+        cmd.append("--prune")
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        excerpt = result.stderr.strip()[-_STDERR_EXCERPT:]
+        raise HTTPException(
+            status_code=500,
+            detail=f"archive failed (exit {result.returncode}): {excerpt}",
+        )
+    return ArchiveResponse(exit_code=result.returncode, stdout=result.stdout)

--- a/apps/python/web/routers/archive.py
+++ b/apps/python/web/routers/archive.py
@@ -39,7 +39,10 @@ def post_archive(
     if prune:
         cmd.append("--prune")
 
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    # No command injection: args are passed as a list (no shell=True), the only
+    # dynamic value (month) is regex-validated to ^\d{4}-\d{2}$ above, and the
+    # binary path is a fixed constant.
+    result = subprocess.run(cmd, capture_output=True, text=True)  # noqa: S603
     if result.returncode != 0:
         excerpt = result.stderr.strip()[-_STDERR_EXCERPT:]
         raise HTTPException(

--- a/apps/web/components/briefing/ArchiveButton.tsx
+++ b/apps/web/components/briefing/ArchiveButton.tsx
@@ -1,0 +1,49 @@
+import { useState } from "react"
+
+type Status = "idle" | "running" | "done" | "error"
+
+/** Triggers POST /api/archive (previous month) and surfaces the result inline. */
+export function ArchiveButton() {
+  const [status, setStatus] = useState<Status>("idle")
+  const [message, setMessage] = useState<string>("")
+
+  const run = async () => {
+    setStatus("running")
+    setMessage("")
+    try {
+      const res = await fetch("/api/archive", { method: "POST", cache: "no-store" })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        setStatus("error")
+        setMessage(String(data?.detail ?? `HTTP ${res.status}`))
+        return
+      }
+      setStatus("done")
+      setMessage(String(data?.stdout ?? "").trim() || "Archive complete.")
+    } catch (e) {
+      setStatus("error")
+      setMessage(String(e))
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2 px-2 py-1">
+      <button
+        data-testid="archive-button"
+        onClick={run}
+        disabled={status === "running"}
+        className="rounded border px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
+      >
+        {status === "running" ? "Archiving…" : "Archive last month"}
+      </button>
+      {message && (
+        <span
+          data-testid="archive-message"
+          className={status === "error" ? "text-xs text-destructive" : "text-xs text-muted-foreground"}
+        >
+          {message}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/apps/web/components/screens/BriefingDashboard.tsx
+++ b/apps/web/components/screens/BriefingDashboard.tsx
@@ -1,6 +1,7 @@
 "use client"
 import { useEffect, useMemo, useState } from "react"
 
+import { ArchiveButton } from "@/components/briefing/ArchiveButton"
 import { BriefingPanel } from "@/components/briefing/BriefingPanel"
 import { BriefingRow } from "@/components/briefing/BriefingRow"
 import { BriefingSearch } from "@/components/briefing/BriefingSearch"
@@ -118,6 +119,7 @@ export function BriefingDashboard() {
           fullSize && "hidden",
         )}
       >
+        <ArchiveButton />
         <BriefingSearch onSearch={setQuery} />
         <BriefingTabs files={files} selected={tab} onSelect={setTab} />
         <table className="w-full text-sm">

--- a/apps/web/tests/archive-button.test.tsx
+++ b/apps/web/tests/archive-button.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { ArchiveButton } from "@/components/briefing/ArchiveButton"
+
+const fetchMock = vi.fn()
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  })
+}
+
+describe("ArchiveButton", () => {
+  beforeEach(() => {
+    fetchMock.mockReset()
+    vi.stubGlobal("fetch", fetchMock)
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("POSTs to /api/archive and shows the result", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ exit_code: 0, stdout: "created: briefing_2026-05.zip" }))
+    render(<ArchiveButton />)
+
+    await userEvent.setup().click(screen.getByTestId("archive-button"))
+
+    await waitFor(() =>
+      expect(screen.getByTestId("archive-message")).toHaveTextContent("briefing_2026-05.zip"),
+    )
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toBe("/api/archive")
+    expect(opts.method).toBe("POST")
+  })
+
+  it("surfaces the error detail on failure", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ detail: "archive failed: rclone not found" }, 500))
+    render(<ArchiveButton />)
+
+    await userEvent.setup().click(screen.getByTestId("archive-button"))
+
+    await waitFor(() =>
+      expect(screen.getByTestId("archive-message")).toHaveTextContent("rclone not found"),
+    )
+  })
+})

--- a/bin/archive.sh
+++ b/bin/archive.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+ENV_FILE="$PROJECT_ROOT/.env"
+if [ -f "$ENV_FILE" ]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "$ENV_FILE"
+    set +a
+fi
+
+exec "$PROJECT_ROOT/apps/python/bin/archive.sh" "$@"

--- a/launchd/com.ai-agent.archive.plist
+++ b/launchd/com.ai-agent.archive.plist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Monthly briefing archive job.
+
+  Manual install (edit the absolute paths below to match your checkout):
+    cp launchd/com.ai-agent.archive.plist ~/Library/LaunchAgents/
+    launchctl load ~/Library/LaunchAgents/com.ai-agent.archive.plist
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.ai-agent.archive.plist
+
+  Runs on the 1st of each month at 03:00 and archives the previous month.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.ai-agent.archive</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/nakagawakazusa/work/ai-agent/bin/archive.sh</string>
+    </array>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Day</key>
+        <integer>1</integer>
+        <key>Hour</key>
+        <integer>3</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/ai-agent-archive.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/ai-agent-archive.err.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- `apps/python/bin/archive.sh` (+ `bin/archive.sh` wrapper): zip `output/briefing/*_YYYY-MM-*.md` into `briefing_YYYY-MM.zip` and upload via rclone. `--month` (default previous month), `--prune` (off by default). Skips with exit 0 when no files; non-zero + setup hint when rclone missing/upload fails.
- `launchd/com.ai-agent.archive.plist`: monthly schedule (manual `launchctl load`).
- Backend `POST /api/archive`: runs the script via subprocess (optional `month`/`prune`), returns stdout/exit code; 500 + stderr excerpt on failure.
- `ArchiveButton` component on the Briefing screen.

## Test plan
- [x] Backend pytest: target-month file selection, no-files skip, retain/prune, rclone-missing error, API success/failure/validation
- [x] Frontend: ArchiveButton success + error rendering
- [x] `bash -n`, `plutil -lint`, `tsc --noEmit`, full pytest (597 passed)

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a monthly briefing archive workflow that zips past briefings and uploads them to Google Drive, exposes it via a backend API, and surfaces it in the Briefing UI.

New Features:
- Introduce a Bash script to zip monthly briefing markdown files and upload them to a configured Google Drive remote via rclone, with optional pruning of local files.
- Add a secured POST /api/archive endpoint that runs the archive script for a given month or the previous month by default.
- Add an ArchiveButton control to the Briefing dashboard to trigger the archive API and display success or error messages.
- Add a launchd plist to schedule the archive script to run automatically on the first of each month.

Tests:
- Add backend tests for the archive Bash script’s file selection, pruning behavior, and error handling when rclone is missing.
- Add API tests for POST /api/archive covering auth, parameter validation, command construction, and error propagation.
- Add frontend tests for ArchiveButton to verify successful invocations and surfaced error messages.