### PR TITLE
docs: add briefing archive setup guide (rclone → Google Drive)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,8 @@ CLAUDE_MODEL=
 DISCORD_TOKEN=your_discord_bot_token_here
 NOTION_API_KEY=your_notion_integration_token_here
 NOTION_DATABASE_ID=your_notion_database_id_here
+
+# Briefing archive (bin/archive.sh, POST /api/archive). See docs/briefing-archive.md.
+# rclone remote name (default: gdrive) and remote path (default: ai-agent/briefing).
+RCLONE_REMOTE=repo-briefing
+# RCLONE_PATH=ai-agent/briefing

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ bin/chat.sh --list     # list saved sessions
 |---|---|
 | Configuration (env vars, config schema, prompts) | [docs/configuration.md](docs/configuration.md) |
 | Scheduled execution (macOS launchd) | [docs/launchd-setup.md](docs/launchd-setup.md) |
+| Briefing archive (monthly zip → Google Drive via rclone) | [docs/briefing-archive.md](docs/briefing-archive.md) |
 | Briefing evaluation pipeline | [docs/evaluation.md](docs/evaluation.md) |
 | Local LLM mode (Ollama + Chroma) | [docs/local-llm.md](docs/local-llm.md) |
 | Testing & dependency management | [docs/testing.md](docs/testing.md) |

--- a/docs/briefing-archive.md
+++ b/docs/briefing-archive.md
@@ -53,8 +53,42 @@ bin/archive.sh --month 2026-05 --prune
 ```
 
 Result: `briefing_YYYY-MM.zip` is created under `apps/python/output/archive/` and
-uploaded to `gdrive:ai-agent/briefing/`. With no matching files the script exits
+uploaded to `<remote>:ai-agent/briefing/`. With no matching files the script exits
 zero and prints a skip message; local md files are **kept** unless `--prune` is given.
+
+### Custom remote name
+
+If you named the remote something other than `gdrive` (e.g. `repo-briefing`),
+tell the scripts via `RCLONE_REMOTE` — add it to `.env` so both the CLI and the
+Web API pick it up:
+
+```bash
+# .env
+RCLONE_REMOTE=repo-briefing
+```
+
+```bash
+rclone listremotes          # repo-briefing:
+bin/archive.sh --month 2026-05
+# → uploaded: repo-briefing:ai-agent/briefing/briefing_2026-05.zip
+```
+
+## Verify the upload
+
+```bash
+# 1. List the remote (most reliable)
+rclone ls  repo-briefing:ai-agent/briefing      # sizes + names
+rclone lsl repo-briefing:ai-agent/briefing      # + modtimes
+
+# 3. The local copy (kept unless --prune)
+ls apps/python/output/archive/
+```
+
+2. **Google Drive web/app** — open [drive.google.com](https://drive.google.com)
+   → *My Drive* → the `ai-agent/briefing/` folder (the `RCLONE_PATH` value becomes
+   the folder path). Searching `briefing_2026-05.zip` also finds it. If the remote
+   was created with the `drive.file` scope, only rclone-uploaded files are visible —
+   that is expected, and `rclone ls` showing the file confirms it is stored.
 
 ## Configuration
 

--- a/docs/briefing-archive.md
+++ b/docs/briefing-archive.md
@@ -1,0 +1,93 @@
+# Briefing Archive — Monthly Zip to Google Drive
+
+Archive accumulated briefing markdown files (`apps/python/output/briefing/*_YYYY-MM-*.md`)
+into a monthly zip and upload it to Google Drive at zero cost via
+[`rclone`](https://rclone.org/). Runnable manually (CLI), automatically
+(launchd), or from the Web UI (the **Archive last month** button on the Briefing
+screen, which calls `POST /api/archive`).
+
+> `rclone` is a standalone CLI tool — **not** an MCP server and unrelated to
+> Claude. The archive scripts shell out to it directly. If it is missing or
+> unconfigured, archiving exits non-zero with a setup hint (this is expected
+> until you complete the steps below).
+
+## 1. Install rclone
+
+```bash
+brew install rclone
+```
+
+## 2. Configure a Google Drive remote
+
+`rclone config` is interactive and opens a browser for Google OAuth:
+
+```bash
+rclone config
+```
+
+- `n` — New remote
+- name — **`gdrive`** (the scripts' default; use another name only if you also set `RCLONE_REMOTE`, see below)
+- Storage — `drive` (Google Drive)
+- `client_id` / `client_secret` — leave blank (press Enter) for the defaults
+- scope — `1` (full access) or `drive.file` is enough
+- accept the remaining defaults, then complete the browser sign-in
+- `y` to confirm, `q` to quit
+
+Verify:
+
+```bash
+rclone listremotes      # should list: gdrive:
+```
+
+## 3. Run the archive
+
+```bash
+# Previous month (default), keep local md files
+bin/archive.sh
+
+# A specific month
+bin/archive.sh --month 2026-05
+
+# Delete local md after a successful upload
+bin/archive.sh --month 2026-05 --prune
+```
+
+Result: `briefing_YYYY-MM.zip` is created under `apps/python/output/archive/` and
+uploaded to `gdrive:ai-agent/briefing/`. With no matching files the script exits
+zero and prints a skip message; local md files are **kept** unless `--prune` is given.
+
+## Configuration
+
+Override via environment variables (e.g. in `.env`, which the root wrappers and
+`bin/serve.sh` source so the Web API picks them up too):
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `RCLONE_REMOTE` | `gdrive` | rclone remote name |
+| `RCLONE_PATH` | `ai-agent/briefing` | Remote path under the remote |
+| `ARCHIVE_BRIEFING_DIR` | `apps/python/output/briefing` | Source dir of md files |
+| `ARCHIVE_OUTPUT_DIR` | `apps/python/output/archive` | Where the zip is written |
+
+## Web UI
+
+The **Archive last month** button on the Briefing screen issues
+`POST /api/archive` (optional `?month=YYYY-MM&prune=true`). On success it shows
+the script stdout; on failure it shows a `500` with a stderr excerpt — the same
+rclone setup hint surfaces here.
+
+## Scheduled execution (launchd)
+
+A monthly job template lives at `launchd/com.ai-agent.archive.plist` (runs on the
+1st of each month at 03:00, archiving the previous month).
+
+```bash
+# Edit the absolute paths inside the plist to match your checkout first, then:
+cp launchd/com.ai-agent.archive.plist ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/com.ai-agent.archive.plist
+
+# Unload
+launchctl unload ~/Library/LaunchAgents/com.ai-agent.archive.plist
+```
+
+See [launchd-setup.md](launchd-setup.md) for general launchd notes (PATH/HOME
+environment keys matter for non-interactive runs).


### PR DESCRIPTION
## Summary
- New `docs/briefing-archive.md`: rclone install + `gdrive` remote config, CLI usage (`--month`/`--prune`), env-var overrides, Web UI button, and launchd scheduling.
- Clarifies rclone is a standalone CLI (not MCP) and that the "rclone not found" error is expected until configured.
- Linked from the README docs table.

## Test plan
- [x] Docs only; no code changes

## Summary by Sourcery

Document the briefing archive workflow using rclone to upload monthly briefing zips to Google Drive and link it from the main docs index.

Documentation:
- Add a dedicated guide for configuring rclone with Google Drive and running the monthly briefing archive via CLI, Web UI, and launchd.
- Clarify expected behavior and configuration options for the rclone-based archive, including environment variable overrides and launchd scheduling.
- Link the new briefing archive guide from the README documentation table.