### PR TITLE
chore: convert Japanese code comments/docstrings to English

### DIFF
--- a/apps/python/src/claude_runner.py
+++ b/apps/python/src/claude_runner.py
@@ -21,17 +21,18 @@ logger = get_logger(__name__)
 
 
 def _parse_and_log_usage(stdout: str, label: str) -> str:
-    """``--output-format json`` の stdout を解析し使用量を記録、テキスト結果を返す。
+    """Parse ``--output-format json`` stdout, record usage, and return the text result.
 
-    JSON でない / ``result`` フィールドが無い場合は警告を出して raw stdout を
-    そのまま返す（使用量ログはスキップ）— 使用量計測のために本処理を壊さない。
+    If the output is not JSON or lacks a ``result`` field, log a warning and
+    return the raw stdout as-is (skipping the usage log) — usage measurement must
+    not break the main task.
     """
     try:
         parsed = json.loads(stdout)
         result_text = parsed["result"]
     except (json.JSONDecodeError, KeyError, TypeError):
         logger.warning(
-            "claude CLI 出力を JSON として解析できませんでした、使用量ログをスキップ [%s]", label,
+            "could not parse claude CLI output as JSON, skipping usage log [%s]", label,
         )
         return stdout.strip()
 
@@ -44,34 +45,34 @@ def _parse_and_log_usage(stdout: str, label: str) -> str:
             duration_ms=parsed.get("duration_ms"),
         )
     else:
-        # usage を出さない呼び出しは正常運用でもありうるため debug に留める（ノイズ回避）
-        logger.debug("claude CLI 出力に usage が無いため使用量ログをスキップ [%s]", label)
+        # Calls without usage can happen in normal operation, so keep this at debug (avoid noise).
+        logger.debug("no usage in claude CLI output, skipping usage log [%s]", label)
 
     return result_text.strip() if isinstance(result_text, str) else str(result_text)
 
 
 def _config_model() -> str | None:
-    """briefing.json の ``model`` フィールドを返す。読めなければ None。
+    """Return the ``model`` field from briefing.json. None if it cannot be read.
 
-    briefing.json が無い / 壊れている場合でもモデル解決を止めないため、
-    例外は握りつぶして None を返す（呼び出し側で DEFAULT_MODEL にフォールバック）。
+    To avoid blocking model resolution when briefing.json is missing or broken,
+    swallow exceptions and return None (the caller falls back to DEFAULT_MODEL).
     """
     try:
         model = config_mod.CONFIG.model
     except FileNotFoundError:
-        # briefing.json 未作成（例: web 起動直後）は想定内なので静かに無視。
+        # briefing.json not yet created (e.g. right after web startup) is expected; ignore quietly.
         return None
-    except Exception:  # noqa: BLE001 — 予期しない config エラーでもモデル解決は止めない
-        logger.warning("config からのモデル取得に失敗、DEFAULT_MODEL を使用", exc_info=True)
+    except Exception:  # noqa: BLE001 — unexpected config errors must not block model resolution
+        logger.warning("failed to read model from config, using DEFAULT_MODEL", exc_info=True)
         return None
     return model.strip() if model and model.strip() else None
 
 
 def get_model() -> str:
-    """claude CLI に渡すモデル ID を解決する。
+    """Resolve the model ID passed to the claude CLI.
 
-    優先順位: ``CLAUDE_MODEL`` env > briefing.json の ``model`` > ``DEFAULT_MODEL``。
-    env はアドホックな上書き用に最優先のまま。
+    Precedence: ``CLAUDE_MODEL`` env > briefing.json ``model`` > ``DEFAULT_MODEL``.
+    env stays highest priority for ad-hoc overrides.
     """
     env_model = os.environ.get("CLAUDE_MODEL", "").strip()
     if env_model:
@@ -80,17 +81,17 @@ def get_model() -> str:
 
 
 def _backoff_delay(attempt: int) -> float:
-    """attempt 番目 (1-indexed) のリトライ前に待機する秒数を返す。"""
+    """Return the seconds to wait before the ``attempt``-th retry (1-indexed)."""
     return RETRY_BASE_DELAY * (RETRY_BACKOFF_FACTOR ** (attempt - 1))
 
 
 def build_env(auth_mode: str) -> dict[str, str]:
-    """auth_mode に応じてサブプロセスに渡す env を作る。
+    """Build the env passed to the subprocess according to auth_mode.
 
-    - ``cli``: ``ANTHROPIC_API_KEY`` を削除して Claude Code CLI の OAuth を使わせる。
-    - ``api``: Keychain (なければ .env 経由の os.environ) から
-      ``ANTHROPIC_API_KEY`` を取り出して env に注入する。Keychain にも env にも
-      無ければキーは未設定のまま — 呼び出し側で claude CLI が認証エラーになる。
+    - ``cli``: strip ``ANTHROPIC_API_KEY`` so the Claude Code CLI uses its OAuth.
+    - ``api``: pull ``ANTHROPIC_API_KEY`` from the Keychain (or os.environ via
+      .env) and inject it into env. If it is in neither, the key stays unset —
+      the claude CLI then raises an auth error on the caller's side.
 
     Public API — also imported by ``web.routers.chat``. (The earlier underscore
     prefix was a stale "internal" signal that didn't reflect actual usage.)
@@ -109,20 +110,20 @@ def run_claude(
     timeout: int = 300,
     max_attempts: int = RETRY_MAX_ATTEMPTS,
 ) -> str:
-    """claude CLI を subprocess で呼び出し、結果を返す。
+    """Invoke the claude CLI as a subprocess and return the result.
 
-    ANTHROPIC_API_KEY を子プロセスに渡さないことで、
-    WebSearch がサブスクリプション認証(OAuth)を使うようにする。
+    By not passing ANTHROPIC_API_KEY to the child process, WebSearch uses
+    subscription auth (OAuth).
 
-    Anthropic API の 5xx 系エラー (例: 529 Overloaded) は指数バックオフで
-    最大 ``max_attempts`` 回までリトライする。
+    Anthropic API 5xx errors (e.g. 529 Overloaded) are retried with exponential
+    backoff up to ``max_attempts`` times.
     """
     if max_attempts < 1:
-        raise ValueError(f"max_attempts は 1 以上である必要があります (got {max_attempts})")
+        raise ValueError(f"max_attempts must be >= 1 (got {max_attempts})")
 
     claude_path = shutil.which("claude")
     if claude_path is None:
-        raise RuntimeError("claude CLI が見つかりません。PATH を確認してください。")
+        raise RuntimeError("claude CLI not found. Check your PATH.")
 
     env = build_env(auth_mode=state_mod.read_state().auth_mode)
     model = get_model()
@@ -137,7 +138,7 @@ def run_claude(
     last_detail = ""
     for attempt in range(1, max_attempts + 1):
         logger.info(
-            "claude CLI 呼び出し開始: %s (timeout=%ds, attempt=%d/%d)",
+            "claude CLI call start: %s (timeout=%ds, attempt=%d/%d)",
             label, timeout, attempt, max_attempts,
         )
         try:
@@ -150,15 +151,15 @@ def run_claude(
                 env=env,
             )
         except subprocess.TimeoutExpired as exc:
-            logger.error("claude CLI タイムアウト: %s (%ds)", label, timeout)
-            raise RuntimeError(f"claude CLI がタイムアウトしました ({label})") from exc
+            logger.error("claude CLI timeout: %s (%ds)", label, timeout)
+            raise RuntimeError(f"claude CLI timed out ({label})") from exc
 
         if result.returncode == 0:
-            logger.info("claude CLI 完了: %s (%d文字)", label, len(result.stdout))
+            logger.info("claude CLI done: %s (%d chars)", label, len(result.stdout))
             return _parse_and_log_usage(result.stdout, label)
 
         logger.error(
-            "claude CLI エラー [%s] rc=%d attempt=%d/%d\nstdout=%s\nstderr=%s",
+            "claude CLI error [%s] rc=%d attempt=%d/%d\nstdout=%s\nstderr=%s",
             label, result.returncode, attempt, max_attempts, result.stdout, result.stderr,
         )
         last_returncode = result.returncode
@@ -167,7 +168,7 @@ def run_claude(
         if is_transient(result.stdout, result.stderr) and attempt < max_attempts:
             delay = _backoff_delay(attempt)
             logger.warning(
-                "一時的なエラーを検出、%.1fs 後にリトライします [%s] (attempt %d/%d)",
+                "transient error detected, retrying in %.1fs [%s] (attempt %d/%d)",
                 delay, label, attempt, max_attempts,
             )
             time.sleep(delay)
@@ -176,4 +177,4 @@ def run_claude(
 
     if len(last_detail) > 2000:
         last_detail = last_detail[:2000] + "…(truncated)"
-    raise RuntimeError(f"claude CLI エラー [{label}] rc={last_returncode}: {last_detail}")
+    raise RuntimeError(f"claude CLI error [{label}] rc={last_returncode}: {last_detail}")

--- a/apps/python/src/config.py
+++ b/apps/python/src/config.py
@@ -1,18 +1,18 @@
-"""briefing.json と xss_intel.json をロードするモジュール。
+"""Module that loads briefing.json and xss_intel.json.
 
-ブリーフィングの設定スキーマは Pydantic v2 モデルで 1 箇所に定義し、
-``/api/config`` と ``load_config()`` の両方で共有する。継承構造:
+The briefing config schema is defined once as Pydantic v2 models and shared by
+both ``/api/config`` and ``load_config()``. Inheritance structure:
 
-- ``BriefingFileConfig`` — ``briefing.json`` に書ける部分（公開可能）。
-  ``/api/config`` の input/output スキーマとして ``web.schemas`` から
-  ``BriefingConfigSchema`` の名前で re-export される。
-- ``BriefingConfig`` — ``BriefingFileConfig`` を継承し、env から注入する
-  クレデンシャル 4 フィールドを足す。ランタイム消費者 (handler / generator /
-  notifier) はこちらを受け取る。
+- ``BriefingFileConfig`` — the part writable in ``briefing.json`` (publishable).
+  Re-exported from ``web.schemas`` as ``BriefingConfigSchema`` for the
+  ``/api/config`` input/output schema.
+- ``BriefingConfig`` — extends ``BriefingFileConfig`` with the 4 credential
+  fields injected from env. Runtime consumers (handler / generator / notifier)
+  receive this one.
 
-入力バリデーション (``tickers`` / ``watch_sectors`` の non-empty 等) は
-Pydantic 側で集約。``load_config()`` は ``pydantic.ValidationError`` を
-``ValueError`` にラップして公開コントラクトを維持する。
+Input validation (non-empty ``tickers`` / ``watch_sectors``, etc.) is
+consolidated in Pydantic. ``load_config()`` wraps ``pydantic.ValidationError``
+in ``ValueError`` to keep the public contract.
 """
 import json
 import os
@@ -24,9 +24,9 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from src.credentials import get_credential
 
-# Repo root .env（apps/python/ より 2 階層上）を優先ロード。
-# キーチェーンに登録済みの値は credentials.get_credential() が優先するため、
-# .env はキーチェーン未登録時のフォールバックとして機能する。
+# Load the repo-root .env first (two levels up from apps/python/).
+# Since credentials.get_credential() prefers values already in the keychain,
+# .env acts as the fallback when a key is not registered in the keychain.
 load_dotenv(Path(__file__).parents[2] / ".env")
 
 CONFIG_PATH = Path(os.getenv("BRIEFING_CONFIG_PATH", str(Path(__file__).parents[1] / "config" / "briefing.json")))
@@ -38,8 +38,8 @@ class Conflict(BaseModel):
     affected_sectors: list[str]
     related_tickers: list[str] = Field(default_factory=list)
     notes: str | None = None
-    # ローカル LLM 経路の pre-fetch 用英語検索クエリ (#153)。日本語トピック名の
-    # 検索は常設の索引ページを引きがちなので、設定があればこちらを優先する。
+    # English search query for the local-LLM path pre-fetch (#153). Searching by
+    # Japanese topic name tends to hit standing index pages, so prefer this when set.
     query_en: str | None = None
 
 
@@ -67,16 +67,16 @@ class WatchEvent(BaseModel):
 
 
 class BriefingFileConfig(BaseModel):
-    """``briefing.json`` で表現される部分。クレデンシャルは含まない。
+    """The part expressed in ``briefing.json``. Contains no credentials.
 
-    ``/api/config`` の input/output として直接安全に使える形にしてある。
-    ``extra="forbid"`` は briefing.json の typo (例: ``watch_evens``) を黙って
-    捨てるのではなく load 時に弾くため。"""
+    Shaped so it can be used directly and safely as ``/api/config`` input/output.
+    ``extra="forbid"`` rejects briefing.json typos (e.g. ``watch_evens``) at load
+    time instead of silently dropping them."""
 
     model_config = ConfigDict(extra="forbid")
 
-    # claude CLI に渡すモデル ID（任意）。未設定なら DEFAULT_MODEL。
-    # 優先順位は CLAUDE_MODEL env > この config 値 > DEFAULT_MODEL（claude_runner.get_model 参照）。
+    # Model ID passed to the claude CLI (optional). DEFAULT_MODEL if unset.
+    # Precedence: CLAUDE_MODEL env > this config value > DEFAULT_MODEL (see claude_runner.get_model).
     model: str | None = None
     portfolio: PortfolioConfig
     geopolitical: GeopoliticalConfig = Field(default_factory=GeopoliticalConfig)
@@ -85,10 +85,11 @@ class BriefingFileConfig(BaseModel):
 
 
 class BriefingConfig(BriefingFileConfig):
-    """ランタイム用。ファイル部分 + env 経由のクレデンシャル。
+    """For runtime use: the file part + credentials via env.
 
-    継承順がポイント: ``BriefingFileConfig`` (file shape) を拡張する形なので、
-    API 側に渡すときは ``BriefingFileConfig`` 視点に絞り込めば secrets は漏れない。"""
+    The inheritance order matters: because it extends ``BriefingFileConfig``
+    (the file shape), narrowing to the ``BriefingFileConfig`` view when passing
+    to the API ensures secrets do not leak."""
 
     discord_token: str = ""
     discord_channel_id: str = ""
@@ -97,13 +98,13 @@ class BriefingConfig(BriefingFileConfig):
 
 
 def load_config() -> BriefingConfig:
-    """briefing.json と環境変数から BriefingConfig を構築して返す。
+    """Build and return a BriefingConfig from briefing.json and env vars.
 
-    Pydantic の ``ValidationError`` は ``ValueError`` にラップする — 既存の
-    呼び出し側 (load_config を直接叩く CLI 起動パス、tests/test_config.py) が
-    ``ValueError`` を期待しているための後方互換。エラーメッセージは最初の
-    違反だけを抜き出して "at <loc>: <msg>" の形に整える (Pydantic 既定の
-    フル stringification は startup ログとして読みづらい)。"""
+    Pydantic's ``ValidationError`` is wrapped in ``ValueError`` for backward
+    compatibility — existing callers (the CLI startup path that calls load_config
+    directly, tests/test_config.py) expect ``ValueError``. The error message
+    extracts only the first violation into an "at <loc>: <msg>" form (Pydantic's
+    default full stringification is hard to read as a startup log)."""
     raw = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
     try:
         return BriefingConfig(
@@ -161,7 +162,7 @@ class XssIntelConfig:
 
 
 def load_xss_config() -> XssIntelConfig:
-    """xss_intel.json と環境変数から XssIntelConfig を構築して返す。"""
+    """Build and return an XssIntelConfig from xss_intel.json and env vars."""
     raw = json.loads(XSS_INTEL_CONFIG_PATH.read_text(encoding="utf-8"))
     targets = XssTargetsConfig(**raw["targets"])
 
@@ -178,7 +179,7 @@ _XSS_CONFIG: XssIntelConfig | None = None
 
 
 def get_xss_config() -> XssIntelConfig:
-    """XssIntelConfig をシングルトンとして返す（初回アクセス時にのみ読み込む）。"""
+    """Return XssIntelConfig as a singleton (loaded only on first access)."""
     global _XSS_CONFIG
     if _XSS_CONFIG is None:
         _XSS_CONFIG = load_xss_config()

--- a/apps/python/src/credentials.py
+++ b/apps/python/src/credentials.py
@@ -1,12 +1,12 @@
-"""OS Keychain ラッパ + .env フォールバック。
+"""OS Keychain wrapper + .env fallback.
 
-`python-keyring` 経由で OS のキーチェーンに資格情報を保存する。読み出し時に
-キーチェーンが ``None`` を返した場合のみ、同名の環境変数にフォールバックする。
-書き込みは常にキーチェーンへ行う（.env は不変）。
+Stores credentials in the OS keychain via `python-keyring`. On read, falls back
+to the same-named environment variable only when the keychain returns ``None``.
+Writes always go to the keychain (.env is immutable).
 
-許可された名前 (`ALLOWED_KEYS`) 以外は ``ValueError``。これは
-``/api/credentials`` の入力サニタイズと、運用ミスでよく分からないキーが
-保管されないようにするためのガード。
+Names outside the allowed set (`ALLOWED_KEYS`) raise ``ValueError``. This guards
+both the ``/api/credentials`` input sanitization and against operational
+mistakes that would store unknown keys.
 """
 import os
 from typing import Any

--- a/apps/python/src/evaluator/extract.py
+++ b/apps/python/src/evaluator/extract.py
@@ -23,20 +23,20 @@ def _extract_json_array(raw: str) -> list:
     try:
         data = json.loads(text)
     except json.JSONDecodeError:
-        logger.warning("eval-extract: JSON 解析失敗、空として扱います")
+        logger.warning("eval-extract: JSON parse failed, treating as empty")
         return []
     return data if isinstance(data, list) else []
 
 
 def _normalize_targets(value) -> list[str]:
-    # LLM が単一文字列を返した場合に文字分割しないよう、リスト化してから正規化する。
+    # Wrap in a list before normalizing so a single string from the LLM is not split into chars.
     if not isinstance(value, list):
         value = [value] if str(value).strip() else []
     return [str(t) for t in value if str(t).strip()]
 
 
 def _to_int(value, default: int) -> int:
-    # 非数値・型不整合な horizon_days で抽出全体が落ちないよう既定値に倒す。
+    # Fall back to the default so a non-numeric/type-mismatched horizon_days does not break extraction.
     try:
         return int(value)
     except (TypeError, ValueError):
@@ -76,6 +76,6 @@ def extract(target: str = "all") -> None:
     dates = storage.list_briefing_dates() if target == "all" else [target]
     for date_str in dates:
         if (storage.CLAIMS_DIR / f"{date_str}.json").exists():
-            logger.info("eval-extract: %s は抽出済み、スキップ", date_str)
+            logger.info("eval-extract: %s already extracted, skipping", date_str)
             continue
         extract_one(date_str)

--- a/apps/python/src/evaluator/report.py
+++ b/apps/python/src/evaluator/report.py
@@ -179,11 +179,11 @@ def build_report() -> str:
     agg = aggregate(scores, claims_by_id)
     html = _build_html(agg)
 
-    # 最新レポート（常に上書き）
+    # Latest report (always overwritten)
     storage.REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
     storage.REPORT_PATH.write_text(html, encoding="utf-8")
 
-    # 日付付きレポート（蓄積）
+    # Dated report (accumulated)
     dated_path = storage.dated_report_path(date.today().isoformat())
     dated_path.parent.mkdir(parents=True, exist_ok=True)
     dated_path.write_text(html, encoding="utf-8")

--- a/apps/python/src/evaluator/score.py
+++ b/apps/python/src/evaluator/score.py
@@ -42,10 +42,10 @@ def parse_verdict(raw: str) -> dict:
 
 
 def parse_verdicts_batch(raw: str) -> list[dict] | None:
-    """バッチ応答 (JSON 配列) をパースする。失敗時は None を返す。
+    """Parse a batch response (JSON array). Return None on failure.
 
-    非 dict 要素が 1 件でもあれば None を返してフォールバックを促す。
-    id は呼び出し側でポジションベースに上書きするため、ここでは raw 値をそのまま格納する。
+    Return None if even one element is not a dict, to trigger the fallback.
+    The id is overwritten position-based by the caller, so store the raw value here.
     """
     text = raw.strip()
     m = _FENCE_RE.search(text)
@@ -65,7 +65,7 @@ def parse_verdicts_batch(raw: str) -> list[dict] | None:
         if verdict not in _VALID_VERDICT:
             verdict = "unresolved"
         results.append({
-            "id": item.get("id"),  # 呼び出し側でポジションベースに確定する
+            "id": item.get("id"),  # finalized position-based by the caller
             "verdict": verdict,
             "confidence": _to_float(item.get("confidence"), 0.0),
             "rationale": str(item.get("rationale", "")),
@@ -81,7 +81,7 @@ def _to_float(value, default: float) -> float:
 
 
 def score_claim(claim: dict, all_dates: list[str]) -> dict:
-    """1 件の claim を採点する。内部では score_claims_batch を経由する。"""
+    """Score a single claim. Internally goes through score_claims_batch."""
     results = score_claims_batch([claim], all_dates)
     return results[0]
 
@@ -91,19 +91,19 @@ def score_claims_batch(
     all_dates: list[str],
     precomputed: dict[str, list[str]] | None = None,
 ) -> list[dict]:
-    """同一 followup グループの claims を 1 回の LLM 呼び出しで採点する。
+    """Score claims in the same followup group with a single LLM call.
 
-    precomputed: {claim_id: followup_dates} の事前計算済みマップ。
-    渡された場合は followup_dates() の再計算を省略する。
-    フォールバック: バッチ応答のパースに失敗した場合は per-claim で再実行する。
+    precomputed: a precomputed {claim_id: followup_dates} map. When passed,
+    skips recomputing followup_dates().
+    Fallback: if the batch response fails to parse, re-run per-claim.
     """
-    # followup_dates の解決
+    # Resolve followup_dates
     followup_map: dict[str, list[str]] = precomputed if precomputed is not None else {
         c["id"]: followup_dates(c["id"][:10], c["horizon_days"], all_dates)
         for c in claims
     }
 
-    # followup が 1 件もない claim はここで即解決
+    # Claims with no followups are resolved immediately here
     resolved: list[dict] = []
     pending: list[dict] = []
     for c in claims:
@@ -116,7 +116,7 @@ def score_claims_batch(
     if not pending:
         return resolved
 
-    # followup 本文を union して構築（グループ内で重複しないよう set で結合）
+    # Build the union of followup bodies (joined via a set to dedupe within the group)
     all_followup_dates: list[str] = sorted(
         {d for c in pending for d in followup_map[c["id"]]}
     )
@@ -138,14 +138,14 @@ def score_claims_batch(
 
     batch_results = parse_verdicts_batch(raw)
     if batch_results is not None and len(batch_results) == len(pending):
-        # LLM の id は信頼せず、ポジションベースで pending の id を確定する
+        # Do not trust the LLM's id; finalize pending ids position-based
         for result, claim in zip(batch_results, pending):
             result["id"] = claim["id"]
         return resolved + batch_results
 
-    # フォールバック: バッチ応答が壊れていた場合は 1 件ずつ再実行
+    # Fallback: if the batch response was broken, re-run one claim at a time
     logger.warning(
-        "eval-judge バッチ応答のパースに失敗 (%s)、per-claim フォールバック実行", base_date,
+        "eval-judge batch response parse failed (%s), running per-claim fallback", base_date,
     )
     fallback = []
     for c in pending:
@@ -163,7 +163,7 @@ def score_claims_batch(
         single_raw = run_claude(single_prompt, label=f"eval-judge {c['id']}")
         single_results = parse_verdicts_batch(single_raw)
         if single_results and len(single_results) == 1:
-            single_results[0]["id"] = c["id"]  # ポジションベースで id 確定
+            single_results[0]["id"] = c["id"]  # finalize id position-based
             fallback.append(single_results[0])
         else:
             fallback.append({"id": c["id"], "verdict": "unresolved", "confidence": 0.0,
@@ -183,7 +183,7 @@ def score(target: str = "all") -> None:
         existing = {s["id"]: s for s in storage.load_json(scores_file)} \
             if scores_file.exists() else {}
 
-        # 確定済みと未処理に分ける
+        # Split into finalized and pending
         finalized: list[dict] = []
         pending: list[dict] = []
         for claim in claims:
@@ -197,7 +197,7 @@ def score(target: str = "all") -> None:
             storage.save_json(scores_file, finalized)
             continue
 
-        # followup_dates を一度だけ計算してキャッシュし、グループ化とバッチ処理で再利用
+        # Compute followup_dates once and cache it, reused for grouping and batching
         followups_cache: dict[str, list[str]] = {
             c["id"]: followup_dates(c["id"][:10], c["horizon_days"], all_dates)
             for c in pending
@@ -213,7 +213,7 @@ def score(target: str = "all") -> None:
             group_cache = {c["id"]: followups_cache[c["id"]] for c in claims_in_group}
             batch_results.extend(score_claims_batch(claims_in_group, all_dates, group_cache))
 
-        # 元の claim 順序に合わせて保存
+        # Save in the original claim order
         id_to_result = {r["id"]: r for r in finalized + batch_results}
         results = [id_to_result[c["id"]] for c in claims if c["id"] in id_to_result]
         storage.save_json(scores_file, results)

--- a/apps/python/src/evaluator/storage.py
+++ b/apps/python/src/evaluator/storage.py
@@ -12,7 +12,7 @@ EVAL_DIR = OUTPUT_DIR / "eval"
 CLAIMS_DIR = EVAL_DIR / "claims"
 SCORES_DIR = EVAL_DIR / "scores"
 REPORT_DIR = EVAL_DIR / "reports"
-REPORT_PATH = EVAL_DIR / "report.html"  # 最新レポート（常に上書き）
+REPORT_PATH = EVAL_DIR / "report.html"  # latest report (always overwritten)
 
 
 def dated_report_path(date_str: str) -> Path:
@@ -44,7 +44,7 @@ def list_briefing_dates() -> list[str]:
             continue
         d = m.group(1)
         try:
-            date.fromisoformat(d)  # 形式は合うが暦上無効な日付を除外
+            date.fromisoformat(d)  # exclude well-formed but calendar-invalid dates
         except ValueError:
             continue
         dates.append(d)

--- a/apps/python/src/fetcher/stocks.py
+++ b/apps/python/src/fetcher/stocks.py
@@ -22,7 +22,7 @@ def fetch_stock_move_map(tickers: list[str]) -> dict[str, str]:
             logger.debug("stock fetch: %s: %s", t, moves[t])
         except Exception as e:
             logger.warning("stock fetch failed [%s]: %s", t, e)
-            moves[t] = f"取得エラー ({e})"
+            moves[t] = f"Stock fetch error ({e})"
     return moves
 
 

--- a/apps/python/src/fetcher/stocks.py
+++ b/apps/python/src/fetcher/stocks.py
@@ -5,11 +5,12 @@ logger = get_logger(__name__)
 
 
 def fetch_stock_move_map(tickers: list[str]) -> dict[str, str]:
-    """yfinance で前日比を取得し、ticker → 表示文字列の dict で返す (#152)。
+    """Fetch day-over-day change via yfinance and return a ticker → display-string dict (#152).
 
-    ローカル LLM 経路の保有銘柄テーブルは Python 側でセルを埋めるため、
-    結合済み文字列ではなく per-ticker の値が要る。取得失敗はエラー文字列を
-    入れて呼び出し側に判断を委ねる (テーブル側は出典セル同様 `-` 等で表示)。
+    The local-LLM path's holdings table fills cells on the Python side, so it
+    needs per-ticker values rather than one joined string. On fetch failure, an
+    error string is stored and the decision left to the caller (the table renders
+    it like a source cell, e.g. with `-`).
     """
     moves: dict[str, str] = {}
     for t in tickers:
@@ -18,15 +19,15 @@ def fetch_stock_move_map(tickers: list[str]) -> dict[str, str]:
             pct = (info.last_price / info.previous_close - 1) * 100
             arrow = "↑" if pct > 0 else "↓"
             moves[t] = f"{arrow}{abs(pct):.1f}%  (${info.last_price:.2f})"
-            logger.debug("株価取得: %s: %s", t, moves[t])
+            logger.debug("stock fetch: %s: %s", t, moves[t])
         except Exception as e:
-            logger.warning("株価取得失敗 [%s]: %s", t, e)
+            logger.warning("stock fetch failed [%s]: %s", t, e)
             moves[t] = f"取得エラー ({e})"
     return moves
 
 
 def fetch_stock_moves(tickers: list[str]) -> str:
-    """yfinance で前日比を取得（無料）"""
+    """Fetch day-over-day change via yfinance (free)."""
     return "\n".join(
         f"{t}: {move}" for t, move in fetch_stock_move_map(tickers).items()
     )

--- a/apps/python/src/generator/briefing.py
+++ b/apps/python/src/generator/briefing.py
@@ -10,23 +10,23 @@ from src.prompt_safety import neutralize_user_text
 
 logger = get_logger(__name__)
 
-# 並列実行のため実際の待機時間は max(MAIN, SECTORS) = 480s（合計ではない）
+# Because of parallel execution, actual wait time is max(MAIN, SECTORS) = 480s (not the sum).
 
-# 高性能モデル出力を捕捉した few-shot 例。安価なモデルでも構成を保てるよう
-# メインブリーフィングのプロンプトに注入する（#192）。再生成手順は
-# prompts/examples/README.md を参照。
+# Few-shot example captured from a high-capability model's output. Injected into
+# the main briefing prompt so cheaper models keep the structure (#192). See
+# prompts/examples/README.md for the regeneration steps.
 _FEW_SHOT_PATH = Path(__file__).parents[2] / "prompts" / "examples" / "briefing_few_shot.md"
 
 
 @lru_cache(maxsize=1)
 def load_briefing_few_shot() -> str:
-    """メインブリーフィングの few-shot 例を読み込んで返す。
+    """Load and return the main briefing few-shot example.
 
-    few-shot は ``render()`` の **値** として渡るため、本文中の ``$`` が
-    プレースホルダとして再解釈されることはない（単一パス置換）。
+    The few-shot is passed as a **value** to ``render()``, so any ``$`` in its
+    body is never reinterpreted as a placeholder (single-pass substitution).
 
-    アセットはリポジトリ同梱で実行中に変わらないため ``lru_cache`` で
-    1 回だけ読み、``generate_briefing()`` 呼び出しごとのディスク I/O を避ける。
+    The asset ships with the repo and does not change at runtime, so ``lru_cache``
+    reads it once to avoid disk I/O on every ``generate_briefing()`` call.
     """
     return _FEW_SHOT_PATH.read_text(encoding="utf-8")
 
@@ -89,7 +89,7 @@ def build_watch_events_context(config: BriefingConfig) -> str:
 
 
 def generate_briefing(stocks: str, config: BriefingConfig) -> str:
-    """メイン分析とセクタースイープを並列実行してブリーフィングを生成する。"""
+    """Generate the briefing by running the main analysis and sector sweep in parallel."""
     tickers = join_safe(config.portfolio.tickers, sep=", ")
     themes = join_safe(config.portfolio.themes, sep=", ")
 
@@ -120,18 +120,18 @@ def generate_briefing(stocks: str, config: BriefingConfig) -> str:
             try:
                 results[key] = future.result()
             except Exception as e:
-                logger.error("claude CLI 失敗 [%s]: %s", key, e)
+                logger.error("claude CLI failed [%s]: %s", key, e)
                 errors[key] = str(e)
 
     if "main" in errors:
-        raise RuntimeError(f"ブリーフィング生成に失敗しました: メイン分析\n{errors['main']}")
+        raise RuntimeError(f"briefing generation failed: main analysis\n{errors['main']}")
 
     assert "main" in results, "main result missing despite no error recorded"
 
     main_text = results["main"]
 
     if "sectors" in errors:
-        logger.warning("セクタースイープ失敗（メイン分析は成功）: %s", errors["sectors"])
+        logger.warning("sector sweep failed (main analysis succeeded): %s", errors["sectors"])
         return main_text + "\n\n---\n\n⚠️ セクター動向の取得に失敗しました。\n" + errors["sectors"]
 
     assert "sectors" in results, "sectors result missing despite no error recorded"

--- a/apps/python/src/generator/briefing_api.py
+++ b/apps/python/src/generator/briefing_api.py
@@ -130,7 +130,7 @@ def _make_client():
     api_key = get_credential("ANTHROPIC_API_KEY")
     if not api_key:
         raise SystemExit(
-            "ANTHROPIC_API_KEY が未設定です（Keychain か .env に設定してください）"
+            "ANTHROPIC_API_KEY is unset (set it in the Keychain or .env)"
         )
     import anthropic
 
@@ -143,7 +143,7 @@ def run_briefing_api(config: BriefingConfig, client) -> str:
     tickers = join_safe(config.portfolio.tickers, sep=", ")
     themes = join_safe(config.portfolio.themes, sep=", ")
 
-    logger.info("株価取得中...")
+    logger.info("fetching stock moves...")
     moves = fetch_stock_move_map(config.portfolio.tickers)
     stocks = "\n".join(f"- {t}: {m}" for t, m in moves.items()) or "(取得なし)"
 
@@ -175,7 +175,7 @@ def _gen_and_log(client, label: str, prompt: str) -> str:
     text, usage = generate_section(client, system=SYSTEM_PROMPT, prompt=prompt)
     dt_ms = int((datetime.now() - t0).total_seconds() * 1000)
     log_section_usage(label, usage, duration_ms=dt_ms)
-    logger.info("[section] %s 生成完了 (%d 文字)", label, len(text))
+    logger.info("[section] %s generated (%d chars)", label, len(text))
     return text
 
 
@@ -184,12 +184,12 @@ def _require_brave_key() -> str:
 
     key = os.environ.get("BRAVE_API_KEY", "").strip()
     if not key:
-        raise SystemExit("BRAVE_API_KEY が未設定です（.env に設定してください）")
+        raise SystemExit("BRAVE_API_KEY is unset (set it in .env)")
     return key
 
 
 def main(argv: list[str] | None = None) -> int:
-    logger.info("=== Claude API ブリーフィング（検証スパイク）開始 ===")
+    logger.info("=== Claude API briefing (verification spike) start ===")
     config = load_config()
     client = _make_client()  # validates ANTHROPIC_API_KEY
     _require_brave_key()  # fail fast before any fetching
@@ -197,8 +197,8 @@ def main(argv: list[str] | None = None) -> int:
 
     today = date.today().isoformat()
     out_path = write_md_file(BRIEFING_OUTPUT_DIR, f"briefing_api_{today}.md", md)
-    logger.info("保存完了: %s", out_path)
-    logger.info("=== Claude API ブリーフィング終了 ===")
+    logger.info("saved: %s", out_path)
+    logger.info("=== Claude API briefing end ===")
     return 0
 
 

--- a/apps/python/src/generator/prompt.py
+++ b/apps/python/src/generator/prompt.py
@@ -5,11 +5,12 @@ PROMPTS_DIR = Path(__file__).parents[2] / "prompts"
 
 
 def render(template_name: str, **kwargs: str) -> str:
-    """prompts/{template_name}.md を読み込み、$name プレースホルダを埋め込んで返す。
+    """Load prompts/{template_name}.md, fill in $name placeholders, and return it.
 
-    string.Template を使うことで、もし将来 ``render(user_input, ...)`` のように
-    テンプレート側に外部入力が渡る経路が生まれても、``{0.__class__.__init__.__globals__}``
-    のような attribute walk は構文として成立せず、Python レベルの情報漏洩を機構的に遮断する。
+    Using string.Template means that even if a future path passes external input
+    into the template (e.g. ``render(user_input, ...)``), an attribute walk like
+    ``{0.__class__.__init__.__globals__}`` is not valid syntax, structurally
+    blocking Python-level information leakage.
     """
     path = PROMPTS_DIR / f"{template_name}.md"
     template = Template(path.read_text(encoding="utf-8"))

--- a/apps/python/src/generator/weekly_summary.py
+++ b/apps/python/src/generator/weekly_summary.py
@@ -1,4 +1,4 @@
-"""週次ブリーフィングサマリーを生成する。"""
+"""Generate the weekly briefing summary."""
 from datetime import date, timedelta
 
 from src.claude_runner import get_model, run_claude
@@ -11,7 +11,7 @@ logger = get_logger(__name__)
 
 
 def _format_briefings(pages: list[dict]) -> str:
-    """ページリストを Claude プロンプト用テキストにまとめる。
+    """Combine the page list into text for the Claude prompt.
 
     Each page body is wrapped in an untrusted-context block because the
     page text is prior LLM output that may itself have ingested
@@ -25,18 +25,18 @@ def _format_briefings(pages: list[dict]) -> str:
 
 
 def week_label() -> str:
-    """今週の範囲ラベルを返す（例: 2026-04-19〜2026-04-25）。"""
+    """Return this week's range label (e.g. 2026-04-19〜2026-04-25)."""
     today = date.today()
     start = today - timedelta(days=6)
     return f"{start.strftime('%Y-%m-%d')}〜{today.strftime('%Y-%m-%d')}"
 
 
 def generate_weekly_summary(pages: list[dict]) -> str:
-    """過去7日分のページリストから週次サマリーを生成して返す。"""
+    """Generate and return the weekly summary from the last 7 days of pages."""
     if not pages:
-        raise ValueError("週次サマリー生成に必要なページが見つかりませんでした")
+        raise ValueError("no pages found for weekly summary generation")
 
     prompt = render("weekly_summary", briefings=_format_briefings(pages), week_label=week_label())
 
-    logger.info("週次サマリー生成中 (model=%s, 対象ページ数=%d)...", get_model(), len(pages))
+    logger.info("generating weekly summary (model=%s, pages=%d)...", get_model(), len(pages))
     return run_claude(prompt, "週次サマリー生成", TIMEOUT_WEEKLY_SUMMARY)

--- a/apps/python/src/generator/xss_report.py
+++ b/apps/python/src/generator/xss_report.py
@@ -9,7 +9,7 @@ logger = get_logger(__name__)
 
 
 def generate_xss_report(config: XssIntelConfig) -> str:
-    """claude CLI + WebSearch で XSS 脆弱性インテリジェンスレポートを生成"""
+    """Generate the XSS vulnerability intelligence report via claude CLI + WebSearch."""
     frameworks = neutralize_user_text(", ".join(config.targets.frameworks))
     libraries = neutralize_user_text(", ".join(config.targets.libraries))
     keywords = neutralize_user_text(", ".join(config.targets.keywords))
@@ -22,8 +22,8 @@ def generate_xss_report(config: XssIntelConfig) -> str:
         date=date.today().strftime("%Y-%m-%d"),
     )
 
-    logger.debug("対象フレームワーク: %s / ライブラリ: %s", frameworks, libraries)
+    logger.debug("target frameworks: %s / libraries: %s", frameworks, libraries)
 
     text = run_claude(prompt, "XSS Intel", timeout=300)
-    logger.info("XSS レポート生成完了 (%d文字)", len(text))
+    logger.info("XSS report generated (%d chars)", len(text))
     return text

--- a/apps/python/src/handler.py
+++ b/apps/python/src/handler.py
@@ -18,32 +18,32 @@ logger = get_logger(__name__)
 def _preflight() -> None:
     """Log a WARNING for each missing credential before the pipeline starts."""
     if not _is_configured(CONFIG.discord_token, CONFIG.discord_channel_id):
-        logger.warning("DISCORD_TOKEN または CHANNEL_ID が未設定 — Discord 通知をスキップします")
+        logger.warning("DISCORD_TOKEN or CHANNEL_ID unset — skipping Discord notification")
     if not _is_configured(CONFIG.notion_api_key, CONFIG.notion_database_id):
-        logger.warning("NOTION_API_KEY または NOTION_DATABASE_ID が未設定 — Notion 通知をスキップします")
+        logger.warning("NOTION_API_KEY or NOTION_DATABASE_ID unset — skipping Notion notification")
 
 
 def lambda_handler(event=None, context=None, *, dry_run: bool = False):
-    """株価ブリーフィングを生成し Discord/Notion/ローカル MD に配信する Lambda ハンドラ。"""
-    logger.info("=== My World Briefing 開始 ===")
+    """Lambda handler that generates the stock briefing and delivers it to Discord/Notion/local MD."""
+    logger.info("=== My World Briefing start ===")
     _preflight()
 
     if dry_run:
-        logger.info("Dry-run モード — パイプラインをスキップします")
+        logger.info("Dry-run mode — skipping the pipeline")
         return {"statusCode": 200, "body": "dry-run"}
 
-    logger.info("株価取得中...")
+    logger.info("fetching stock moves...")
     stocks = fetch_stock_moves(CONFIG.portfolio.tickers)
 
-    logger.info("ブリーフィング生成中 (WebSearch)...")
+    logger.info("generating briefing (WebSearch)...")
     briefing = generate_briefing(stocks, CONFIG)
 
-    logger.debug("ブリーフィング生成完了 (length=%d)", len(briefing))
+    logger.debug("briefing generated (length=%d)", len(briefing))
 
     discord_ok = _is_configured(CONFIG.discord_token, CONFIG.discord_channel_id)
     notion_ok = _is_configured(CONFIG.notion_api_key, CONFIG.notion_database_id)
 
-    # ローカル MD 出力を先に行う: Discord/Notion で例外が出ても本文をディスクに残せる
+    # Write local MD first: keep the body on disk even if Discord/Notion raise.
     md_written = False
     try:
         save_briefing_md(
@@ -54,14 +54,14 @@ def lambda_handler(event=None, context=None, *, dry_run: bool = False):
         )
         md_written = True
     except OSError as exc:
-        logger.warning("ローカル MD 出力失敗: %s — 継続します", exc)
+        logger.warning("local MD write failed: %s — continuing", exc)
 
     if discord_ok:
-        logger.info("Discord に送信中...")
+        logger.info("sending to Discord...")
         send_to_discord(briefing, CONFIG.discord_token, CONFIG.discord_channel_id)
 
     if notion_ok:
-        logger.info("Notion にページ作成中...")
+        logger.info("creating Notion page...")
         model = get_model()
         notion_text = briefing + f"\n\n---\nModel: {model}"
         metrics = extract_briefing_metrics(briefing, CONFIG.portfolio.tickers)
@@ -76,7 +76,7 @@ def lambda_handler(event=None, context=None, *, dry_run: bool = False):
         if page_url:
             logger.info("Notion ページ: %s", page_url)
 
-    logger.info("=== 完了 ===")
+    logger.info("=== done ===")
     return {"statusCode": 200, "body": "Briefing sent.", "md_written": md_written}
 
 

--- a/apps/python/src/local_llm/articles.py
+++ b/apps/python/src/local_llm/articles.py
@@ -142,7 +142,7 @@ def enrich_with_article_text(
         },
     )
     attempted, fetched = count_article_fetches(enriched, per_macro=per_macro, per_group=per_group)
-    logger.info("[articles] 本文取得 %d/%d 件成功", fetched, attempted)
+    logger.info("[articles] fetched bodies for %d/%d", fetched, attempted)
     return enriched
 
 

--- a/apps/python/src/local_llm/briefing/generate.py
+++ b/apps/python/src/local_llm/briefing/generate.py
@@ -54,27 +54,27 @@ def generate_local_briefing(
     num_ctx = (options or {}).get("num_ctx")
     if num_ctx and est_tokens > num_ctx:
         logger.warning(
-            "[briefing] プロンプト概算 %d tokens (%d 文字) が num_ctx=%d を超過 — "
-            "末尾が切り捨てられる可能性",
+            "[briefing] prompt est. %d tokens (%d chars) exceeds num_ctx=%d — "
+            "the tail may be truncated",
             est_tokens,
             total_chars,
             num_ctx,
         )
     else:
         logger.info(
-            "[briefing] プロンプト概算 %d tokens (%d 文字) / num_ctx=%s",
+            "[briefing] prompt est. %d tokens (%d chars) / num_ctx=%s",
             est_tokens,
             total_chars,
-            num_ctx if num_ctx else "(Ollama 既定)",
+            num_ctx if num_ctx else "(Ollama default)",
         )
 
-    logger.info("[briefing] ollama.chat — 単発生成 (tools 不使用)")
+    logger.info("[briefing] ollama.chat — single-shot generation (no tools)")
     resp = ollama_client.chat(model=model, messages=messages, options=options)
     msg = _msg_field(resp, "message")
     if msg is None:
         msg = resp
     content = _msg_field(msg, "content", "") or ""
-    logger.info("[briefing] 生成完了 (%d 文字)", len(content))
+    logger.info("[briefing] generation done (%d chars)", len(content))
 
     if content:
         print(content, flush=True)

--- a/apps/python/src/local_llm/briefing/prefetch.py
+++ b/apps/python/src/local_llm/briefing/prefetch.py
@@ -106,11 +106,11 @@ def _safe_search(
         else:
             kept.append(r)
     if n_index:
-        logger.info("[prefetch] %r: 索引ページ %d 件を除外", query, n_index)
+        logger.info("[prefetch] %r: excluded %d index pages", query, n_index)
     if n_malformed:
-        logger.info("[prefetch] %r: 不正URL(スペース含む) %d 件を除外", query, n_malformed)
+        logger.info("[prefetch] %r: excluded %d malformed URLs (with spaces)", query, n_malformed)
     if n_stale:
-        logger.info("[prefetch] %r: 古い記事 %d 件を除外 (>%d 日)", query, n_stale, STALE_ARTICLE_DAYS)
+        logger.info("[prefetch] %r: excluded %d stale articles (>%d days)", query, n_stale, STALE_ARTICLE_DAYS)
     return kept[:count]
 
 

--- a/apps/python/src/local_llm/cli.py
+++ b/apps/python/src/local_llm/cli.py
@@ -179,8 +179,8 @@ def _cmd_ask(cfg, question: str) -> int:
 
 
 def _make_briefing_ollama(cfg):
-    """Ollama クライアントを生成モデル用に初期化して返す。失敗時は OllamaUnavailable を送出。"""
-    logger.info("Ollama 接続確認中...")
+    """Initialize and return the Ollama client for the generation model. Raises OllamaUnavailable on failure."""
+    logger.info("checking Ollama connection...")
     olm = make_ollama_client(cfg)
     # briefing only generates; pass None so an un-pulled embed_model does not block it.
     ensure_models_available(olm, cfg.model, embed_model=None)
@@ -191,20 +191,20 @@ def _make_briefing_ollama(cfg):
 
 
 def _prefetch_and_enrich(briefing_cfg, search_client, today: str):
-    """Brave Search pre-fetch + 記事本文取得を行い (ctx, article_summary) を返す。"""
+    """Run the Brave Search pre-fetch + article body fetch and return (ctx, article_summary)."""
     logger.info(
-        "Brave Search pre-fetch 開始 — 銘柄 %d 件 + マクロ + 地政学",
+        "Brave Search pre-fetch start — %d tickers + macro + geopolitics",
         len(briefing_cfg.portfolio.tickers),
     )
     ctx = prefetch_briefing_context(briefing_cfg, search_client=search_client, today=today)
-    logger.info("Brave Search pre-fetch 完了 — 上位ヒットの記事本文を取得")
+    logger.info("Brave Search pre-fetch done — fetching article bodies of top hits")
     # The model cannot write concrete facts from snippets alone, so extract the
     # bodies of the top hits and inject them into the prompt (#151). Failures
     # fall back to the snippet.
     ctx = enrich_with_article_text(ctx)
     attempted, fetched = count_article_fetches(ctx)
     article_summary = f"{fetched}/{attempted} 件取得 (上位ヒットのみ・失敗はスニペットで代替)"
-    logger.info("記事本文取得完了 — プロンプトに注入")
+    logger.info("article bodies fetched — injecting into the prompt")
     return ctx, article_summary
 
 
@@ -217,8 +217,8 @@ def _generate_section(
     system_prompt: str,
     gen_options: dict,
 ) -> str:
-    """1セクションを生成して返す。中国語を検出した場合は1回だけ再生成する。"""
-    logger.info("[section] %s 生成開始 (model=%s)", label, model)
+    """Generate and return one section. If Chinese is detected, regenerate once."""
+    logger.info("[section] %s generation start (model=%s)", label, model)
     out = ""
     for attempt in range(2):
         out = generate_local_briefing(
@@ -231,13 +231,13 @@ def _generate_section(
         if not has_simplified_chinese_text(out):
             break
         if attempt == 0:
-            logger.warning("[section] %s に中国語を検出 — 再生成します", label)
-    logger.info("[section] %s 生成完了 (%d 文字)", label, len(out))
+            logger.warning("[section] %s contains Chinese — regenerating", label)
+    logger.info("[section] %s generated (%d chars)", label, len(out))
     return out
 
 
 def _generate_all_sections(cfg, briefing_cfg, ctx, moves, olm, system_prompt: str, today: str) -> str:
-    """Five-stage section-split generation を実行して結合した body を返す。
+    """Run the five-stage section-split generation and return the joined body.
 
     Five-stage section-split generation (top news / sector / geopolitics /
     holdings table / insight). Writing every section in a single chat() scatters
@@ -254,21 +254,21 @@ def _generate_all_sections(cfg, briefing_cfg, ctx, moves, olm, system_prompt: st
             system_prompt=system_prompt, gen_options=gen_options,
         )
 
-    body_top = _gen("トップニュース", build_section_topnews_prompt(briefing_cfg, ctx=ctx, today=today))
+    body_top = _gen("top news", build_section_topnews_prompt(briefing_cfg, ctx=ctx, today=today))
     # The world → sector → ticker narrative's middle layer. Extract the affected
     # sectors from the top-news body and connect them to the holdings (#162).
-    body_sector = _gen("セクター影響", build_section_sector_prompt(briefing_cfg, prior_text=body_top, today=today))
+    body_sector = _gen("sector impact", build_section_sector_prompt(briefing_cfg, prior_text=body_top, today=today))
     # The holdings table uses per-ticker structured output (#152). The model only
     # writes {topic, source_index} JSON; URLs, price moves, and table assembly are
     # done on the Python side.
-    logger.info("[section] 保有銘柄テーブル 構造化生成開始")
+    logger.info("[section] holdings table structured generation start")
     body_port = generate_portfolio_table(
         briefing_cfg.portfolio.tickers,
         ctx=ctx, moves=moves, ollama_client=olm,
         model=cfg.model, options=gen_options, today=today,
     )
-    logger.info("[section] 保有銘柄テーブル 生成完了 (%d 文字)", len(body_port))
-    body_geo = _gen("地政学+イベント", build_section_geo_events_prompt(briefing_cfg, ctx=ctx, today=today))
+    logger.info("[section] holdings table generated (%d chars)", len(body_port))
+    body_geo = _gen("geopolitics+events", build_section_geo_events_prompt(briefing_cfg, ctx=ctx, today=today))
     # Safety net so that even if the model silently omits an investment-relevant
     # topic (e.g. Middle East = oil), the configured topic's heading and sources
     # are always preserved on the Python side (#175).
@@ -279,7 +279,7 @@ def _generate_all_sections(cfg, briefing_cfg, ctx, moves, olm, system_prompt: st
     # Final synthesis stage — route to the (possibly stronger) reasoning model
     # while the cheaper main model handled the extraction/summary stages (#171).
     body_insight = _gen(
-        "自分への示唆",
+        "insight",
         build_section_insight_prompt(briefing_cfg, prior_text=prior_text, today=today),
         model=cfg.synthesis_model,
     )
@@ -291,11 +291,11 @@ def _generate_all_sections(cfg, briefing_cfg, ctx, moves, olm, system_prompt: st
 
 
 def _post_briefing_to_notion(md: str, briefing_cfg, today: str) -> bool:
-    """Notion へブリーフィングを投稿する。成功時 True、失敗時 False を返す。"""
+    """Post the briefing to Notion. Return True on success, False on failure."""
     if not (briefing_cfg.notion_api_key and briefing_cfg.notion_database_id):
-        logger.error("--notion 指定だが NOTION_API_KEY / NOTION_DATABASE_ID が未設定")
+        logger.error("--notion given but NOTION_API_KEY / NOTION_DATABASE_ID unset")
         return False
-    logger.info("Notion へ投稿中...")
+    logger.info("posting to Notion...")
     url = send_to_notion(
         md,
         briefing_cfg.notion_api_key,
@@ -304,15 +304,15 @@ def _post_briefing_to_notion(md: str, briefing_cfg, today: str) -> bool:
         tags=["agent", "local"],
     )
     if url:
-        logger.info("Notion 投稿完了: %s", url)
+        logger.info("Notion post done: %s", url)
         return True
-    logger.error("Notion 投稿に失敗しました")
+    logger.error("Notion post failed")
     return False
 
 
 def _cmd_briefing(cfg, *, post_to_notion: bool) -> int:
     logger.info(
-        "=== ローカル LLM ブリーフィング開始 (model=%s, synthesis_model=%s) ===",
+        "=== local LLM briefing start (model=%s, synthesis_model=%s) ===",
         cfg.model,
         cfg.synthesis_model,
     )
@@ -320,21 +320,21 @@ def _cmd_briefing(cfg, *, post_to_notion: bool) -> int:
     brave_api_key = os.environ.get("BRAVE_API_KEY", "").strip()
     if not brave_api_key:
         logger.error(
-            "BRAVE_API_KEY が未設定です — `.env` に BRAVE_API_KEY=... を追加してください "
-            "(https://api-dashboard.search.brave.com/ で Free プラン取得)"
+            "BRAVE_API_KEY is unset — add BRAVE_API_KEY=... to `.env` "
+            "(get a Free plan at https://api-dashboard.search.brave.com/)"
         )
         return 1
 
     try:
         olm = _make_briefing_ollama(cfg)
     except OllamaUnavailable as e:
-        logger.error("Ollama に接続できません: %s", e)
+        logger.error("cannot connect to Ollama: %s", e)
         return 1
 
-    logger.info("briefing.json 読み込み中...")
+    logger.info("loading briefing.json...")
     briefing_cfg = load_briefing_config()
 
-    logger.info("株価取得中 (tickers=%s)...", ", ".join(briefing_cfg.portfolio.tickers))
+    logger.info("fetching stock moves (tickers=%s)...", ", ".join(briefing_cfg.portfolio.tickers))
     moves = fetch_stock_move_map(briefing_cfg.portfolio.tickers)
 
     today = date.today().isoformat()  # YYYY-MM-DD — shared by both the filename and the prompt
@@ -346,13 +346,13 @@ def _cmd_briefing(cfg, *, post_to_notion: bool) -> int:
     validation = validate_urls(body, ctx)
     if validation.fabricated > 0:
         logger.warning(
-            "[briefing] URL 捏造検出: %d/%d 件を <URL未検証> に置換しました",
+            "[briefing] URL fabrication detected: replaced %d/%d with <URL unverified>",
             validation.fabricated,
             validation.total,
         )
     else:
         logger.info(
-            "[briefing] URL 検証 OK: %d/%d 件が pre-fetch 由来",
+            "[briefing] URL validation OK: %d/%d came from pre-fetch",
             validation.verified,
             validation.total,
         )
@@ -369,10 +369,10 @@ def _cmd_briefing(cfg, *, post_to_notion: bool) -> int:
     BRIEFING_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     out_path = BRIEFING_OUTPUT_DIR / f"local_{today}.md"
     out_path.write_text(md, encoding="utf-8")
-    logger.info("ブリーフィング保存完了: %s", out_path)
+    logger.info("briefing saved: %s", out_path)
 
     if post_to_notion and not _post_briefing_to_notion(md, briefing_cfg, today):
         return 1
 
-    logger.info("=== ローカル LLM ブリーフィング終了 ===")
+    logger.info("=== local LLM briefing end ===")
     return 0

--- a/apps/python/src/local_llm/config.py
+++ b/apps/python/src/local_llm/config.py
@@ -89,7 +89,7 @@ def _env_number(name: str, default, cast):
         return cast(raw)
     except ValueError:
         logger.warning(
-            "env %s=%r を %s に変換できないため既定値 %r を使用",
+            "env %s=%r could not be converted to %s, using default %r",
             name,
             raw,
             cast.__name__,

--- a/apps/python/src/local_llm/portfolio.py
+++ b/apps/python/src/local_llm/portfolio.py
@@ -120,10 +120,10 @@ def _generate_row(
     try:
         data = json.loads(content)
     except (json.JSONDecodeError, TypeError) as e:
-        logger.warning("[portfolio] %s: JSON 解析失敗: %s (raw=%r)", ticker, e, content[:200])
+        logger.warning("[portfolio] %s: JSON parse failed: %s (raw=%r)", ticker, e, content[:200])
         return GENERATION_ERROR_TOPIC, None
     if not isinstance(data, dict):
-        logger.warning("[portfolio] %s: JSON が object でない: %r", ticker, content[:200])
+        logger.warning("[portfolio] %s: JSON is not an object: %r", ticker, content[:200])
         return GENERATION_ERROR_TOPIC, None
 
     topic = str(data.get("topic") or "").strip() or NO_NEWS_TOPIC
@@ -131,7 +131,7 @@ def _generate_row(
     if not isinstance(idx, int) or isinstance(idx, bool) or not (1 <= idx <= len(hits)):
         if idx is not None:
             logger.warning(
-                "[portfolio] %s: source_index=%r が範囲外 (hits=%d) — 出典なし扱い",
+                "[portfolio] %s: source_index=%r out of range (hits=%d) — treating as no source",
                 ticker,
                 idx,
                 len(hits),
@@ -171,7 +171,7 @@ def generate_portfolio_table(
             topic: str = NO_NEWS_TOPIC
             idx: int | None = None
         else:
-            logger.info("[portfolio] %s: 行生成 (hits=%d)", ticker, len(hits))
+            logger.info("[portfolio] %s: generating row (hits=%d)", ticker, len(hits))
             topic, idx = _generate_row(
                 ticker,
                 hits,

--- a/apps/python/src/metrics/briefing.py
+++ b/apps/python/src/metrics/briefing.py
@@ -1,13 +1,13 @@
-"""ブリーフィングテキストから Notion 数値プロパティ用のメトリクスを抽出する。"""
+"""Extract metrics for Notion number properties from the briefing text."""
 import re
 
 
 def extract_briefing_metrics(text: str, tickers: list[str]) -> dict:
-    """文字数・言及銘柄数を Notion extra_properties 形式で返す。
+    """Return character count and mentioned-ticker count in Notion extra_properties form.
 
-    ティッカーは ASCII 英数字・アンダースコアの lookaround で照合する。
-    \b では日本語助詞に直接隣接するケース（例: "PLTRは上昇"）を検出できないため、
-    (?<![A-Za-z0-9_])TICKER(?![A-Za-z0-9_]) を使用する。
+    Tickers are matched with ASCII alphanumeric/underscore lookarounds. ``\\b``
+    cannot detect cases directly adjacent to a Japanese particle (e.g. "PLTRは上昇"),
+    so (?<![A-Za-z0-9_])TICKER(?![A-Za-z0-9_]) is used instead.
 
     Returns:
         {"CharCount": {"number": N}, "TickerCount": {"number": M}}

--- a/apps/python/src/metrics/xss.py
+++ b/apps/python/src/metrics/xss.py
@@ -1,12 +1,12 @@
-"""XSS レポートテキストから Notion 数値プロパティ用のメトリクスを抽出する。"""
+"""Extract metrics for Notion number properties from the XSS report text."""
 import re
 
 
 def extract_xss_metrics(text: str) -> dict:
-    """重要度別（High/Medium/Low）の件数を Notion extra_properties 形式で返す。
+    """Return counts by severity (High/Medium/Low) in Notion extra_properties form.
 
-    プロンプト出力の構造化行 「深刻度: <level>」 のみをカウントし、
-    散文中の high/low といった一般語による誤カウントを防ぐ。
+    Only counts the structured ``深刻度: <level>`` lines from the prompt output,
+    preventing miscounts from generic words like "high"/"low" in prose.
 
     Returns:
         {"HighCount": {"number": N}, "MediumCount": {"number": M}, "LowCount": {"number": L}}

--- a/apps/python/src/notifier/discord.py
+++ b/apps/python/src/notifier/discord.py
@@ -6,7 +6,7 @@ logger = get_logger(__name__)
 
 
 def _wrap_tables_in_codeblock(text: str) -> str:
-    """Markdown テーブルブロックをコードブロックで囲み、Discord で等幅表示にする。"""
+    """Wrap Markdown table blocks in a code block so Discord renders them monospaced."""
     lines = text.splitlines(keepends=True)
     result = []
     i = 0
@@ -32,8 +32,9 @@ def _wrap_tables_in_codeblock(text: str) -> str:
 
 
 def _chunk_preserving_fences(text: str, chunk_size: int = 1900) -> list[str]:
-    """テキストを chunk_size 以内に分割する。コードフェンス（```）をまたぐ場合は
-    チャンク末尾でフェンスを閉じ、次チャンク先頭で再開することでバランスを保つ。"""
+    """Split text into chunks <= chunk_size. When a chunk would split across a code
+    fence (```), close the fence at the chunk end and reopen it at the next chunk
+    start to keep them balanced."""
     chunks: list[str] = []
     current_lines: list[str] = []
     current_len = 0
@@ -41,21 +42,21 @@ def _chunk_preserving_fences(text: str, chunk_size: int = 1900) -> list[str]:
     fence_opener = "```"
 
     for line in text.splitlines(keepends=True):
-        # フェンス状態の更新より先に overflow を判定する（閉じフェンス行自体が
-        # 境界を超えるケースで、まだ開いている状態のまま flush できるように）
+        # Check overflow before updating fence state (so that when a closing-fence
+        # line itself crosses the boundary, we can flush while still "open").
         if current_len + len(line) > chunk_size and current_lines:
             chunk = "".join(current_lines)
             if in_fence:
-                chunk += "```\n"   # 開いているフェンスを閉じる
+                chunk += "```\n"   # close the open fence
             chunks.append(chunk)
             current_lines = []
             current_len = 0
             if in_fence:
                 reopen = fence_opener + "\n"
-                current_lines = [reopen]  # 元の言語指定を保ってフェンスを再開
+                current_lines = [reopen]  # reopen the fence, preserving its language tag
                 current_len = len(reopen)
 
-        # 言語指定（```python 等）も含めてフェンス開閉を追跡する
+        # Track fence open/close including the language tag (e.g. ```python)
         stripped = line.rstrip()
         if in_fence:
             if stripped == "```":
@@ -74,9 +75,9 @@ def _chunk_preserving_fences(text: str, chunk_size: int = 1900) -> list[str]:
 
 
 def send_to_discord(text: str, token: str, channel_id: str):
-    """Discord Bot API でチャンネルにメッセージ送信（2000文字制限を考慮して分割）"""
+    """Send a message to a channel via the Discord Bot API (chunked for the 2000-char limit)."""
     if not token or not channel_id:
-        logger.error("DISCORD_TOKEN または CHANNEL_ID が未設定")
+        logger.error("DISCORD_TOKEN or CHANNEL_ID unset")
         return
     url = f"https://discord.com/api/v10/channels/{channel_id}/messages"
     headers = {"Authorization": f"Bot {token}"}
@@ -85,5 +86,5 @@ def send_to_discord(text: str, token: str, channel_id: str):
     for i, chunk in enumerate(chunks, 1):
         res = requests.post(url, headers=headers, json={"content": chunk})
         res.raise_for_status()
-        logger.debug("Discord 送信完了 (chunk %d/%d)", i, len(chunks))
-    logger.info("Discord 送信完了 (合計%dチャンク)", len(chunks))
+        logger.debug("Discord send done (chunk %d/%d)", i, len(chunks))
+    logger.info("Discord send done (%d chunks total)", len(chunks))

--- a/apps/python/src/notifier/local_md.py
+++ b/apps/python/src/notifier/local_md.py
@@ -17,36 +17,36 @@ def save_briefing_md(
     *,
     rotation_enabled: bool = True,
 ) -> Path:
-    """ブリーフィング本文を briefing_YYYY-MM-DD.md として書き込む。
+    """Write the briefing body as briefing_YYYY-MM-DD.md.
 
-    rotation_enabled=True のとき output_dir 内の同パターンファイルを
-    新しい順に retention_days 件残して削除する。
-    rotation_enabled=False のとき削除は行わず全ファイルを無制限に保持する。
+    When rotation_enabled=True, keep the newest retention_days files matching the
+    same pattern in output_dir and delete the rest.
+    When rotation_enabled=False, delete nothing and retain all files unbounded.
     """
     if retention_days < 1:
         raise ValueError(
-            f"retention_days は 1 以上である必要があります (got {retention_days})"
+            f"retention_days must be >= 1 (got {retention_days})"
         )
 
     today = today or date.today()
     output_dir.mkdir(parents=True, exist_ok=True)
     path = output_dir / f"briefing_{today.strftime('%Y-%m-%d')}.md"
     path.write_text(text, encoding="utf-8")
-    logger.info("ローカル MD 出力: %s (%d文字)", path, len(text))
+    logger.info("local MD written: %s (%d chars)", path, len(text))
 
     if rotation_enabled:
         _prune_old(output_dir, retention_days)
     else:
-        logger.debug("ローテーション無効 — 古い MD は削除しません")
+        logger.debug("rotation disabled — not deleting old MD files")
     return path
 
 
 def write_md_file(output_dir: Path, filename: str, text: str) -> Path:
-    """output_dir/filename にテキストを書き込む。ディレクトリがなければ作成する。"""
+    """Write text to output_dir/filename, creating the directory if needed."""
     output_dir.mkdir(parents=True, exist_ok=True)
     path = output_dir / filename
     path.write_text(text, encoding="utf-8")
-    logger.info("MD 出力: %s (%d文字)", path, len(text))
+    logger.info("MD written: %s (%d chars)", path, len(text))
     return path
 
 
@@ -59,6 +59,6 @@ def _prune_old(output_dir: Path, retention_days: int) -> None:
     for stale in matched[retention_days:]:
         try:
             stale.unlink()
-            logger.info("古い MD を削除: %s", stale.name)
+            logger.info("deleted old MD: %s", stale.name)
         except FileNotFoundError:
             pass

--- a/apps/python/src/notifier/markdown.py
+++ b/apps/python/src/notifier/markdown.py
@@ -13,9 +13,10 @@ from src.constants import (
 
 
 def _parse_inline(text: str) -> list[dict]:
-    """1行のインラインマークダウンを Notion rich_text オブジェクトのリストに変換。
-    対応: **bold**, [label](url), それ以外はプレーンテキスト。
-    2000文字制限を超えないようにチャンク分割も行う。
+    """Convert one line of inline markdown to a list of Notion rich_text objects.
+
+    Supports: **bold**, [label](url); everything else is plain text. Also chunks
+    the text so it never exceeds the 2000-character limit.
     """
     rich_texts: list[dict] = []
     pos = 0
@@ -38,7 +39,7 @@ def _parse_inline(text: str) -> list[dict]:
 
 
 def _plain_chunks(text: str, bold: bool = False) -> list[dict]:
-    """2000文字ごとに分割したプレーンテキスト rich_text を返す。"""
+    """Return plain-text rich_text chunked every 2000 characters."""
     result = []
     for i in range(0, max(len(text), 1), NOTION_CHAR_LIMIT):
         chunk = text[i:i + NOTION_CHAR_LIMIT]
@@ -50,7 +51,7 @@ def _plain_chunks(text: str, bold: bool = False) -> list[dict]:
 
 
 def _link_chunks(label: str, url: str) -> list[dict]:
-    """リンク付き rich_text を返す。ラベルが 2000文字を超える場合はチャンク分割する。"""
+    """Return linked rich_text, chunking when the label exceeds 2000 characters."""
     result = []
     for i in range(0, max(len(label), 1), NOTION_CHAR_LIMIT):
         chunk = label[i:i + NOTION_CHAR_LIMIT]
@@ -63,7 +64,7 @@ def _link_chunks(label: str, url: str) -> list[dict]:
 
 
 def _list_block(block_type: str, text: str) -> dict:
-    """numbered_list_item / bulleted_list_item ブロックを生成する共通ファクトリ。"""
+    """Shared factory that builds numbered_list_item / bulleted_list_item blocks."""
     return {
         "object": "block",
         "type": block_type,
@@ -72,7 +73,7 @@ def _list_block(block_type: str, text: str) -> dict:
 
 
 def _line_to_block(line: str) -> dict | None:
-    """1行を Notion ブロック辞書に変換。空行・区切り線・見出し・リスト・段落を処理する。"""
+    """Convert one line to a Notion block dict. Handles blanks, dividers, headings, lists, paragraphs."""
     stripped = line.rstrip()
 
     if not stripped:
@@ -131,7 +132,7 @@ def _is_table_separator(line: str) -> bool:
 
 
 def _table_rows_to_block(rows: list[str]) -> dict:
-    """連続する Markdown テーブル行を Notion table ブロックに変換する。"""
+    """Convert consecutive Markdown table rows into a Notion table block."""
     data_rows = [r for r in rows if not _is_table_separator(r)]
     has_header = len(rows) >= 2 and _is_table_separator(rows[1])
 
@@ -164,11 +165,11 @@ def _table_rows_to_block(rows: list[str]) -> dict:
 
 
 def _split_label_colon(line: str) -> list[str]:
-    """「ラベル：内容」形式の行を2行に分割して返す。該当しない場合はそのまま返す。
+    """Split a "label：content" line into two lines. Return unchanged if it does not match.
 
-    例: "- **AI・クラウド：**強い。..." → ["**AI・クラウド：**", "強い。..."]
-    - 箇条書きプレフィックス（- / *）は除去する
-    - 既存の ** マーカーは除去してから付け直す（二重 ** 防止）
+    Example: "- **AI・クラウド：**強い。..." → ["**AI・クラウド：**", "強い。..."]
+    - Strip the list prefix (- / *).
+    - Strip existing ** markers before re-adding them (prevents double **).
     """
     m = NOTION_LABEL_COLON_RE.match(line.rstrip())
     if not m:
@@ -181,11 +182,13 @@ def _split_label_colon(line: str) -> list[str]:
 
 
 def markdown_to_notion_blocks(markdown: str) -> list[dict]:
-    """Markdown 文字列を Notion ブロック辞書のリストに変換して返す。
+    """Convert a Markdown string into a list of Notion block dicts.
 
-    - Markdown テーブルは Notion table ブロックに変換する。
-    - インデント付き箇条書き（2スペース/タブ + - や 1.）は直前のリストブロックの children に追加する。
-    - 「ラベル：内容」行はラベルと内容を別ブロックに分割する（テーブル・インデント行は除く）。
+    - Markdown tables become Notion table blocks.
+    - Indented list items (2 spaces/tab + - or 1.) are appended to the children
+      of the preceding list block.
+    - "label：content" lines are split into separate label/content blocks
+      (excluding table and indented lines).
     """
     markdown = re.sub(r"\*{4,}", "**", markdown)
     blocks: list[dict] = []

--- a/apps/python/src/notifier/notion.py
+++ b/apps/python/src/notifier/notion.py
@@ -11,16 +11,16 @@ logger = get_logger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# ヘルパー
+# Helpers
 # ---------------------------------------------------------------------------
 
 def _utcnow() -> datetime:
-    """テストでモック可能な UTC 現在時刻を返す。"""
+    """Return the current UTC time (mockable in tests)."""
     return datetime.now(timezone.utc)
 
 
 def _resolve_title_prop(notion: Client, database_id: str, sample_title: str) -> str | None:
-    """タイトルプロパティのキー名を試行して特定する。成功したキー名を返し、全て失敗した場合は None を返す。"""
+    """Identify the title property key by trial. Return the working key, or None if all fail."""
     for candidate in ("Name", "title"):
         try:
             page = notion.pages.create(
@@ -28,7 +28,7 @@ def _resolve_title_prop(notion: Client, database_id: str, sample_title: str) -> 
                 properties={candidate: {"title": [{"type": "text", "text": {"content": sample_title}}]}},
             )
             notion.pages.update(page["id"], archived=True)
-            logger.debug("タイトルプロパティキー確定: %r", candidate)
+            logger.debug("title property key determined: %r", candidate)
             return candidate
         except Exception:
             continue
@@ -36,7 +36,7 @@ def _resolve_title_prop(notion: Client, database_id: str, sample_title: str) -> 
 
 
 # ---------------------------------------------------------------------------
-# 公開 API
+# Public API
 # ---------------------------------------------------------------------------
 
 def send_to_notion(
@@ -47,16 +47,16 @@ def send_to_notion(
     tags: list[str] | None = None,
     extra_properties: dict | None = None,
 ) -> str:
-    """Notion データベースに新規ページとしてレポートを投稿する。作成したページの URL を返す。"""
+    """Post the report as a new page in the Notion database. Return the created page URL."""
     if not api_key or not database_id:
-        logger.error("NOTION_API_KEY または NOTION_DATABASE_ID が未設定")
+        logger.error("NOTION_API_KEY or NOTION_DATABASE_ID unset")
         return ""
 
     notion = Client(auth=api_key)
     page_title = title or f"Report — {date.today().strftime('%Y-%m-%d')}"
     blocks = markdown_to_notion_blocks(text)
 
-    # databases.retrieve でタイトルプロパティキーを取得。失敗時は名前候補を順に試す。
+    # Get the title property key via databases.retrieve. On failure, try name candidates in order.
     title_prop_name: str | None = None
     try:
         db = notion.databases.retrieve(database_id)
@@ -66,15 +66,15 @@ def send_to_notion(
             None,
         )
     except Exception:
-        logger.exception("Notion データベーススキーマの取得に失敗しました (database_id=%s)", database_id)
+        logger.exception("failed to retrieve Notion database schema (database_id=%s)", database_id)
 
     if title_prop_name is None:
         title_prop_name = _resolve_title_prop(notion, database_id, page_title)
     if title_prop_name is None:
-        logger.error("Notion タイトルプロパティの特定に失敗しました (database_id=%s)", database_id)
+        logger.error("failed to identify the Notion title property (database_id=%s)", database_id)
         return ""
 
-    # Notion API は children を 100 ブロックずつしか受け付けない
+    # The Notion API only accepts children 100 blocks at a time.
     first_batch = blocks[:100]
     remaining = blocks[100:]
 
@@ -95,7 +95,7 @@ def send_to_notion(
             children=first_batch,
         )
     except Exception:
-        logger.exception("Notion ページ作成に失敗しました (database_id=%s, title=%s)", database_id, page_title)
+        logger.exception("failed to create Notion page (database_id=%s, title=%s)", database_id, page_title)
         return ""
 
     page_id = response["id"]
@@ -107,15 +107,15 @@ def send_to_notion(
                 children=remaining[i:i + 100],
             )
         except Exception:
-            logger.exception("Notion ブロック追加に失敗しました (page_id=%s, index=%d)", page_id, i)
+            logger.exception("failed to append Notion blocks (page_id=%s, index=%d)", page_id, i)
 
     page_url = response.get("url", "")
-    logger.info("Notion ページ作成完了: %s", page_url)
+    logger.info("Notion page created: %s", page_url)
     return page_url
 
 
 # ---------------------------------------------------------------------------
-# 週次サマリー用: ページ取得
+# For the weekly summary: page fetching
 # ---------------------------------------------------------------------------
 
 def _rich_text_to_str(rich_texts: list[dict]) -> str:
@@ -123,7 +123,7 @@ def _rich_text_to_str(rich_texts: list[dict]) -> str:
 
 
 def _block_to_text(block: dict) -> str:
-    """Notion ブロック辞書を Markdown 行に変換する。"""
+    """Convert a Notion block dict to a Markdown line."""
     block_type = block.get("type", "")
     content = block.get(block_type, {})
     text = _rich_text_to_str(content.get("rich_text", []))
@@ -144,10 +144,10 @@ def _block_to_text(block: dict) -> str:
 
 
 def _paginate(call, base_kwargs: dict) -> list[dict]:
-    """Notion API のカーソルページネーションを共通化する。
+    """Centralize cursor pagination for the Notion API.
 
-    ``call`` は ``start_cursor`` を含む kwargs を受け取り ``has_more`` / ``next_cursor`` /
-    ``results`` キーを持つレスポンスを返す callable。
+    ``call`` is a callable that takes kwargs including ``start_cursor`` and returns
+    a response with ``has_more`` / ``next_cursor`` / ``results`` keys.
     """
     results: list[dict] = []
     cursor: str | None = None
@@ -164,18 +164,18 @@ def _paginate(call, base_kwargs: dict) -> list[dict]:
 
 
 def _fetch_blocks(notion: Client, block_id: str) -> list[dict]:
-    """指定ブロックの全子ブロックをページネーションして返す。"""
+    """Paginate and return all child blocks of the given block."""
     return _paginate(notion.blocks.children.list, {"block_id": block_id, "page_size": 100})
 
 
 def _fetch_page_text(notion: Client, page_id: str) -> str:
-    """ページ全ブロックをテキストに変換して返す（ページネーション・ネスト対応）。"""
+    """Convert all blocks of a page to text (pagination- and nesting-aware)."""
     def _collect(block_id: str) -> list[str]:
         lines: list[str] = []
         for block in _fetch_blocks(notion, block_id):
             block_type = block.get("type", "")
             if block_type == "table":
-                # テーブル行は子ブロックとして格納されているため個別に取得する
+                # Table rows are stored as child blocks, so fetch them separately.
                 has_header = block.get("table", {}).get("has_column_header", False)
                 col_count = block.get("table", {}).get("table_width", 0)
                 for i, row in enumerate(_fetch_blocks(notion, block["id"])):
@@ -186,7 +186,7 @@ def _fetch_page_text(notion: Client, page_id: str) -> str:
                 line = _block_to_text(block)
                 if line:
                     lines.append(line)
-                # ネストした子ブロック（インデントリストなど）を再帰取得
+                # Recursively fetch nested child blocks (indented lists, etc.)
                 if block.get("has_children") and block_type not in ("table",):
                     lines.extend(_collect(block["id"]))
         return lines
@@ -211,21 +211,21 @@ def _get_page_tags(page: dict) -> list[str]:
 def fetch_weekly_pages(
     api_key: str, database_id: str, days: int = 7, tag: str = "agent"
 ) -> list[dict]:
-    """過去 N 日分の指定タグ付きブリーフィングページを Notion から取得してテキスト化する。
+    """Fetch the last N days of tagged briefing pages from Notion and convert to text.
 
     Args:
-        tag: 取得対象の Tags 値（デフォルト "agent"）。空文字の場合はタグ絞り込みなし。
+        tag: Tags value to filter on (default "agent"). Empty string means no tag filter.
 
     Returns:
-        [{"title": str, "date": str, "text": str}, ...] (作成日昇順)
+        [{"title": str, "date": str, "text": str}, ...] (ascending by created date)
     """
     if not api_key or not database_id:
-        logger.error("NOTION_API_KEY または NOTION_DATABASE_ID が未設定")
+        logger.error("NOTION_API_KEY or NOTION_DATABASE_ID unset")
         return []
 
     notion = Client(auth=api_key)
-    # Notion API 2025-09-03 では databases.query が廃止されたため search を使用。
-    # parent.database_id・created_time・tag は Python 側でフィルタリングする。
+    # databases.query was removed in Notion API 2025-09-03, so use search instead.
+    # parent.database_id, created_time, and tag are filtered on the Python side.
     since_dt = _utcnow() - timedelta(days=days)
     normalized_db_id = database_id.replace("-", "")
 
@@ -236,7 +236,7 @@ def fetch_weekly_pages(
             "page_size": 100,
         })
     except Exception:
-        logger.exception("Notion 検索に失敗しました (database_id=%s)", database_id)
+        logger.exception("Notion search failed (database_id=%s)", database_id)
         return []
 
     filtered = []
@@ -262,16 +262,16 @@ def fetch_weekly_pages(
         try:
             text = _fetch_page_text(notion, page_id)
         except Exception:
-            logger.exception("ページ本文の取得に失敗しました (page_id=%s)", page_id)
+            logger.exception("failed to fetch page body (page_id=%s)", page_id)
             text = ""
         title = _extract_page_title(page)
         created = page.get("created_time", "")[:10]
-        logger.debug("取得済み: %s (%s)", title, created)
+        logger.debug("fetched: %s (%s)", title, created)
         return {"title": title, "date": created, "text": text}
 
     with ThreadPoolExecutor(max_workers=5) as pool:
         pages = list(pool.map(_fetch, filtered))
 
     pages.sort(key=lambda p: p["date"])
-    logger.info("週次ページ取得完了: %d件", len(pages))
+    logger.info("weekly pages fetched: %d", len(pages))
     return pages

--- a/apps/python/src/state.py
+++ b/apps/python/src/state.py
@@ -1,9 +1,9 @@
-"""``~/.ai-agent/state.json`` の読み書き。
+"""Read and write ``~/.ai-agent/state.json``.
 
-ホストごとの非機密ランタイム状態。資格情報は Keychain (``src.credentials``)、
-ユーザー設定 (portfolio 等) は ``apps/python/config/briefing.json``、
-このファイルは「オンボーディング済みか」「auth_mode は cli か api か」
-といった runtime トグル専用。
+Per-host non-sensitive runtime state. Credentials live in the Keychain
+(``src.credentials``) and user settings (portfolio, etc.) in
+``apps/python/config/briefing.json``; this file is only for runtime toggles like
+"has onboarded" and "is auth_mode cli or api".
 """
 import json
 import os

--- a/apps/python/src/usage_logger.py
+++ b/apps/python/src/usage_logger.py
@@ -1,7 +1,8 @@
-"""Claude CLI 呼び出しごとのトークン使用量・コストを JSONL に追記する。
+"""Append per-Claude-CLI-call token usage and cost to a JSONL file.
 
-`src/logger.py` の「日次ファイル + 7 日リテンション」規約に倣う。
-ログ記録の失敗が元のタスクを壊してはならないため、例外は握りつぶす。
+Follows the "daily file + 7-day retention" convention from `src/logger.py`.
+Exceptions are swallowed because a logging failure must never break the
+original task.
 """
 import json
 from datetime import datetime, timedelta
@@ -19,10 +20,10 @@ USAGE_FILE_GLOB = "*-usage.jsonl"
 
 
 def parse_usage_file_date(path: Path):
-    """``YYYYMMDD-usage.jsonl`` のファイル名から日付 (date) を取り出す。
+    """Extract the date from a ``YYYYMMDD-usage.jsonl`` filename.
 
-    ``usage_logger`` と ``bin/usage_report.py`` で共有し、ファイル名規約の
-    ドリフトを防ぐ。解析できなければ ``None`` を返す。
+    Shared by ``usage_logger`` and ``bin/usage_report.py`` to prevent drift in
+    the filename convention. Returns ``None`` if it cannot be parsed.
     """
     try:
         return datetime.strptime(path.stem.replace("-usage", ""), "%Y%m%d").date()
@@ -34,9 +35,9 @@ _last_purge_date = None
 
 
 def _maybe_purge(usage_dir: Path) -> None:
-    """同日内の重複 purge を避けるため、1 日 1 回だけ ``_purge_old_logs`` を呼ぶ。
+    """Call ``_purge_old_logs`` at most once per day to avoid duplicate purges.
 
-    高頻度呼び出し時にディレクトリ全 glob を毎回走らせる無駄を省く。
+    Avoids the waste of globbing the whole directory on every high-frequency call.
     """
     global _last_purge_date
     today = datetime.now().date()
@@ -60,9 +61,10 @@ def _purge_old_logs(usage_dir: Path) -> None:
 
 
 def log_usage(label: str, usage: dict, cost_usd: float | None, duration_ms: int | None) -> None:
-    """1 回の claude 呼び出しの使用量を当日ファイルに 1 行追記する。
+    """Append one line of usage for a single claude call to today's file.
 
-    例外は記録のみで握りつぶす — 使用量ログの失敗で本処理を止めない。
+    Exceptions are logged and swallowed — a usage-log failure must not stop the
+    main task.
     """
     try:
         USAGE_DIR.mkdir(parents=True, exist_ok=True)
@@ -82,5 +84,5 @@ def log_usage(label: str, usage: dict, cost_usd: float | None, duration_ms: int 
         log_file = USAGE_DIR / f"{datetime.now().strftime('%Y%m%d')}-usage.jsonl"
         with log_file.open("a", encoding="utf-8") as f:
             f.write(json.dumps(record, ensure_ascii=False) + "\n")
-    except Exception:  # noqa: BLE001 — 使用量ログの失敗は本処理を止めない
-        logger.warning("使用量ログの記録に失敗しました [%s]", label, exc_info=True)
+    except Exception:  # noqa: BLE001 — a usage-log failure must not stop the main task
+        logger.warning("failed to record usage log [%s]", label, exc_info=True)

--- a/apps/python/src/usage_report.py
+++ b/apps/python/src/usage_report.py
@@ -1,4 +1,4 @@
-"""log/usage/*.jsonl を集計し、label 別・日別のトークン/コスト合計を出力する。"""
+"""Aggregate log/usage/*.jsonl and print token/cost totals per label and per day."""
 import argparse
 import json
 import sys
@@ -34,7 +34,7 @@ def _iter_records(usage_dir: Path, days: int | None):
 
 
 def build_summary(usage_dir: Path, days: int | None) -> dict:
-    """(day, label) ごとにトークン/コスト/呼び出し回数を集計する。"""
+    """Aggregate tokens/cost/call count per (day, label)."""
     summary: dict = defaultdict(lambda: {
         "calls": 0,
         "input_tokens": 0,

--- a/apps/python/src/weekly_handler.py
+++ b/apps/python/src/weekly_handler.py
@@ -1,4 +1,4 @@
-"""週次ブリーフィング振り返りページを Notion に作成するハンドラ。"""
+"""Handler that creates the weekly briefing recap page in Notion."""
 from src.config import CONFIG
 from src.generator.weekly_summary import generate_weekly_summary, week_label
 from src.notifier.notion import fetch_weekly_pages, send_to_notion
@@ -8,10 +8,10 @@ logger = get_logger(__name__)
 
 
 def weekly_handler(event=None, context=None):
-    """過去7日のブリーフィングを集約し、週次振り返りページを Notion に作成する。"""
-    logger.info("=== 週次振り返り 開始 ===")
+    """Aggregate the last 7 days of briefings and create a weekly recap page in Notion."""
+    logger.info("=== weekly recap start ===")
 
-    logger.info("Notion から過去7日のページを取得中...")
+    logger.info("fetching the last 7 days of pages from Notion...")
     pages = fetch_weekly_pages(
         CONFIG.notion_api_key,
         CONFIG.notion_database_id,
@@ -19,14 +19,14 @@ def weekly_handler(event=None, context=None):
     )
 
     if not pages:
-        logger.warning("対象ページが見つかりませんでした。処理を終了します。")
+        logger.warning("no target pages found; exiting.")
         return {"statusCode": 204, "body": "No pages found."}
 
-    logger.info("週次サマリー生成中 (%d ページ)...", len(pages))
+    logger.info("generating weekly summary (%d pages)...", len(pages))
     summary = generate_weekly_summary(pages)
     title = f"週次振り返り — {week_label()}"
 
-    logger.info("Notion にページ作成中...")
+    logger.info("creating Notion page...")
     page_url = send_to_notion(
         summary,
         CONFIG.notion_api_key,
@@ -36,11 +36,11 @@ def weekly_handler(event=None, context=None):
     )
 
     if not page_url:
-        logger.error("Notion へのページ作成に失敗しました")
+        logger.error("failed to create the page in Notion")
         return {"statusCode": 500, "body": "Failed to post weekly summary to Notion."}
 
-    logger.info("Notion ページ: %s", page_url)
-    logger.info("=== 完了 ===")
+    logger.info("Notion page: %s", page_url)
+    logger.info("=== done ===")
     return {"statusCode": 200, "body": f"Weekly summary posted: {page_url}"}
 
 

--- a/apps/python/src/xss_handler.py
+++ b/apps/python/src/xss_handler.py
@@ -23,29 +23,29 @@ def _write_md_fallback(text: str, filename: str) -> Path:
 def _preflight(config) -> None:
     """Log a WARNING for each missing credential before the pipeline starts."""
     if not _is_configured(config.discord_token, config.discord_channel_id):
-        logger.warning("DISCORD_TOKEN または CHANNEL_ID が未設定 — Discord 通知をスキップします")
+        logger.warning("DISCORD_TOKEN or CHANNEL_ID unset — skipping Discord notification")
     if not _is_configured(config.notion_api_key, config.notion_database_id):
-        logger.warning("NOTION_API_KEY または NOTION_DATABASE_ID が未設定 — Notion 通知をスキップします")
+        logger.warning("NOTION_API_KEY or NOTION_DATABASE_ID unset — skipping Notion notification")
 
 
 def lambda_handler(event=None, context=None, *, dry_run: bool = False):
-    """XSS インテリジェンスレポートを生成し Discord/Notion に配信する Lambda ハンドラ。"""
-    logger.info("=== XSS Intel Agent 開始 ===")
+    """Lambda handler that generates the XSS intelligence report and delivers it to Discord/Notion."""
+    logger.info("=== XSS Intel Agent start ===")
     config = get_xss_config()
     _preflight(config)
 
     if dry_run:
-        logger.info("Dry-run モード — パイプラインをスキップします")
+        logger.info("Dry-run mode — skipping the pipeline")
         return {"statusCode": 200, "body": "dry-run"}
     result: dict[str, object] = {}
 
-    logger.info("XSS 脆弱性レポート生成中 (WebSearch)...")
+    logger.info("generating XSS vulnerability report (WebSearch)...")
     try:
         report = generate_xss_report(config)
-        logger.debug("レポート生成完了 (length=%d)", len(report))
+        logger.debug("report generated (length=%d)", len(report))
         result["generation"] = "ok"
     except Exception as e:
-        logger.exception("レポート生成に失敗しました")
+        logger.exception("report generation failed")
         result["generation"] = str(e)
         return {"statusCode": 500, "body": result}
 
@@ -53,19 +53,19 @@ def lambda_handler(event=None, context=None, *, dry_run: bool = False):
     notion_ok = _is_configured(config.notion_api_key, config.notion_database_id)
 
     if discord_ok:
-        logger.info("Discord に送信中...")
+        logger.info("sending to Discord...")
         try:
             send_to_discord(report, config.discord_token, config.discord_channel_id)
             result["discord"] = "ok"
         except Exception as e:
-            logger.exception("Discord 送信に失敗しました")
+            logger.exception("Discord send failed")
             result["discord"] = str(e)
     else:
-        logger.warning("DISCORD_TOKEN または CHANNEL_ID が未設定 — Discord 通知をスキップします")
+        logger.warning("DISCORD_TOKEN or CHANNEL_ID unset — skipping Discord notification")
         result["discord"] = "skipped"
 
     if notion_ok:
-        logger.info("Notion にページ作成中...")
+        logger.info("creating Notion page...")
         try:
             metrics = extract_xss_metrics(report)
             page_url = send_to_notion(
@@ -77,22 +77,22 @@ def lambda_handler(event=None, context=None, *, dry_run: bool = False):
                 extra_properties=metrics,
             )
             if page_url:
-                logger.info("Notion ページ: %s", page_url)
+                logger.info("Notion page: %s", page_url)
             result["notion"] = page_url or "ok"
         except Exception as e:
-            logger.exception("Notion 送信に失敗しました")
+            logger.exception("Notion send failed")
             result["notion"] = str(e)
     else:
-        logger.warning("NOTION_API_KEY または NOTION_DATABASE_ID が未設定 — Notion 通知をスキップします")
+        logger.warning("NOTION_API_KEY or NOTION_DATABASE_ID unset — skipping Notion notification")
         result["notion"] = "skipped"
 
     if not discord_ok or not notion_ok:
         filename = f"xss_intel_{date.today().strftime('%Y-%m-%d')}.md"
         path = _write_md_fallback(report, filename)
-        logger.info("MD ファイルに出力しました: %s", path)
+        logger.info("wrote MD file: %s", path)
         result["md_fallback"] = str(path)
 
-    logger.info("=== 完了 ===")
+    logger.info("=== done ===")
 
     notifier_values = [result.get("discord", "ok"), result.get("notion", "ok")]
     all_notifiers_failed = all(v not in ("ok", "skipped") and v is not None for v in notifier_values)

--- a/apps/python/tests/local_llm/test_briefing.py
+++ b/apps/python/tests/local_llm/test_briefing.py
@@ -775,7 +775,7 @@ def test_generate_local_briefing_defaults_to_no_options(caplog):
     assert olm.calls[0]["options"] is None
     # num_ctx 不明時は警告ではなく info で「Ollama 既定」と記録する
     assert not any(r.levelname == "WARNING" for r in caplog.records)
-    assert any("(Ollama 既定)" in r.getMessage() for r in caplog.records)
+    assert any("(Ollama default)" in r.getMessage() for r in caplog.records)
 
 
 def test_generate_local_briefing_warns_when_prompt_exceeds_num_ctx(caplog):
@@ -1139,7 +1139,7 @@ def test_cmd_briefing_strips_fabricated_urls_from_output(monkeypatch, tmp_path, 
     assert "<URL未検証>" in content
     # caveat にも捏造件数が出ている
     assert "捏造 1 件" in content
-    assert any("URL 捏造検出" in r.message for r in caplog.records)
+    assert any("URL fabrication detected" in r.message for r in caplog.records)
 
 
 def test_cmd_briefing_posts_to_notion_when_flag(monkeypatch, tmp_path):
@@ -1195,7 +1195,7 @@ def test_cmd_briefing_regens_on_chinese_output(monkeypatch, tmp_path, caplog):
     content = list(fake.output_dir.glob("local_*.md"))[0].read_text()
     assert "什么变了" not in content
     assert "S&P 500 が過去最高値" in content
-    assert any("中国語" in r.message for r in caplog.records)
+    assert any("contains Chinese" in r.message for r in caplog.records)
 
 
 def test_cmd_briefing_without_brave_api_key_fails_fast(monkeypatch, tmp_path, caplog):

--- a/apps/python/tests/local_llm/test_portfolio.py
+++ b/apps/python/tests/local_llm/test_portfolio.py
@@ -150,7 +150,7 @@ def test_generate_portfolio_table_out_of_range_index_means_no_source(caplog):
         )
 
     assert "| PLTR | ↑1.0% | 話題 | - |" in table
-    assert any("範囲外" in r.message for r in caplog.records)
+    assert any("out of range" in r.message for r in caplog.records)
 
 
 def test_generate_portfolio_table_null_index_means_no_source():
@@ -182,7 +182,7 @@ def test_generate_portfolio_table_invalid_json_falls_back(caplog):
         )
 
     assert f"| PLTR | ↑1.0% | {GENERATION_ERROR_TOPIC} | - |" in table
-    assert any("JSON 解析失敗" in r.message for r in caplog.records)
+    assert any("JSON parse failed" in r.message for r in caplog.records)
 
 
 def test_generate_portfolio_table_sanitizes_pipes_in_topic_and_title():

--- a/apps/python/tests/test_claude_runner.py
+++ b/apps/python/tests/test_claude_runner.py
@@ -27,7 +27,7 @@ def _make_result(returncode=0, stdout="output", stderr=""):
 class TestRunClaude:
     def test_cli_not_found_raises(self):
         with patch("src.claude_runner.shutil.which", return_value=None):
-            with pytest.raises(RuntimeError, match="claude CLI が見つかりません"):
+            with pytest.raises(RuntimeError, match="claude CLI not found"):
                 run_claude("prompt", "test")
 
     def test_success_returns_stripped_stdout(self):
@@ -42,7 +42,7 @@ class TestRunClaude:
                 "src.claude_runner.subprocess.run",
                 side_effect=subprocess.TimeoutExpired("claude", 300),
             ):
-                with pytest.raises(RuntimeError, match="タイムアウト"):
+                with pytest.raises(RuntimeError, match="timed out"):
                     run_claude("prompt", "test", timeout=300)
 
     def test_nonzero_returncode_raises_with_stderr(self):
@@ -362,7 +362,7 @@ class TestRunClaudeRetry:
                 "src.claude_runner.subprocess.run",
                 side_effect=subprocess.TimeoutExpired("claude", 300),
             ) as mock_run:
-                with pytest.raises(RuntimeError, match="タイムアウト"):
+                with pytest.raises(RuntimeError, match="timed out"):
                     run_claude("prompt", "test", timeout=300)
 
         assert mock_run.call_count == 1

--- a/apps/python/tests/test_generator_briefing.py
+++ b/apps/python/tests/test_generator_briefing.py
@@ -139,7 +139,7 @@ class TestGenerateBriefing:
             return "sectors ok"
 
         with patch("src.generator.briefing.run_claude", side_effect=mock):
-            with pytest.raises(RuntimeError, match="メイン分析"):
+            with pytest.raises(RuntimeError, match="main analysis"):
                 generate_briefing("PLTR: +2%", config)
 
     def test_sectors_failure_returns_degraded_output(self):

--- a/apps/python/tests/test_stocks.py
+++ b/apps/python/tests/test_stocks.py
@@ -36,7 +36,7 @@ class TestFetchStockMoves:
         with patch("src.fetcher.stocks.yf.Ticker", side_effect=Exception("API down")):
             result = fetch_stock_moves(["PLTR"])
         assert "PLTR" in result
-        assert "取得エラー" in result
+        assert "Stock fetch error" in result
 
     def test_empty_tickers_returns_empty_string(self):
         result = fetch_stock_moves([])
@@ -60,7 +60,7 @@ class TestFetchStockMoveMap:
     def test_error_ticker_gets_error_string(self):
         with patch("src.fetcher.stocks.yf.Ticker", side_effect=Exception("API down")):
             moves = fetch_stock_move_map(["PLTR"])
-        assert "取得エラー" in moves["PLTR"]
+        assert "Stock fetch error" in moves["PLTR"]
 
     def test_empty_tickers_returns_empty_dict(self):
         assert fetch_stock_move_map([]) == {}

--- a/apps/python/tests/test_weekly_handler.py
+++ b/apps/python/tests/test_weekly_handler.py
@@ -116,7 +116,7 @@ class TestFormatBriefings:
 
 class TestGenerateWeeklySummary:
     def test_empty_pages_raises(self):
-        with pytest.raises(ValueError, match="見つかりませんでした"):
+        with pytest.raises(ValueError, match="no pages found"):
             generate_weekly_summary([])
 
     def test_delegates_to_run_claude(self):


### PR DESCRIPTION
## Summary
- Translate comments, docstrings, and developer-facing log/exception messages across `apps/python/src` to English, per the CLAUDE.md "Code Style" rule.
- **Preserved (no behavior change)**: user-facing output strings (prompts, briefing/Notion/Discord content, CLI `--help`, table headers, report HTML), usage-dashboard run labels, and CJK detection data (Simplified-Chinese chars, Japanese keyword weights).
- Updated test assertions that matched the now-English exception/log strings.

## Test plan
- [x] `pytest` — 603 passed
- [x] Verified no Japanese remains in comments/docstrings (only English comments citing CJK example data remain)

Closes #264

## Summary by Sourcery

Translate Japanese developer-facing comments, docstrings, and log/exception messages in the Python apps to English while preserving runtime behavior and public/user-facing strings.

Enhancements:
- Standardize logging and error message text in English across CLI, Notion, Discord, XSS, evaluator, and local LLM components for clearer diagnostics.
- Clarify configuration and usage helper docstrings and comments, including briefing, scoring, usage logging, and Notion/Discord markdown handling.
- Improve inline documentation around batching, pagination, caching, and fallback behaviors in evaluators and generators without changing functionality.

Tests:
- Update Python tests to assert against the new English log and exception messages and to keep behavior expectations unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Translated user-facing documentation, log messages, and error strings from Japanese to English for clearer, consistent output.
* **Bug Fixes**
  * Corrected XSS severity metrics to count only structured severity markers, avoiding miscounts from general prose.
* **Improvements**
  * Enhanced logging with additional English debug details (including clearer lifecycle/progress and more explicit messaging when expected CLI output is missing).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->