### PR TITLE
feat(web): show archive result as dismissible toast popup

### DIFF
--- a/apps/web/components/briefing/ArchiveButton.tsx
+++ b/apps/web/components/briefing/ArchiveButton.tsx
@@ -45,7 +45,10 @@ export function ArchiveButton() {
           <Toast
             data-testid="archive-message"
             variant={status === "error" ? "error" : "success"}
-            onClose={() => setStatus("idle")}
+            onClose={() => {
+              setStatus("idle")
+              setMessage("")
+            }}
           >
             {message}
           </Toast>

--- a/apps/web/components/briefing/ArchiveButton.tsx
+++ b/apps/web/components/briefing/ArchiveButton.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react"
 
+import { Toast, ToastViewport } from "@/components/ui/toast"
+
 type Status = "idle" | "running" | "done" | "error"
 
 /** Triggers POST /api/archive (previous month) and surfaces the result inline. */
@@ -26,6 +28,8 @@ export function ArchiveButton() {
     }
   }
 
+  const showToast = (status === "done" || status === "error") && message
+
   return (
     <div className="flex items-center gap-2 px-2 py-1">
       <button
@@ -36,13 +40,16 @@ export function ArchiveButton() {
       >
         {status === "running" ? "Archiving…" : "Archive last month"}
       </button>
-      {message && (
-        <span
-          data-testid="archive-message"
-          className={status === "error" ? "text-xs text-destructive" : "text-xs text-muted-foreground"}
-        >
-          {message}
-        </span>
+      {showToast && (
+        <ToastViewport>
+          <Toast
+            data-testid="archive-message"
+            variant={status === "error" ? "error" : "success"}
+            onClose={() => setStatus("idle")}
+          >
+            {message}
+          </Toast>
+        </ToastViewport>
       )}
     </div>
   )

--- a/apps/web/components/ui/toast.tsx
+++ b/apps/web/components/ui/toast.tsx
@@ -52,7 +52,7 @@ function ToastViewport({ className, ...props }: React.HTMLAttributes<HTMLDivElem
   return (
     <div
       className={cn(
-        "pointer-events-none fixed left-1/2 top-4 z-50 flex w-full max-w-md -translate-x-1/2 flex-col gap-2 px-4",
+        "pointer-events-none fixed left-1/2 top-4 z-50 flex w-full -translate-x-1/2 flex-col gap-2 px-4",
         className
       )}
       {...props}

--- a/apps/web/components/ui/toast.tsx
+++ b/apps/web/components/ui/toast.tsx
@@ -11,8 +11,8 @@ const toastVariants = cva(
   {
     variants: {
       variant: {
-        success: "border-green-700 bg-green-600 text-white",
-        error: "border-red-700 bg-red-600 text-white",
+        success: "border-green-700 bg-green-600/70 text-white backdrop-blur-sm",
+        error: "border-red-700 bg-red-600/70 text-white backdrop-blur-sm",
       },
     },
     defaultVariants: {
@@ -52,7 +52,7 @@ function ToastViewport({ className, ...props }: React.HTMLAttributes<HTMLDivElem
   return (
     <div
       className={cn(
-        "pointer-events-none fixed bottom-4 right-4 z-50 flex w-full max-w-sm flex-col gap-2",
+        "pointer-events-none fixed left-1/2 top-4 z-50 flex w-full max-w-md -translate-x-1/2 flex-col gap-2 px-4",
         className
       )}
       {...props}

--- a/apps/web/components/ui/toast.tsx
+++ b/apps/web/components/ui/toast.tsx
@@ -28,9 +28,12 @@ export interface ToastProps
 }
 
 /** Dismissible popup notification. Success → green, error → red. */
-function Toast({ className, variant, onClose, children, ...props }: ToastProps) {
+function Toast({ className, variant, onClose, children, role, ...props }: ToastProps) {
+  // Errors deserve an assertive announcement; success is a passive status update.
+  const ariaRole = role ?? (variant === "error" ? "alert" : "status")
+
   return (
-    <div role="status" className={cn(toastVariants({ variant }), className)} {...props}>
+    <div role={ariaRole} className={cn(toastVariants({ variant }), className)} {...props}>
       <div className="flex-1 break-words text-sm">{children}</div>
       {onClose && (
         <button

--- a/apps/web/components/ui/toast.tsx
+++ b/apps/web/components/ui/toast.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const toastVariants = cva(
+  "pointer-events-auto flex items-start gap-3 rounded-md border px-4 py-3 shadow-lg",
+  {
+    variants: {
+      variant: {
+        success: "border-green-700 bg-green-600 text-white",
+        error: "border-red-700 bg-red-600 text-white",
+      },
+    },
+    defaultVariants: {
+      variant: "success",
+    },
+  }
+)
+
+export interface ToastProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof toastVariants> {
+  onClose?: () => void
+}
+
+/** Dismissible popup notification. Success → green, error → red. */
+function Toast({ className, variant, onClose, children, ...props }: ToastProps) {
+  return (
+    <div role="status" className={cn(toastVariants({ variant }), className)} {...props}>
+      <div className="flex-1 break-words text-sm">{children}</div>
+      {onClose && (
+        <button
+          type="button"
+          aria-label="Close"
+          data-testid="toast-close"
+          onClick={onClose}
+          className="rounded-sm opacity-80 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-white/60"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      )}
+    </div>
+  )
+}
+
+/** Fixed bottom-right overlay container for toasts. */
+function ToastViewport({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "pointer-events-none fixed bottom-4 right-4 z-50 flex w-full max-w-sm flex-col gap-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Toast, ToastViewport, toastVariants }

--- a/apps/web/tests/archive-button.test.tsx
+++ b/apps/web/tests/archive-button.test.tsx
@@ -46,4 +46,19 @@ describe("ArchiveButton", () => {
       expect(screen.getByTestId("archive-message")).toHaveTextContent("rclone not found"),
     )
   })
+
+  it("dismisses the toast when the close button is clicked", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ exit_code: 0, stdout: "created: briefing_2026-05.zip" }))
+    render(<ArchiveButton />)
+    const user = userEvent.setup()
+
+    await user.click(screen.getByTestId("archive-button"))
+    await waitFor(() => expect(screen.getByTestId("archive-message")).toBeInTheDocument())
+
+    await user.click(screen.getByTestId("toast-close"))
+
+    await waitFor(() =>
+      expect(screen.queryByTestId("archive-message")).not.toBeInTheDocument(),
+    )
+  })
 })


### PR DESCRIPTION
## Summary
- Add reusable `Toast` / `ToastViewport` UI component (green success / red error, X to close).
- `ArchiveButton` now surfaces results as a dismissible popup instead of inline text.

## Test plan
- [x] `vitest run tests/archive-button.test.tsx` (3 passed, incl. close)
- [x] `npm run lint` / `npm run build`

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Surface archive operation results as dismissible toast notifications instead of inline messages.

New Features:
- Introduce a reusable Toast and ToastViewport UI component for success and error notifications.
- Display archive success and error messages in a bottom-right toast popup triggered by the ArchiveButton.

Tests:
- Add a test to verify that the archive result toast can be dismissed via its close button.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Archive operations now display toast notifications to confirm success or report errors
  * Added a reusable toast notification system with dismissible functionality and success/error states

* **Tests**
  * Added test coverage for toast notification dismissal

<!-- end of auto-generated comment: release notes by coderabbit.ai -->