### PR TITLE
feat(web): mirror QA chat Q&A to local daily briefing

### DIFF
--- a/apps/python/tests/test_api_chat.py
+++ b/apps/python/tests/test_api_chat.py
@@ -694,6 +694,38 @@ async def test_chat_notion_import_creates_local_briefing_when_missing(
     assert "Q?" in created.read_text(encoding="utf-8")
 
 
+async def test_chat_notion_import_succeeds_when_local_append_fails(
+    authed_client, isolated_keyring, clear_credential_env, monkeypatch, local_briefing_dir, caplog
+):
+    """Local-briefing append is best-effort: an OSError must not fail the
+    already-successful Notion save (still 200), and the failure is logged."""
+    import logging
+
+    _seed_notion_creds()
+    factory = _fake_run_factory(
+        stdout=_stream_json_result("done https://www.notion.so/abc"),
+        returncode=0,
+    )
+    monkeypatch.setattr("web.routers.chat.subprocess.run", factory)
+    monkeypatch.setattr("web.routers.chat.shutil.which", lambda _: "/fake/bin/claude")
+
+    def _boom(*_a, **_kw):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("web.routers.chat._append_to_local_briefing", _boom)
+
+    with caplog.at_level(logging.WARNING):
+        response = await authed_client.post(
+            "/api/chat/notion-import",
+            json={"date": "2026-05-30", "question": "Q?", "answer": "A!"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["url"] == "https://www.notion.so/abc"
+    assert not (local_briefing_dir / "briefing_2026-05-30.md").exists()
+    assert "failed to append Q&A to local briefing" in caplog.text
+
+
 async def test_chat_notion_import_defaults_to_sonnet_model(
     authed_client, isolated_keyring, clear_credential_env, monkeypatch, local_briefing_dir
 ):

--- a/apps/python/tests/test_api_chat.py
+++ b/apps/python/tests/test_api_chat.py
@@ -525,6 +525,16 @@ async def test_chat_job_is_gc_after_grace_period(
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture
+def local_briefing_dir(tmp_path, monkeypatch):
+    """Point the router's BRIEFING_DIR at a tmp dir so the notion-import
+    success path doesn't append to the real apps/python/output/briefing."""
+    d = tmp_path / "output" / "briefing"
+    d.mkdir(parents=True)
+    monkeypatch.setattr("web.routers.chat.BRIEFING_DIR", d)
+    return d
+
+
 def _seed_notion_creds():
     from src import credentials as cred_mod
     cred_mod.set_credential("NOTION_API_KEY", "k-test")
@@ -588,7 +598,7 @@ async def test_chat_notion_import_400_when_api_key_missing(
 
 
 async def test_chat_notion_import_success_invokes_skill_and_extracts_url(
-    authed_client, isolated_keyring, clear_credential_env, monkeypatch
+    authed_client, isolated_keyring, clear_credential_env, monkeypatch, local_briefing_dir
 ):
     _seed_notion_creds()
     page_url = "https://www.notion.so/created-page-abc123"
@@ -634,8 +644,58 @@ async def test_chat_notion_import_success_invokes_skill_and_extracts_url(
     assert env.get("NOTION_DATABASE_ID") == "db-test"
 
 
+async def test_chat_notion_import_appends_to_local_briefing(
+    authed_client, isolated_keyring, clear_credential_env, monkeypatch, local_briefing_dir
+):
+    """On success, the Q&A is appended to briefing_<date>.md in addition to Notion."""
+    _seed_notion_creds()
+    existing = local_briefing_dir / "briefing_2026-05-30.md"
+    existing.write_text("# 既存ブリーフィング\n", encoding="utf-8")
+    factory = _fake_run_factory(
+        stdout=_stream_json_result("done https://www.notion.so/abc"),
+        returncode=0,
+    )
+    monkeypatch.setattr("web.routers.chat.subprocess.run", factory)
+    monkeypatch.setattr("web.routers.chat.shutil.which", lambda _: "/fake/bin/claude")
+
+    response = await authed_client.post(
+        "/api/chat/notion-import",
+        json={"date": "2026-05-30", "question": "半導体リスクは？", "answer": "TSMC の地政学…"},
+    )
+
+    assert response.status_code == 200
+    text = existing.read_text(encoding="utf-8")
+    assert "# 既存ブリーフィング" in text  # original content preserved
+    assert "## 追記: QA チャット (2026-05-30)" in text
+    assert "半導体リスクは？" in text
+    assert "TSMC の地政学…" in text
+
+
+async def test_chat_notion_import_creates_local_briefing_when_missing(
+    authed_client, isolated_keyring, clear_credential_env, monkeypatch, local_briefing_dir
+):
+    """When no briefing file exists for the date, it is created with the Q&A."""
+    _seed_notion_creds()
+    factory = _fake_run_factory(
+        stdout=_stream_json_result("done https://www.notion.so/abc"),
+        returncode=0,
+    )
+    monkeypatch.setattr("web.routers.chat.subprocess.run", factory)
+    monkeypatch.setattr("web.routers.chat.shutil.which", lambda _: "/fake/bin/claude")
+
+    response = await authed_client.post(
+        "/api/chat/notion-import",
+        json={"date": "2026-05-30", "question": "Q?", "answer": "A!"},
+    )
+
+    assert response.status_code == 200
+    created = local_briefing_dir / "briefing_2026-05-30.md"
+    assert created.exists()
+    assert "Q?" in created.read_text(encoding="utf-8")
+
+
 async def test_chat_notion_import_defaults_to_sonnet_model(
-    authed_client, isolated_keyring, clear_credential_env, monkeypatch
+    authed_client, isolated_keyring, clear_credential_env, monkeypatch, local_briefing_dir
 ):
     _seed_notion_creds()
     factory = _fake_run_factory(

--- a/apps/python/web/routers/chat.py
+++ b/apps/python/web/routers/chat.py
@@ -345,6 +345,27 @@ def _extract_final_text(stream_json_stdout: str) -> str:
     return final
 
 
+def _append_to_local_briefing(date: str, question: str, answer: str) -> Path:
+    """Append the Q&A to the local daily briefing markdown file.
+
+    Mirrors the `## 追記:` block the /notion-import skill writes to the Notion
+    page, so the local `briefing_<date>.md` stays in sync with Notion. The
+    file is created (with its parent dir) if it does not exist yet, so a Q&A
+    is never silently dropped for a date with no briefing run.
+    """
+    target = BRIEFING_DIR / f"briefing_{date}.md"
+    block = (
+        f"\n\n---\n\n"
+        f"## 追記: QA チャット ({date})\n\n"
+        f"**Q:** {question}\n\n"
+        f"{answer}\n"
+    )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with target.open("a", encoding="utf-8") as fh:
+        fh.write(block)
+    return target
+
+
 @router.post("/chat/notion-import", response_model=ChatNotionImportResponse)
 def post_chat_notion_import(body: ChatNotionImportBody) -> ChatNotionImportResponse:
     """Delegate the save to the local `/notion-import` skill via the CLI.
@@ -444,5 +465,13 @@ def post_chat_notion_import(body: ChatNotionImportBody) -> ChatNotionImportRespo
                 f"(skill report: {report})"
             ),
         )
+
+    # Notion is the primary durable artifact; the local briefing mirror is
+    # best-effort. A filesystem hiccup here must not fail an already-successful
+    # Notion append, so we log and continue rather than raising.
+    try:
+        _append_to_local_briefing(body.date, body.question, body.answer)
+    except OSError as exc:
+        logger.warning("failed to append Q&A to local briefing for %s: %s", body.date, exc)
 
     return ChatNotionImportResponse(url=url_match.group(0), summary=final_text.strip()[:500])

--- a/apps/python/web/routers/chat.py
+++ b/apps/python/web/routers/chat.py
@@ -352,6 +352,9 @@ def _append_to_local_briefing(date: str, question: str, answer: str) -> Path:
     page, so the local `briefing_<date>.md` stays in sync with Notion. The
     file is created (with its parent dir) if it does not exist yet, so a Q&A
     is never silently dropped for a date with no briefing run.
+
+    ``date`` is already constrained to ``^\\d{4}-\\d{2}-\\d{2}$`` by
+    ``ChatNotionImportBody``, so it cannot path-traverse out of BRIEFING_DIR.
     """
     target = BRIEFING_DIR / f"briefing_{date}.md"
     block = (
@@ -470,7 +473,8 @@ def post_chat_notion_import(body: ChatNotionImportBody) -> ChatNotionImportRespo
     # best-effort. A filesystem hiccup here must not fail an already-successful
     # Notion append, so we log and continue rather than raising.
     try:
-        _append_to_local_briefing(body.date, body.question, body.answer)
+        local_path = _append_to_local_briefing(body.date, body.question, body.answer)
+        logger.info("appended Q&A to local briefing %s", local_path)
     except OSError as exc:
         logger.warning("failed to append Q&A to local briefing for %s: %s", body.date, exc)
 


### PR DESCRIPTION
## Summary
- `post_chat_notion_import` now appends the Q&A to `briefing_<date>.md` after a successful Notion append (best-effort; creates the file if missing, never fails the Notion save).
- Append block mirrors the skill's `## 追記:` format.

## Test plan
- [x] `pytest tests/test_api_chat.py` (37 passed, incl. append + create-when-missing)

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Mirror successful Notion chat imports into the local daily briefing while keeping Notion as the source of truth.

New Features:
- Append successful chat Q&A imports to a dated local briefing markdown file that mirrors the Notion `## 追記:` block format.

Enhancements:
- Treat local briefing updates as best-effort side effects that never cause the Notion import endpoint to fail, logging filesystem errors instead.

Tests:
- Add tests and fixtures to verify appending Q&A content to existing briefings, creating briefing files when missing, and isolating briefing output during tests.