### PR TITLE
feat: add journaling agent MD store and API (Phase 1)

### DIFF
--- a/apps/python/src/journal_store.py
+++ b/apps/python/src/journal_store.py
@@ -1,0 +1,81 @@
+"""Journal store — append and read daily Markdown notes.
+
+The journaling agent accumulates free-form daily notes (thoughts, what
+happened today) so they can later be used as context for brainstorming.
+
+Storage layout: one Markdown file per day under ``JOURNAL_DIR`` named
+``YYYY-MM-DD.md``. Each appended note becomes a timestamped section so a
+single day can hold many entries while staying human-readable.
+
+``JOURNAL_DIR`` lives under ``output/`` which is gitignored, so personal
+notes are never committed (matches the briefing output convention).
+"""
+import re
+from datetime import datetime
+from pathlib import Path
+
+JOURNAL_DIR = Path(__file__).parents[1] / "output" / "journal"
+
+# Journal file names are exactly a date: YYYY-MM-DD.md (no path separators).
+_FILE_RE = re.compile(r"^(\d{4}-\d{2}-\d{2})\.md$")
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _today() -> str:
+    """Return today's date as YYYY-MM-DD (local time)."""
+    return datetime.now().strftime("%Y-%m-%d")
+
+
+def _path_for(date: str) -> Path:
+    """Return the file path for a date, validating the date format first."""
+    if not _DATE_RE.match(date):
+        raise ValueError(f"Invalid journal date: {date!r}")
+    return JOURNAL_DIR / f"{date}.md"
+
+
+def append_entry(content: str, date: str | None = None) -> str:
+    """Append a timestamped note to the day's file, creating it if absent.
+
+    Returns the date (YYYY-MM-DD) the note was written to. A new file is
+    seeded with a ``# Journal {date}`` heading before the first section.
+    """
+    text = content.strip()
+    if not text:
+        raise ValueError("Journal entry content must not be empty")
+
+    date = date or _today()
+    path = _path_for(date)
+    JOURNAL_DIR.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now().strftime("%H:%M:%S")
+    section = f"## {timestamp}\n\n{text}\n"
+
+    if path.exists():
+        existing = path.read_text(encoding="utf-8").rstrip("\n")
+        path.write_text(f"{existing}\n\n{section}", encoding="utf-8")
+    else:
+        path.write_text(f"# Journal {date}\n\n{section}", encoding="utf-8")
+    return date
+
+
+def list_dates() -> list[str]:
+    """Return available journal dates, newest first."""
+    if not JOURNAL_DIR.exists():
+        return []
+    dates = [
+        m.group(1)
+        for path in JOURNAL_DIR.glob("*.md")
+        if path.is_file() and (m := _FILE_RE.match(path.name))
+    ]
+    dates.sort(reverse=True)
+    return dates
+
+
+def read_entry(date: str) -> str | None:
+    """Return the Markdown body for a date, or None if it does not exist."""
+    if not _DATE_RE.match(date):
+        return None
+    path = JOURNAL_DIR / f"{date}.md"
+    if not path.exists() or not path.is_file():
+        return None
+    return path.read_text(encoding="utf-8")

--- a/apps/python/src/journal_store.py
+++ b/apps/python/src/journal_store.py
@@ -65,17 +65,26 @@ def append_entry(content: str, date: str | None = None) -> str:
     return date
 
 
-def list_dates() -> list[str]:
-    """Return available journal dates, newest first."""
+def list_files() -> list[tuple[str, Path]]:
+    """Return (date, path) for available journal files, newest first.
+
+    Returning the globbed ``Path`` lets callers reuse it (e.g. for ``stat()``)
+    instead of rebuilding the path from the date string.
+    """
     if not JOURNAL_DIR.exists():
         return []
-    dates = [
-        m.group(1)
+    files = [
+        (m.group(1), path)
         for path in JOURNAL_DIR.glob("*.md")
         if path.is_file() and (m := _FILE_RE.match(path.name))
     ]
-    dates.sort(reverse=True)
-    return dates
+    files.sort(key=lambda f: f[0], reverse=True)
+    return files
+
+
+def list_dates() -> list[str]:
+    """Return available journal dates, newest first."""
+    return [date for date, _ in list_files()]
 
 
 def read_entry(date: str) -> str | None:

--- a/apps/python/src/journal_store.py
+++ b/apps/python/src/journal_store.py
@@ -50,11 +50,18 @@ def append_entry(content: str, date: str | None = None) -> str:
     timestamp = datetime.now().strftime("%H:%M:%S")
     section = f"## {timestamp}\n\n{text}\n"
 
-    if path.exists():
-        existing = path.read_text(encoding="utf-8").rstrip("\n")
-        path.write_text(f"{existing}\n\n{section}", encoding="utf-8")
-    else:
-        path.write_text(f"# Journal {date}\n\n{section}", encoding="utf-8")
+    # Append-only writes so concurrent appends cannot read-modify-write over
+    # each other and silently drop entries. The day heading is seeded once,
+    # on first creation, via exclusive-create ("x") which no-ops if the file
+    # already exists.
+    try:
+        with open(path, "x", encoding="utf-8") as fh:
+            fh.write(f"# Journal {date}\n")
+    except FileExistsError:
+        pass
+
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(f"\n{section}")
     return date
 
 

--- a/apps/python/tests/test_api_journal.py
+++ b/apps/python/tests/test_api_journal.py
@@ -1,0 +1,116 @@
+"""Tests for /api/journal — daily Markdown journal append + read (#271).
+
+Contract:
+- ``POST /api/journal`` appends a timestamped note to the day's file,
+  creating the file if absent; returns {date}.
+- ``GET /api/journal`` returns newest-first list of {date, size}.
+- ``GET /api/journal/{date}`` returns {date, content} (raw markdown).
+- Unknown / invalid date returns 404.
+- Auth is required (Bearer) on all endpoints.
+"""
+import pytest
+
+from src import journal_store
+
+
+@pytest.fixture
+def journal_dir(tmp_path, monkeypatch):
+    """Point the journal store at a tmp dir."""
+    d = tmp_path / "journal"
+    monkeypatch.setattr(journal_store, "JOURNAL_DIR", d)
+    return d
+
+
+async def test_list_requires_auth(async_client, journal_dir):
+    response = await async_client.get("/api/journal")
+    assert response.status_code == 401
+
+
+async def test_append_requires_auth(async_client, journal_dir):
+    response = await async_client.post("/api/journal", json={"content": "hi"})
+    assert response.status_code == 401
+
+
+async def test_append_creates_file(authed_client, journal_dir):
+    response = await authed_client.post(
+        "/api/journal", json={"content": "First thought", "date": "2026-06-24"}
+    )
+    assert response.status_code == 200
+    assert response.json()["date"] == "2026-06-24"
+    path = journal_dir / "2026-06-24.md"
+    assert path.exists()
+    body = path.read_text(encoding="utf-8")
+    assert "# Journal 2026-06-24" in body
+    assert "First thought" in body
+
+
+async def test_append_twice_keeps_both(authed_client, journal_dir):
+    await authed_client.post("/api/journal", json={"content": "one", "date": "2026-06-24"})
+    await authed_client.post("/api/journal", json={"content": "two", "date": "2026-06-24"})
+    body = (journal_dir / "2026-06-24.md").read_text(encoding="utf-8")
+    assert "one" in body and "two" in body
+    # only one top-level heading
+    assert body.count("# Journal 2026-06-24") == 1
+
+
+async def test_append_defaults_to_today(authed_client, journal_dir):
+    response = await authed_client.post("/api/journal", json={"content": "no date"})
+    assert response.status_code == 200
+    assert journal_store._DATE_RE.match(response.json()["date"])
+
+
+async def test_append_empty_content_rejected(authed_client, journal_dir):
+    response = await authed_client.post("/api/journal", json={"content": "   "})
+    assert response.status_code == 400
+
+
+async def test_append_blank_string_rejected_by_schema(authed_client, journal_dir):
+    response = await authed_client.post("/api/journal", json={"content": ""})
+    assert response.status_code == 422
+
+
+async def test_append_invalid_date_rejected(authed_client, journal_dir):
+    response = await authed_client.post(
+        "/api/journal", json={"content": "x", "date": "not-a-date"}
+    )
+    assert response.status_code == 400
+
+
+async def test_list_newest_first(authed_client, journal_dir):
+    for date in ("2026-06-22", "2026-06-24", "2026-06-23"):
+        await authed_client.post("/api/journal", json={"content": "x", "date": date})
+    response = await authed_client.get("/api/journal")
+    assert response.status_code == 200
+    dates = [d["date"] for d in response.json()["dates"]]
+    assert dates == ["2026-06-24", "2026-06-23", "2026-06-22"]
+
+
+async def test_list_includes_size(authed_client, journal_dir):
+    await authed_client.post("/api/journal", json={"content": "x", "date": "2026-06-24"})
+    response = await authed_client.get("/api/journal")
+    assert response.json()["dates"][0]["size"] > 0
+
+
+async def test_list_empty_when_dir_missing(authed_client, journal_dir):
+    response = await authed_client.get("/api/journal")
+    assert response.status_code == 200
+    assert response.json()["dates"] == []
+
+
+async def test_get_returns_markdown(authed_client, journal_dir):
+    await authed_client.post("/api/journal", json={"content": "hello", "date": "2026-06-24"})
+    response = await authed_client.get("/api/journal/2026-06-24")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["date"] == "2026-06-24"
+    assert "hello" in body["content"]
+
+
+async def test_get_unknown_date_returns_404(authed_client, journal_dir):
+    response = await authed_client.get("/api/journal/2099-01-01")
+    assert response.status_code == 404
+
+
+async def test_get_invalid_date_returns_404(authed_client, journal_dir):
+    response = await authed_client.get("/api/journal/not-a-date")
+    assert response.status_code == 404

--- a/apps/python/web/app.py
+++ b/apps/python/web/app.py
@@ -8,6 +8,7 @@ from web.routers import (
     config,
     credentials,
     health,
+    journal,
     run,
     state,
     usage,
@@ -24,3 +25,4 @@ app.include_router(chat.router, prefix="/api")
 app.include_router(usage.router, prefix="/api")
 app.include_router(briefing.router, prefix="/api")
 app.include_router(archive.router, prefix="/api")
+app.include_router(journal.router, prefix="/api")

--- a/apps/python/web/routers/journal.py
+++ b/apps/python/web/routers/journal.py
@@ -45,8 +45,8 @@ class AppendEntryResponse(BaseModel):
 def list_journal() -> JournalListResponse:
     """Return available journal dates, newest first."""
     dates = [
-        JournalDate(date=d, size=(journal_store.JOURNAL_DIR / f"{d}.md").stat().st_size)
-        for d in journal_store.list_dates()
+        JournalDate(date=date, size=path.stat().st_size)
+        for date, path in journal_store.list_files()
     ]
     return JournalListResponse(dates=dates)
 

--- a/apps/python/web/routers/journal.py
+++ b/apps/python/web/routers/journal.py
@@ -1,0 +1,70 @@
+"""Journal API — accumulate and read daily Markdown notes (#271, Phase 1).
+
+- ``POST /api/journal`` appends a timestamped note to today's file
+  (or to ``date`` when provided).
+- ``GET /api/journal`` lists available journal dates, newest first.
+- ``GET /api/journal/{date}`` returns the raw Markdown for a date.
+
+Notes are stored under ``output/journal/`` (gitignored). Phase 2 will feed
+this content into the chat flow for brainstorming.
+"""
+from pydantic import BaseModel, Field
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from src import journal_store
+from web.auth import require_bearer
+
+router = APIRouter(dependencies=[Depends(require_bearer)])
+
+
+class JournalDate(BaseModel):
+    date: str  # YYYY-MM-DD
+    size: int  # bytes
+
+
+class JournalListResponse(BaseModel):
+    dates: list[JournalDate]
+
+
+class JournalEntryResponse(BaseModel):
+    date: str
+    content: str
+
+
+class AppendEntryRequest(BaseModel):
+    content: str = Field(min_length=1)
+    date: str | None = None  # defaults to today when omitted
+
+
+class AppendEntryResponse(BaseModel):
+    date: str
+
+
+@router.get("/journal", response_model=JournalListResponse)
+def list_journal() -> JournalListResponse:
+    """Return available journal dates, newest first."""
+    dates = [
+        JournalDate(date=d, size=(journal_store.JOURNAL_DIR / f"{d}.md").stat().st_size)
+        for d in journal_store.list_dates()
+    ]
+    return JournalListResponse(dates=dates)
+
+
+@router.post("/journal", response_model=AppendEntryResponse)
+def append_journal(req: AppendEntryRequest) -> AppendEntryResponse:
+    """Append a note to the day's journal file, creating it if absent."""
+    try:
+        date = journal_store.append_entry(req.content, req.date)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return AppendEntryResponse(date=date)
+
+
+@router.get("/journal/{date}", response_model=JournalEntryResponse)
+def get_journal(date: str) -> JournalEntryResponse:
+    """Return the Markdown body for a date. Unknown/invalid date returns 404."""
+    content = journal_store.read_entry(date)
+    if content is None:
+        raise HTTPException(status_code=404, detail=f"Journal not found: {date}")
+    return JournalEntryResponse(date=date, content=content)


### PR DESCRIPTION
## Summary
- Add `src/journal_store.py`: append/read daily Markdown notes under `output/journal/` (gitignored)
- Add `GET/POST /api/journal` and `GET /api/journal/{date}` router
- Phase 2 (chat brainstorming over journal) follows in a later PR

## Test plan
- [x] `pytest` — 617 passed (14 new in `test_api_journal.py`)

Closes #271

## Summary by Sourcery

Introduce a journaling backend and authenticated API endpoints for appending and reading daily Markdown notes.

New Features:
- Add a filesystem-backed journal store for per-day Markdown notes under an output directory.
- Expose authenticated /api/journal endpoints to append entries, list available journal dates with sizes, and fetch a day's Markdown content.

Tests:
- Add API tests covering journal append, listing, retrieval, validation, and auth requirements.