### PR TITLE
feat: journaling brainstorm chat over recent entries (Phase 2)

### DIFF
--- a/apps/python/src/chat_session.py
+++ b/apps/python/src/chat_session.py
@@ -15,6 +15,48 @@ def session_name_for(target_date: str) -> str:
     return f"briefing-chat-{target_date}"
 
 
+def journal_session_name_for(target_date: str) -> str:
+    return f"journal-chat-{target_date}"
+
+
+def build_journal_cmd(
+    target_date: str, journal_context: str, session_file: Path
+) -> list[str]:
+    """Return claude CLI args for a journaling brainstorm session.
+
+    Mirrors ``build_cmd`` but seeds the system prompt with the user's recent
+    journal entries instead of a market briefing, so the assistant can help
+    brainstorm and reflect over accumulated daily notes.
+
+    - Resume: ``claude --resume <uuid> --name <name>``
+    - New:    ``claude --session-id <uuid> --name <name> --append-system-prompt <context>``
+    """
+    name = journal_session_name_for(target_date)
+
+    if session_file.exists():
+        session_id = session_file.read_text().strip()
+        return ["claude", "--resume", session_id, "--name", name]
+
+    session_id = str(uuid.uuid4())
+    session_file.parent.mkdir(parents=True, exist_ok=True)
+    session_file.write_text(session_id)
+
+    context = (
+        "以下はユーザーの直近の日記（ジャーナル）です。"
+        "これをコンテキストとして、アイディア出し・思考の整理・次の一手の検討など、"
+        "ユーザーのブレインストーミングを日本語でサポートしてください。\n\n"
+        f"=== ジャーナル ===\n"
+        f"{wrap_untrusted(journal_context, label='journal_entries')}\n"
+        "=== END ==="
+    )
+    return [
+        "claude",
+        "--session-id", session_id,
+        "--name", name,
+        "--append-system-prompt", context,
+    ]
+
+
 def build_cmd(target_date: str, briefing_file: Path, session_file: Path) -> list[str]:
     """Return claude CLI args, resuming if a saved session exists, else creating
     a new one and persisting the UUID to ``session_file``.

--- a/apps/python/src/journal_store.py
+++ b/apps/python/src/journal_store.py
@@ -21,7 +21,7 @@ _FILE_RE = re.compile(r"^(\d{4}-\d{2}-\d{2})\.md$")
 _DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
-def _today() -> str:
+def today() -> str:
     """Return today's date as YYYY-MM-DD (local time)."""
     return datetime.now().strftime("%Y-%m-%d")
 
@@ -43,7 +43,7 @@ def append_entry(content: str, date: str | None = None) -> str:
     if not text:
         raise ValueError("Journal entry content must not be empty")
 
-    date = date or _today()
+    date = date or today()
     path = _path_for(date)
     JOURNAL_DIR.mkdir(parents=True, exist_ok=True)
 

--- a/apps/python/tests/test_api_journal_chat.py
+++ b/apps/python/tests/test_api_journal_chat.py
@@ -135,6 +135,24 @@ async def test_days_limits_context(authed_client, journal_dir, monkeypatch):
     assert "Day one note." not in context
 
 
+async def test_context_capped_at_max_chars(authed_client, journal_dir, monkeypatch):
+    # Make each day large and set a small cap so only the newest fits.
+    (journal_dir / "2026-06-23.md").write_text("A" * 5000, encoding="utf-8")
+    (journal_dir / "2026-06-24.md").write_text("B" * 5000, encoding="utf-8")
+    monkeypatch.setattr("web.routers.chat.JOURNAL_CONTEXT_MAX_CHARS", 6000)
+    factory = _make_popen()
+    monkeypatch.setattr("web.routers.chat.subprocess.Popen", factory)
+
+    response = await authed_client.post("/api/journal/chat", json={"question": "q"})
+    assert response.status_code == 202
+
+    cmd = factory.calls[0][0]
+    context = cmd[cmd.index("--append-system-prompt") + 1]
+    # Newest day kept, older dropped once the budget is exhausted.
+    assert "B" * 5000 in context
+    assert "A" * 5000 not in context
+
+
 async def test_stream_reuses_chat_endpoint(authed_client, journal_dir, monkeypatch):
     factory = _make_popen(stdout_lines=[b"Brainstorm idea\n"])
     monkeypatch.setattr("web.routers.chat.subprocess.Popen", factory)

--- a/apps/python/tests/test_api_journal_chat.py
+++ b/apps/python/tests/test_api_journal_chat.py
@@ -1,0 +1,146 @@
+"""Tests for /api/journal/chat — journaling brainstorm chat (#271, Phase 2).
+
+Contract:
+- ``POST /api/journal/chat`` returns ``202 {job_id, status}`` and schedules
+  the claude subprocess, seeded with recent journal entries as context.
+- 404 when there are no journal entries to brainstorm over.
+- The job streams via the shared ``GET /api/chat/{job_id}/stream``.
+- Auth (Bearer) is required.
+
+Mirrors test_api_chat.py: in test mode the BackgroundTask runs
+synchronously, so the FakePopen has completed by the time POST returns.
+"""
+import io
+
+import pytest
+
+from src import chat_job_store, journal_store
+
+pytestmark = pytest.mark.usefixtures("isolated_state")
+
+
+@pytest.fixture(autouse=True)
+def reset_chat_store():
+    chat_job_store._reset_for_tests()
+    yield
+    chat_job_store._reset_for_tests()
+
+
+@pytest.fixture
+def journal_dir(tmp_path, monkeypatch):
+    """Point the journal store at a tmp dir with two days of entries."""
+    d = tmp_path / "journal"
+    d.mkdir()
+    (d / "2026-06-23.md").write_text("# Journal 2026-06-23\n\nDay one note.", encoding="utf-8")
+    (d / "2026-06-24.md").write_text("# Journal 2026-06-24\n\nDay two note.", encoding="utf-8")
+    monkeypatch.setattr(journal_store, "JOURNAL_DIR", d)
+    return d
+
+
+class FakePopen:
+    def __init__(self, cmd, stdout_lines=None, stderr=b"", returncode=0, **kwargs):
+        self.cmd = cmd
+        self.stdout = iter(stdout_lines or [])
+        self.stderr = io.BytesIO(stderr)
+        self._returncode = returncode
+        self.returncode = None
+
+    def wait(self):
+        self.returncode = self._returncode
+        return self._returncode
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self):
+        pass
+
+
+def _make_popen(stdout_lines=None):
+    calls = []
+
+    def factory(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return FakePopen(cmd, stdout_lines=stdout_lines)
+
+    factory.calls = calls
+    return factory
+
+
+async def test_post_requires_auth(async_client, journal_dir):
+    response = await async_client.post("/api/journal/chat", json={"question": "ideas?"})
+    assert response.status_code == 401
+
+
+async def test_post_returns_202_with_job_id(authed_client, journal_dir, monkeypatch):
+    factory = _make_popen()
+    monkeypatch.setattr("web.routers.chat.subprocess.Popen", factory)
+
+    response = await authed_client.post("/api/journal/chat", json={"question": "ideas?"})
+
+    assert response.status_code == 202, response.text
+    body = response.json()
+    assert body["job_id"]
+    assert chat_job_store.get_job(body["job_id"]) is not None
+
+
+async def test_post_404_when_no_entries(authed_client, tmp_path, monkeypatch):
+    monkeypatch.setattr(journal_store, "JOURNAL_DIR", tmp_path / "empty")
+    response = await authed_client.post("/api/journal/chat", json={"question": "ideas?"})
+    assert response.status_code == 404
+
+
+async def test_post_rejects_empty_question(authed_client, journal_dir):
+    response = await authed_client.post("/api/journal/chat", json={"question": ""})
+    assert response.status_code == 422
+
+
+async def test_post_rejects_out_of_range_days(authed_client, journal_dir):
+    for bad in (0, 32):
+        response = await authed_client.post(
+            "/api/journal/chat", json={"question": "q", "days": bad}
+        )
+        assert response.status_code == 422, f"expected 422 for days={bad}"
+
+
+async def test_context_includes_recent_entries(authed_client, journal_dir, monkeypatch):
+    factory = _make_popen()
+    monkeypatch.setattr("web.routers.chat.subprocess.Popen", factory)
+
+    response = await authed_client.post("/api/journal/chat", json={"question": "q"})
+    assert response.status_code == 202
+
+    # The first (new-session) invocation carries the journal context in the
+    # --append-system-prompt argument.
+    cmd = factory.calls[0][0]
+    assert "--append-system-prompt" in cmd
+    context = cmd[cmd.index("--append-system-prompt") + 1]
+    assert "Day one note." in context
+    assert "Day two note." in context
+
+
+async def test_days_limits_context(authed_client, journal_dir, monkeypatch):
+    factory = _make_popen()
+    monkeypatch.setattr("web.routers.chat.subprocess.Popen", factory)
+
+    response = await authed_client.post(
+        "/api/journal/chat", json={"question": "q", "days": 1}
+    )
+    assert response.status_code == 202
+
+    cmd = factory.calls[0][0]
+    context = cmd[cmd.index("--append-system-prompt") + 1]
+    # Only the newest day (2026-06-24) is loaded.
+    assert "Day two note." in context
+    assert "Day one note." not in context
+
+
+async def test_stream_reuses_chat_endpoint(authed_client, journal_dir, monkeypatch):
+    factory = _make_popen(stdout_lines=[b"Brainstorm idea\n"])
+    monkeypatch.setattr("web.routers.chat.subprocess.Popen", factory)
+
+    post = await authed_client.post("/api/journal/chat", json={"question": "q"})
+    job_id = post.json()["job_id"]
+    stream = await authed_client.get(f"/api/chat/{job_id}/stream")
+    assert stream.status_code == 200
+    assert "Brainstorm idea" in stream.text

--- a/apps/python/web/routers/chat.py
+++ b/apps/python/web/routers/chat.py
@@ -61,8 +61,9 @@ from pydantic import BaseModel, Field
 
 from src import chat_job_store
 from src import credentials as cred_mod
+from src import journal_store
 from src import state as state_mod
-from src.chat_session import build_cmd
+from src.chat_session import build_cmd, build_journal_cmd
 from src.claude_runner import build_env
 from src.logger import get_logger
 from web.auth import require_bearer
@@ -246,6 +247,54 @@ def post_chat(body: ChatBody, background_tasks: BackgroundTasks) -> ChatPostResp
 
     SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
     cmd = build_cmd(body.date, briefing_file, session_file) + ["-p", body.question]
+    env = build_env(auth_mode=state_mod.read_state().auth_mode)
+
+    job = chat_job_store.create_job()
+    background_tasks.add_task(_run_chat_job, job.job_id, cmd, session_file, env)
+    return ChatPostResponse(job_id=job.job_id, status=job.status)
+
+
+class JournalChatBody(BaseModel):
+    question: str = Field(min_length=1)
+    # How many most-recent journal days to load as brainstorm context.
+    days: int = Field(default=7, ge=1, le=31)
+
+
+def _gather_journal_context(days: int) -> str:
+    """Concatenate the newest ``days`` journal files into one context blob.
+
+    Returns "" when there are no journal entries. Each day is delimited so
+    the assistant can tell entries apart; the whole blob is wrapped as
+    untrusted input by ``build_journal_cmd``.
+    """
+    dates = journal_store.list_dates()[:days]
+    sections = []
+    for date in dates:
+        content = journal_store.read_entry(date)
+        if content:
+            sections.append(content.strip())
+    return "\n\n".join(sections)
+
+
+@router.post("/journal/chat", status_code=202, response_model=ChatPostResponse)
+def post_journal_chat(
+    body: JournalChatBody, background_tasks: BackgroundTasks
+) -> ChatPostResponse:
+    """Start a journaling brainstorm chat seeded with recent journal entries.
+
+    Reuses the chat job/stream machinery: the returned ``job_id`` is streamed
+    via ``GET /api/chat/{job_id}/stream`` and cancelled via ``DELETE``.
+    """
+    context = _gather_journal_context(body.days)
+    if not context:
+        raise HTTPException(status_code=404, detail="no journal entries to brainstorm over")
+
+    today = journal_store._today()
+    sessions_dir = journal_store.JOURNAL_DIR / ".sessions"
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    session_file = sessions_dir / today
+
+    cmd = build_journal_cmd(today, context, session_file) + ["-p", body.question]
     env = build_env(auth_mode=state_mod.read_state().auth_mode)
 
     job = chat_job_store.create_job()

--- a/apps/python/web/routers/chat.py
+++ b/apps/python/web/routers/chat.py
@@ -254,25 +254,43 @@ def post_chat(body: ChatBody, background_tasks: BackgroundTasks) -> ChatPostResp
     return ChatPostResponse(job_id=job.job_id, status=job.status)
 
 
+# Upper bound on the assembled journal context. Caps the size of the
+# --append-system-prompt payload (and the token cost) for users with many or
+# very long entries. Newest entries are kept; older ones are dropped once the
+# budget is exhausted.
+JOURNAL_CONTEXT_MAX_CHARS = 40_000
+
+
 class JournalChatBody(BaseModel):
     question: str = Field(min_length=1)
     # How many most-recent journal days to load as brainstorm context.
     days: int = Field(default=7, ge=1, le=31)
 
 
-def _gather_journal_context(days: int) -> str:
+def _gather_journal_context(days: int, max_chars: int | None = None) -> str:
     """Concatenate the newest ``days`` journal files into one context blob.
 
-    Returns "" when there are no journal entries. Each day is delimited so
-    the assistant can tell entries apart; the whole blob is wrapped as
-    untrusted input by ``build_journal_cmd``.
+    Returns "" when there are no journal entries. Entries are appended
+    newest-first and the blob is capped at ``max_chars`` (defaults to the
+    module-level ``JOURNAL_CONTEXT_MAX_CHARS``) so a long history can't blow
+    up the prompt; older entries past the budget are dropped. The whole blob
+    is wrapped as untrusted input by ``build_journal_cmd``.
     """
+    if max_chars is None:
+        max_chars = JOURNAL_CONTEXT_MAX_CHARS
     dates = journal_store.list_dates()[:days]
-    sections = []
+    sections: list[str] = []
+    total = 0
     for date in dates:
         content = journal_store.read_entry(date)
-        if content:
-            sections.append(content.strip())
+        if not content:
+            continue
+        section = content.strip()
+        # +2 accounts for the "\n\n" join separator between sections.
+        if sections and total + len(section) + 2 > max_chars:
+            break
+        sections.append(section)
+        total += len(section) + 2
     return "\n\n".join(sections)
 
 
@@ -289,7 +307,7 @@ def post_journal_chat(
     if not context:
         raise HTTPException(status_code=404, detail="no journal entries to brainstorm over")
 
-    today = journal_store._today()
+    today = journal_store.today()
     sessions_dir = journal_store.JOURNAL_DIR / ".sessions"
     sessions_dir.mkdir(parents=True, exist_ok=True)
     session_file = sessions_dir / today


### PR DESCRIPTION
## Summary
- Add `POST /api/journal/chat`: starts a brainstorm chat seeded with the newest `days` (default 7) of journal entries as context
- Add `build_journal_cmd` in `chat_session.py` (mirrors `build_cmd`, journal context via `--append-system-prompt`, wrapped as untrusted)
- Reuses the existing chat job/SSE machinery — stream via `GET /api/chat/{job_id}/stream`, cancel via `DELETE`

## Test plan
- [x] `pytest` — 628 passed (8 new in `test_api_journal_chat.py`)

Completes the chat-integration acceptance criterion of #271.

## Summary by Sourcery

Add a journaling brainstorm chat endpoint that seeds Claude sessions with recent journal entries and reuses the existing chat job/stream infrastructure.

New Features:
- Expose POST /api/journal/chat to start an authenticated brainstorm chat over the most recent journal days, returning an async chat job.
- Introduce journal-specific Claude session commands that append journal context as an untrusted system prompt for new sessions.

Tests:
- Add API tests covering auth, validation, journal context selection, and reuse of the shared chat streaming endpoint for journal chats.