### PR TITLE
feat(web): add Journal page (record + brainstorm)

### DIFF
--- a/apps/web/app/(main)/journal/page.tsx
+++ b/apps/web/app/(main)/journal/page.tsx
@@ -1,0 +1,18 @@
+export const dynamic = "force-dynamic"
+
+import { JournalScreen } from "@/components/screens/JournalScreen"
+
+export default function JournalPage() {
+  return (
+    <div className="space-y-4">
+      <header>
+        <h2 className="text-xl font-semibold">Journal</h2>
+        <p className="text-sm text-muted-foreground">
+          Jot down what happened today and your thoughts. Entries accumulate
+          per day, and you can brainstorm over them with Claude.
+        </p>
+      </header>
+      <JournalScreen />
+    </div>
+  )
+}

--- a/apps/web/components/Sidebar.tsx
+++ b/apps/web/components/Sidebar.tsx
@@ -23,6 +23,7 @@ const ITEMS: Item[] = [
   { href: "/auth", label: "Auth", icon: "🔑" },
   { href: "/run", label: "Run", icon: "▶️" },
   { href: "/chat", label: "Q&A Chat", icon: "💬" },
+  { href: "/journal", label: "Journal", icon: "📓" },
   { href: "/briefing", label: "Briefing", icon: "📚" },
 ]
 

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -172,7 +172,7 @@ export function JournalScreen() {
   )
 
   return (
-    <div className="grid gap-6 lg:grid-cols-[260px_1fr]">
+    <div className="grid items-start gap-6 lg:grid-cols-[160px_1fr]">
       {/* Left: date list */}
       <aside className="flex flex-col gap-2">
         <h3 className="text-sm font-semibold text-muted-foreground">Entries</h3>

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 
@@ -9,6 +9,15 @@ type Turn = { question: string; answer: string; saved: boolean }
 const PROSE =
   "prose prose-sm max-w-none dark:prose-invert prose-a:text-blue-600 " +
   "hover:prose-a:underline dark:prose-a:text-blue-400"
+
+/** Join the `data:` lines of one raw SSE event block into text. */
+function parseSseEvent(raw: string): string {
+  return raw
+    .split("\n")
+    .filter((l) => l.startsWith("data:"))
+    .map((l) => l.slice(5).replace(/^ /, ""))
+    .join("\n")
+}
 
 /** Parse a Server-Sent Events stream, yielding the joined `data:` text per event. */
 async function* readSse(body: ReadableStream<Uint8Array>): AsyncGenerator<string> {
@@ -21,22 +30,23 @@ async function* readSse(body: ReadableStream<Uint8Array>): AsyncGenerator<string
     buffer += decoder.decode(value, { stream: true })
     let sep: number
     while ((sep = buffer.indexOf("\n\n")) !== -1) {
-      const raw = buffer.slice(0, sep)
+      const data = parseSseEvent(buffer.slice(0, sep))
       buffer = buffer.slice(sep + 2)
-      const data = raw
-        .split("\n")
-        .filter((l) => l.startsWith("data:"))
-        .map((l) => l.slice(5).replace(/^ /, ""))
-        .join("\n")
       if (data) yield data
     }
   }
+  // Flush a trailing event that wasn't terminated by a final "\n\n".
+  const tail = parseSseEvent(buffer)
+  if (tail) yield tail
 }
 
 export function JournalScreen() {
   const [dates, setDates] = useState<JournalDate[]>([])
+  const [datesError, setDatesError] = useState<string | null>(null)
   const [selected, setSelected] = useState<string | null>(null)
   const [content, setContent] = useState("")
+  // Monotonic id so a slow earlier loadEntry can't overwrite a newer selection.
+  const entryReqSeq = useRef(0)
   const [entry, setEntry] = useState("")
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
@@ -47,21 +57,33 @@ export function JournalScreen() {
   const [chatError, setChatError] = useState<string | null>(null)
 
   const loadDates = useCallback(async () => {
-    const res = await fetch("/api/journal", { cache: "no-store" })
-    if (!res.ok) return
-    const data = (await res.json()) as { dates: JournalDate[] }
-    setDates(data.dates)
-    return data.dates
+    try {
+      setDatesError(null)
+      const res = await fetch("/api/journal", { cache: "no-store" })
+      if (!res.ok) {
+        setDatesError(`Failed to load entries (HTTP ${res.status})`)
+        return
+      }
+      const data = (await res.json()) as { dates: JournalDate[] }
+      setDates(data.dates)
+      return data.dates
+    } catch (e) {
+      setDatesError(`Failed to load entries: ${String(e)}`)
+    }
   }, [])
 
   const loadEntry = useCallback(async (date: string) => {
+    const seq = ++entryReqSeq.current
     setSelected(date)
     const res = await fetch(`/api/journal/${date}`, { cache: "no-store" })
+    // Ignore a stale response that lost the race to a newer selection.
+    if (seq !== entryReqSeq.current) return
     if (!res.ok) {
       setContent("")
       return
     }
     const data = (await res.json()) as { content: string }
+    if (seq !== entryReqSeq.current) return
     setContent(data.content)
   }, [])
 
@@ -176,7 +198,9 @@ export function JournalScreen() {
         <label htmlFor="journal-date" className="text-sm font-semibold text-muted-foreground">
           Entries
         </label>
-        {dates.length === 0 ? (
+        {datesError ? (
+          <span className="text-sm text-destructive">{datesError}</span>
+        ) : dates.length === 0 ? (
           <span className="text-sm text-muted-foreground">No entries yet.</span>
         ) : (
           <select

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -3,8 +3,6 @@ import { useCallback, useEffect, useState } from "react"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 
-import { cn } from "@/lib/utils"
-
 type JournalDate = { date: string; size: number }
 type Turn = { question: string; answer: string; saved: boolean }
 
@@ -172,35 +170,34 @@ export function JournalScreen() {
   )
 
   return (
-    <div className="grid items-start gap-6 lg:grid-cols-[160px_1fr]">
-      {/* Left: date list */}
-      <aside className="flex flex-col gap-2">
-        <h3 className="text-sm font-semibold text-muted-foreground">Entries</h3>
+    <div className="flex flex-col gap-6">
+      {/* Top: date picker */}
+      <div className="flex items-center gap-3">
+        <label htmlFor="journal-date" className="text-sm font-semibold text-muted-foreground">
+          Entries
+        </label>
         {dates.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No entries yet.</p>
+          <span className="text-sm text-muted-foreground">No entries yet.</span>
         ) : (
-          <ul className="flex flex-col gap-1">
+          <select
+            id="journal-date"
+            value={selected ?? ""}
+            onChange={(e) => void loadEntry(e.target.value)}
+            className="rounded-md border bg-background px-3 py-2 text-sm"
+          >
+            <option value="" disabled>
+              Select a date…
+            </option>
             {dates.map((d) => (
-              <li key={d.date}>
-                <button
-                  type="button"
-                  onClick={() => void loadEntry(d.date)}
-                  className={cn(
-                    "w-full rounded-md px-3 py-2 text-left text-sm transition-colors",
-                    selected === d.date
-                      ? "bg-accent font-medium text-accent-foreground"
-                      : "hover:bg-accent/50",
-                  )}
-                >
-                  {d.date}
-                </button>
-              </li>
+              <option key={d.date} value={d.date}>
+                {d.date}
+              </option>
             ))}
-          </ul>
+          </select>
         )}
-      </aside>
+      </div>
 
-      {/* Right: record + view + brainstorm */}
+      {/* Full-width: record + view + brainstorm */}
       <div className="flex flex-col gap-6">
         <section className="flex flex-col gap-2 rounded-lg border bg-card p-4">
           <h3 className="text-sm font-semibold">Record today</h3>

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -6,6 +6,7 @@ import remarkGfm from "remark-gfm"
 import { cn } from "@/lib/utils"
 
 type JournalDate = { date: string; size: number }
+type Turn = { question: string; answer: string; saved: boolean }
 
 const PROSE =
   "prose prose-sm max-w-none dark:prose-invert prose-a:text-blue-600 " +
@@ -43,7 +44,7 @@ export function JournalScreen() {
   const [saveError, setSaveError] = useState<string | null>(null)
 
   const [question, setQuestion] = useState("")
-  const [answer, setAnswer] = useState("")
+  const [turns, setTurns] = useState<Turn[]>([])
   const [brainstorming, setBrainstorming] = useState(false)
   const [chatError, setChatError] = useState<string | null>(null)
 
@@ -97,12 +98,23 @@ export function JournalScreen() {
     }
   }, [entry, saving, loadDates, loadEntry])
 
+  // Append text to the answer of the most recent (in-flight) turn.
+  const appendToLastAnswer = useCallback((chunk: string) => {
+    setTurns((prev) => {
+      if (prev.length === 0) return prev
+      const last = prev[prev.length - 1]
+      const answer = last.answer ? `${last.answer}\n${chunk}` : chunk
+      return [...prev.slice(0, -1), { ...last, answer }]
+    })
+  }, [])
+
   const brainstorm = useCallback(async () => {
     const q = question.trim()
     if (!q || brainstorming) return
     setBrainstorming(true)
     setChatError(null)
-    setAnswer("")
+    setTurns((prev) => [...prev, { question: q, answer: "", saved: false }])
+    setQuestion("")
     try {
       const post = await fetch("/api/journal/chat", {
         method: "POST",
@@ -125,14 +137,39 @@ export function JournalScreen() {
         return
       }
       for await (const chunk of readSse(stream.body)) {
-        setAnswer((prev) => (prev ? `${prev}\n${chunk}` : chunk))
+        appendToLastAnswer(chunk)
       }
     } catch (e) {
       setChatError(String(e))
     } finally {
       setBrainstorming(false)
     }
-  }, [question, brainstorming])
+  }, [question, brainstorming, appendToLastAnswer])
+
+  // Persist a brainstorm turn to today's journal file via POST /api/journal.
+  const saveTurn = useCallback(
+    async (index: number) => {
+      const turn = turns[index]
+      if (!turn || turn.saved || !turn.answer) return
+      const content = `### Brainstorm\n\n**Q:** ${turn.question}\n\n${turn.answer}`
+      const res = await fetch("/api/journal", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content }),
+      })
+      if (!res.ok) {
+        setChatError(`Save to journal failed (HTTP ${res.status})`)
+        return
+      }
+      setTurns((prev) =>
+        prev.map((t, i) => (i === index ? { ...t, saved: true } : t)),
+      )
+      const { date } = (await res.json()) as { date: string }
+      await loadDates()
+      if (selected === date) await loadEntry(date)
+    },
+    [turns, loadDates, loadEntry, selected],
+  )
 
   return (
     <div className="grid gap-6 lg:grid-cols-[260px_1fr]">
@@ -219,9 +256,30 @@ export function JournalScreen() {
             </button>
             {chatError && <span className="text-sm text-destructive">{chatError}</span>}
           </div>
-          {answer && (
-            <div className={cn(PROSE, "mt-2 rounded-md border bg-background p-3")}>
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{answer}</ReactMarkdown>
+          {turns.length > 0 && (
+            <div className="mt-2 flex flex-col gap-4">
+              {turns.map((turn, i) => (
+                <div key={i} className="flex flex-col gap-2 rounded-md border bg-background p-3">
+                  <p className="text-sm font-medium text-muted-foreground">
+                    Q: {turn.question}
+                  </p>
+                  <div className={PROSE}>
+                    <ReactMarkdown remarkPlugins={[remarkGfm]}>{turn.answer}</ReactMarkdown>
+                  </div>
+                  {turn.answer && (
+                    <div>
+                      <button
+                        type="button"
+                        onClick={() => void saveTurn(i)}
+                        disabled={turn.saved}
+                        className="rounded-md border px-3 py-1 text-xs transition-colors hover:bg-accent/50 disabled:opacity-50"
+                      >
+                        {turn.saved ? "Saved to journal ✓" : "Save to journal"}
+                      </button>
+                    </div>
+                  )}
+                </div>
+              ))}
             </div>
           )}
         </section>

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -1,0 +1,231 @@
+"use client"
+import { useCallback, useEffect, useState } from "react"
+import ReactMarkdown from "react-markdown"
+import remarkGfm from "remark-gfm"
+
+import { cn } from "@/lib/utils"
+
+type JournalDate = { date: string; size: number }
+
+const PROSE =
+  "prose prose-sm max-w-none dark:prose-invert prose-a:text-blue-600 " +
+  "hover:prose-a:underline dark:prose-a:text-blue-400"
+
+/** Parse a Server-Sent Events stream, yielding the joined `data:` text per event. */
+async function* readSse(body: ReadableStream<Uint8Array>): AsyncGenerator<string> {
+  const reader = body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ""
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+    let sep: number
+    while ((sep = buffer.indexOf("\n\n")) !== -1) {
+      const raw = buffer.slice(0, sep)
+      buffer = buffer.slice(sep + 2)
+      const data = raw
+        .split("\n")
+        .filter((l) => l.startsWith("data:"))
+        .map((l) => l.slice(5).replace(/^ /, ""))
+        .join("\n")
+      if (data) yield data
+    }
+  }
+}
+
+export function JournalScreen() {
+  const [dates, setDates] = useState<JournalDate[]>([])
+  const [selected, setSelected] = useState<string | null>(null)
+  const [content, setContent] = useState("")
+  const [entry, setEntry] = useState("")
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  const [question, setQuestion] = useState("")
+  const [answer, setAnswer] = useState("")
+  const [brainstorming, setBrainstorming] = useState(false)
+  const [chatError, setChatError] = useState<string | null>(null)
+
+  const loadDates = useCallback(async () => {
+    const res = await fetch("/api/journal", { cache: "no-store" })
+    if (!res.ok) return
+    const data = (await res.json()) as { dates: JournalDate[] }
+    setDates(data.dates)
+    return data.dates
+  }, [])
+
+  const loadEntry = useCallback(async (date: string) => {
+    setSelected(date)
+    const res = await fetch(`/api/journal/${date}`, { cache: "no-store" })
+    if (!res.ok) {
+      setContent("")
+      return
+    }
+    const data = (await res.json()) as { content: string }
+    setContent(data.content)
+  }, [])
+
+  useEffect(() => {
+    void loadDates()
+  }, [loadDates])
+
+  const save = useCallback(async () => {
+    const text = entry.trim()
+    if (!text || saving) return
+    setSaving(true)
+    setSaveError(null)
+    try {
+      const res = await fetch("/api/journal", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: text }),
+      })
+      if (!res.ok) {
+        const body = await res.text()
+        setSaveError(`Save failed (HTTP ${res.status}): ${body}`)
+        return
+      }
+      const { date } = (await res.json()) as { date: string }
+      setEntry("")
+      await loadDates()
+      await loadEntry(date)
+    } catch (e) {
+      setSaveError(String(e))
+    } finally {
+      setSaving(false)
+    }
+  }, [entry, saving, loadDates, loadEntry])
+
+  const brainstorm = useCallback(async () => {
+    const q = question.trim()
+    if (!q || brainstorming) return
+    setBrainstorming(true)
+    setChatError(null)
+    setAnswer("")
+    try {
+      const post = await fetch("/api/journal/chat", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ question: q }),
+      })
+      if (!post.ok) {
+        const body = await post.text()
+        setChatError(
+          post.status === 404
+            ? "No journal entries yet — record something first."
+            : `Brainstorm failed (HTTP ${post.status}): ${body}`,
+        )
+        return
+      }
+      const { job_id } = (await post.json()) as { job_id: string }
+      const stream = await fetch(`/api/chat/${job_id}/stream`, { cache: "no-store" })
+      if (!stream.ok || !stream.body) {
+        setChatError(`Stream failed (HTTP ${stream.status})`)
+        return
+      }
+      for await (const chunk of readSse(stream.body)) {
+        setAnswer((prev) => (prev ? `${prev}\n${chunk}` : chunk))
+      }
+    } catch (e) {
+      setChatError(String(e))
+    } finally {
+      setBrainstorming(false)
+    }
+  }, [question, brainstorming])
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[260px_1fr]">
+      {/* Left: date list */}
+      <aside className="flex flex-col gap-2">
+        <h3 className="text-sm font-semibold text-muted-foreground">Entries</h3>
+        {dates.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No entries yet.</p>
+        ) : (
+          <ul className="flex flex-col gap-1">
+            {dates.map((d) => (
+              <li key={d.date}>
+                <button
+                  type="button"
+                  onClick={() => void loadEntry(d.date)}
+                  className={cn(
+                    "w-full rounded-md px-3 py-2 text-left text-sm transition-colors",
+                    selected === d.date
+                      ? "bg-accent font-medium text-accent-foreground"
+                      : "hover:bg-accent/50",
+                  )}
+                >
+                  {d.date}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </aside>
+
+      {/* Right: record + view + brainstorm */}
+      <div className="flex flex-col gap-6">
+        <section className="flex flex-col gap-2 rounded-lg border bg-card p-4">
+          <h3 className="text-sm font-semibold">Record today</h3>
+          <textarea
+            value={entry}
+            onChange={(e) => setEntry(e.target.value)}
+            placeholder="What happened today? What are you thinking about?"
+            rows={5}
+            className="w-full resize-y rounded-md border bg-background p-3 text-sm"
+          />
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={() => void save()}
+              disabled={saving || entry.trim() === ""}
+              className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
+            >
+              {saving ? "Saving…" : "Save entry"}
+            </button>
+            {saveError && <span className="text-sm text-destructive">{saveError}</span>}
+          </div>
+        </section>
+
+        {selected && (
+          <section className="flex flex-col gap-2 rounded-lg border bg-card p-4">
+            <h3 className="text-sm font-semibold">{selected}</h3>
+            <div className={PROSE}>
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+            </div>
+          </section>
+        )}
+
+        <section className="flex flex-col gap-2 rounded-lg border bg-card p-4">
+          <h3 className="text-sm font-semibold">Brainstorm with Claude</h3>
+          <p className="text-xs text-muted-foreground">
+            Ask anything — Claude uses your recent journal entries as context.
+          </p>
+          <textarea
+            value={question}
+            onChange={(e) => setQuestion(e.target.value)}
+            placeholder="e.g. What should I focus on next based on this week?"
+            rows={3}
+            className="w-full resize-y rounded-md border bg-background p-3 text-sm"
+          />
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={() => void brainstorm()}
+              disabled={brainstorming || question.trim() === ""}
+              className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
+            >
+              {brainstorming ? "Thinking…" : "Brainstorm"}
+            </button>
+            {chatError && <span className="text-sm text-destructive">{chatError}</span>}
+          </div>
+          {answer && (
+            <div className={cn(PROSE, "mt-2 rounded-md border bg-background p-3")}>
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{answer}</ReactMarkdown>
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add **Journal** sidebar entry and `/journal` page
- Record daily entries (textarea + Save → `POST /api/journal`)
- Browse entries by date with Markdown rendering (`GET /api/journal`, `GET /api/journal/{date}`)
- Brainstorm panel that streams Claude's answer over recent entries (`POST /api/journal/chat` → `GET /api/chat/{id}/stream`)

This adds the UI for the journaling agent (#271) backend shipped in #272/#273.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx next lint` clean
- [x] `npx vitest run` — 160 passed

## Summary by Sourcery

Add a new Journal page to the web app for daily note-taking and AI-assisted brainstorming.

New Features:
- Introduce a Journal navigation entry and page under /journal in the main web app.
- Allow users to record daily journal entries that are saved via the journaling API and listed by date.
- Display selected journal entries with Markdown rendering, including GFM support.
- Add a brainstorming panel that streams Claude-powered responses based on recent journal entries.

Enhancements:
- Implement a reusable client-side JournalScreen layout that combines entry listing, recording, viewing, and brainstorming in a two-column UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Access journal entries organized by date within a dedicated Journal section
  * Save and edit daily journal entries with automatic persistence
  * Use "Brainstorm with Claude" to get AI-powered suggestions within journal entries
  * Navigate to Journal directly from the sidebar menu

<!-- end of auto-generated comment: release notes by coderabbit.ai -->