### PR TITLE
feat: add output data export (zip) under Config

### DIFF
--- a/apps/python/tests/test_api_export.py
+++ b/apps/python/tests/test_api_export.py
@@ -1,0 +1,66 @@
+"""Tests for /api/export — zip download of the output/ tree.
+
+Contract:
+- ``GET /api/export`` returns a 200 application/zip attachment.
+- The zip contains every file under output/ (paths kept relative to output/).
+- ``.DS_Store`` files and ``.sessions`` dirs are excluded.
+- Auth (Bearer) is required.
+"""
+import io
+import zipfile
+
+import pytest
+
+from web.routers import export as export_router
+
+
+@pytest.fixture
+def output_dir(tmp_path, monkeypatch):
+    """Point the export router at a tmp output tree with sample files."""
+    d = tmp_path / "output"
+    (d / "briefing").mkdir(parents=True)
+    (d / "briefing" / "briefing_2026-06-24.md").write_text("hi", encoding="utf-8")
+    (d / "journal").mkdir()
+    (d / "journal" / "2026-06-24.md").write_text("note", encoding="utf-8")
+    (d / "briefing" / ".sessions").mkdir()
+    (d / "briefing" / ".sessions" / "2026-06-24").write_text("uuid", encoding="utf-8")
+    (d / ".DS_Store").write_text("junk", encoding="utf-8")
+    monkeypatch.setattr(export_router, "OUTPUT_DIR", d)
+    return d
+
+
+async def test_requires_auth(async_client, output_dir):
+    response = await async_client.get("/api/export")
+    assert response.status_code == 401
+
+
+async def test_returns_zip_attachment(authed_client, output_dir):
+    response = await authed_client.get("/api/export")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/zip"
+    assert "attachment" in response.headers["content-disposition"]
+    assert ".zip" in response.headers["content-disposition"]
+
+
+async def test_zip_contains_output_files(authed_client, output_dir):
+    response = await authed_client.get("/api/export")
+    zf = zipfile.ZipFile(io.BytesIO(response.content))
+    names = set(zf.namelist())
+    assert "output/briefing/briefing_2026-06-24.md" in names
+    assert "output/journal/2026-06-24.md" in names
+
+
+async def test_zip_excludes_noise(authed_client, output_dir):
+    response = await authed_client.get("/api/export")
+    zf = zipfile.ZipFile(io.BytesIO(response.content))
+    names = set(zf.namelist())
+    assert not any(".DS_Store" in n for n in names)
+    assert not any(".sessions" in n for n in names)
+
+
+async def test_empty_output_returns_empty_zip(authed_client, tmp_path, monkeypatch):
+    monkeypatch.setattr(export_router, "OUTPUT_DIR", tmp_path / "nonexistent")
+    response = await authed_client.get("/api/export")
+    assert response.status_code == 200
+    zf = zipfile.ZipFile(io.BytesIO(response.content))
+    assert zf.namelist() == []

--- a/apps/python/web/app.py
+++ b/apps/python/web/app.py
@@ -7,6 +7,7 @@ from web.routers import (
     chat,
     config,
     credentials,
+    export,
     health,
     journal,
     run,
@@ -26,3 +27,4 @@ app.include_router(usage.router, prefix="/api")
 app.include_router(briefing.router, prefix="/api")
 app.include_router(archive.router, prefix="/api")
 app.include_router(journal.router, prefix="/api")
+app.include_router(export.router, prefix="/api")

--- a/apps/python/web/routers/export.py
+++ b/apps/python/web/routers/export.py
@@ -1,0 +1,52 @@
+"""GET /api/export — download the whole output/ tree as a single zip.
+
+Bundles ``apps/python/output`` (briefing, journal, eval, archive, ...) into an
+in-memory zip and streams it back as an attachment so the operator can move
+all generated data to another machine in one click. Noise that isn't user
+data is skipped: ``.DS_Store`` files and the ``.sessions`` dirs that hold
+internal claude session ids.
+"""
+import io
+import zipfile
+from datetime import datetime
+from pathlib import Path
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import StreamingResponse
+
+from web.auth import require_bearer
+
+router = APIRouter(dependencies=[Depends(require_bearer)])
+
+OUTPUT_DIR = Path(__file__).parents[2] / "output"
+
+# Names skipped anywhere in the tree: macOS cruft + internal session state.
+_EXCLUDED_NAMES = {".DS_Store", ".sessions"}
+
+
+def _build_zip(root: Path) -> bytes:
+    """Zip every file under ``root``, keeping paths relative to its parent."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        if root.exists():
+            for path in sorted(root.rglob("*")):
+                if not path.is_file():
+                    continue
+                # Skip if any path segment is excluded (covers .sessions dirs).
+                if _EXCLUDED_NAMES & set(path.relative_to(root).parts):
+                    continue
+                zf.write(path, arcname=path.relative_to(root.parent))
+    return buf.getvalue()
+
+
+@router.get("/export")
+def get_export() -> StreamingResponse:
+    """Return the output/ tree as a downloadable zip attachment."""
+    data = _build_zip(OUTPUT_DIR)
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    filename = f"output-export-{stamp}.zip"
+    return StreamingResponse(
+        io.BytesIO(data),
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/apps/web/components/OutputExportPanel.tsx
+++ b/apps/web/components/OutputExportPanel.tsx
@@ -42,7 +42,9 @@ export function OutputExportPanel() {
     a.href = url
     a.download = name
     a.click()
-    URL.revokeObjectURL(url)
+    // Defer revocation: some browsers handle the download asynchronously, so
+    // revoking the object URL synchronously can cancel a large download.
+    setTimeout(() => URL.revokeObjectURL(url), 0)
     setStatus("success")
   }
 

--- a/apps/web/components/OutputExportPanel.tsx
+++ b/apps/web/components/OutputExportPanel.tsx
@@ -1,0 +1,79 @@
+"use client"
+import { useState } from "react"
+
+import { Button } from "@/components/ui/button"
+
+type Status = "idle" | "busy" | "success" | "error"
+
+/** Parse the download filename out of a Content-Disposition header. */
+function filenameFrom(header: string | null, fallback: string): string {
+  const match = header?.match(/filename="?([^"]+)"?/)
+  return match?.[1] ?? fallback
+}
+
+export function OutputExportPanel() {
+  const [status, setStatus] = useState<Status>("idle")
+  const [error, setError] = useState<string | null>(null)
+  const busy = status === "busy"
+
+  const onExport = async () => {
+    setStatus("busy")
+    setError(null)
+    let res: Response
+    try {
+      res = await fetch("/api/export", { cache: "no-store" })
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Network error")
+      setStatus("error")
+      return
+    }
+    if (!res.ok) {
+      setError(`GET /api/export failed (HTTP ${res.status})`)
+      setStatus("error")
+      return
+    }
+    const blob = await res.blob()
+    const name = filenameFrom(
+      res.headers.get("content-disposition"),
+      "output-export.zip",
+    )
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement("a")
+    a.href = url
+    a.download = name
+    a.click()
+    URL.revokeObjectURL(url)
+    setStatus("success")
+  }
+
+  return (
+    <div className="space-y-2" data-testid="output-export-panel">
+      <p className="text-xs text-muted-foreground">
+        Download all output files (briefing, journal, eval…) as a zip for backup
+        or migration.
+      </p>
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={() => void onExport()}
+        disabled={busy}
+        data-testid="output-export"
+      >
+        {busy ? "Preparing…" : "Download output zip"}
+      </Button>
+      {status === "success" && (
+        <p
+          className="text-xs text-green-600 dark:text-green-400"
+          data-testid="output-export-success"
+        >
+          Downloaded
+        </p>
+      )}
+      {error && (
+        <p className="text-xs text-destructive" data-testid="output-export-error">
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/apps/web/components/Sidebar.tsx
+++ b/apps/web/components/Sidebar.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react"
 
 import { AppearancePanel } from "@/components/AppearancePanel"
 import { ConfigFilePanel } from "@/components/ConfigFilePanel"
+import { OutputExportPanel } from "@/components/OutputExportPanel"
 import { SidebarDisclosure } from "@/components/SidebarDisclosure"
 import { useJobState } from "@/lib/jobStore"
 import {
@@ -163,6 +164,13 @@ export function Sidebar() {
               testid="config-file-toggle"
             >
               <ConfigFilePanel />
+            </SidebarDisclosure>
+            <SidebarDisclosure
+              label="Export data"
+              icon="📦"
+              testid="output-export-toggle"
+            >
+              <OutputExportPanel />
             </SidebarDisclosure>
           </div>
         </SidebarDisclosure>


### PR DESCRIPTION
## Summary
- Add `GET /api/export` that bundles the whole `output/` tree (briefing, journal, eval, archive…) into a zip and streams it as a download — for backup / data migration
- Excludes noise: `.DS_Store` files and `.sessions` dirs (internal session ids)
- Add an **Export data** panel under sidebar Config with a download button

## Test plan
- [x] backend `pytest` — 634 passed (5 new in `test_api_export.py`)
- [x] frontend `tsc` / `next lint` clean, `vitest` — 160 passed

## Summary by Sourcery

Add a secured /api/export endpoint and UI panel to download the entire output directory as a zip archive for backup or migration.

New Features:
- Expose a GET /api/export API that streams a zip archive of the output directory, excluding internal and OS-specific noise files.
- Add an Export data panel in the Config sidebar that lets users download the output zip from the UI.

Tests:
- Add backend tests covering authentication, response headers, zip contents, exclusions, and empty output behavior for the /api/export endpoint.