### PR TITLE
feat(web): reusable resize component; resizable briefing list

### DIFF
--- a/apps/web/components/ResizeHandle.tsx
+++ b/apps/web/components/ResizeHandle.tsx
@@ -1,0 +1,44 @@
+"use client"
+import { cn } from "@/lib/utils"
+
+type Props = {
+  onPointerDown: (e: React.PointerEvent) => void
+  /** Which edge of the parent the handle sits on. Parent must be `relative`. */
+  edge?: "right" | "left"
+  className?: string
+  "data-testid"?: string
+}
+
+/**
+ * A thin vertical drag handle for resizing a panel. The hit area is wider
+ * (w-3) than the visible 1px line for easier grabbing. Place inside a
+ * `relative` container; pair with {@link useResizable}.
+ */
+export function ResizeHandle({
+  onPointerDown,
+  edge = "right",
+  className,
+  ...rest
+}: Props) {
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="Resize panel"
+      data-testid={rest["data-testid"]}
+      onPointerDown={onPointerDown}
+      className={cn(
+        "group absolute inset-y-0 z-10 w-3 cursor-col-resize bg-transparent",
+        edge === "left" ? "left-0" : "right-0",
+        className,
+      )}
+    >
+      <div
+        className={cn(
+          "pointer-events-none absolute inset-y-0 w-1 group-hover:bg-primary/50",
+          edge === "left" ? "left-0" : "right-0",
+        )}
+      />
+    </div>
+  )
+}

--- a/apps/web/components/ResizeHandle.tsx
+++ b/apps/web/components/ResizeHandle.tsx
@@ -5,6 +5,8 @@ type Props = {
   onPointerDown: (e: React.PointerEvent) => void
   /** Which edge of the parent the handle sits on. Parent must be `relative`. */
   edge?: "right" | "left"
+  /** Accessible label; override per usage (e.g. "Resize sidebar"). */
+  ariaLabel?: string
   className?: string
   "data-testid"?: string
 }
@@ -17,6 +19,7 @@ type Props = {
 export function ResizeHandle({
   onPointerDown,
   edge = "right",
+  ariaLabel = "Resize panel",
   className,
   ...rest
 }: Props) {
@@ -24,7 +27,7 @@ export function ResizeHandle({
     <div
       role="separator"
       aria-orientation="vertical"
-      aria-label="Resize panel"
+      aria-label={ariaLabel}
       data-testid={rest["data-testid"]}
       onPointerDown={onPointerDown}
       className={cn(

--- a/apps/web/components/Sidebar.tsx
+++ b/apps/web/components/Sidebar.tsx
@@ -182,6 +182,7 @@ export function Sidebar() {
       {!collapsed && (
         <ResizeHandle
           onPointerDown={onResizeStart}
+          ariaLabel="Resize sidebar"
           data-testid="sidebar-resizer"
         />
       )}

--- a/apps/web/components/Sidebar.tsx
+++ b/apps/web/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { useCallback, useEffect, useState } from "react"
 
+import { ResizeHandle } from "@/components/ResizeHandle"
 import { SettingsModal } from "@/components/settings/SettingsModal"
 import { useJobState } from "@/lib/jobStore"
 import {
@@ -70,7 +71,7 @@ export function Sidebar() {
   // CSS custom property on <html> (the same one the boot script restores)
   // and persisted to localStorage on release.
   const onResizeStart = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
+    (e: React.PointerEvent) => {
       e.preventDefault()
       const startX = e.clientX
       const root = document.documentElement
@@ -179,17 +180,10 @@ export function Sidebar() {
       </div>
       {/* Right-edge drag handle to resize the rail (hidden when collapsed). */}
       {!collapsed && (
-        <div
-          role="separator"
-          aria-orientation="vertical"
-          aria-label="Resize sidebar"
-          data-testid="sidebar-resizer"
+        <ResizeHandle
           onPointerDown={onResizeStart}
-          className="group absolute inset-y-0 right-0 w-3 cursor-col-resize bg-transparent"
-        >
-          {/* Visible 1px line; the wider parent is the hit area. */}
-          <div className="pointer-events-none absolute inset-y-0 right-0 w-1 group-hover:bg-primary/50" />
-        </div>
+          data-testid="sidebar-resizer"
+        />
       )}
     </aside>
   )

--- a/apps/web/components/screens/BriefingDashboard.tsx
+++ b/apps/web/components/screens/BriefingDashboard.tsx
@@ -179,6 +179,7 @@ export function BriefingDashboard() {
         {selected && !fullSize && (
           <ResizeHandle
             onPointerDown={startResize}
+            ariaLabel="Resize briefing list"
             data-testid="briefing-list-resizer"
           />
         )}

--- a/apps/web/components/screens/BriefingDashboard.tsx
+++ b/apps/web/components/screens/BriefingDashboard.tsx
@@ -6,8 +6,10 @@ import { BriefingPanel } from "@/components/briefing/BriefingPanel"
 import { BriefingRow } from "@/components/briefing/BriefingRow"
 import { BriefingSearch } from "@/components/briefing/BriefingSearch"
 import { ALL_TAB, BriefingTabs } from "@/components/briefing/BriefingTabs"
+import { ResizeHandle } from "@/components/ResizeHandle"
 import { BriefingFile, BriefingListResponse } from "@/lib/briefing-types"
 import { useBriefingData } from "@/lib/hooks/useBriefingData"
+import { useResizable } from "@/lib/hooks/useResizable"
 import { cn } from "@/lib/utils"
 
 function initialTab(): string {
@@ -28,6 +30,12 @@ export function BriefingDashboard() {
     close,
   } = useBriefingData()
   const [fullSize, setFullSize] = useState(false)
+  const { width: listWidth, startResize } = useResizable({
+    storageKey: "ai-agent:briefing-list-width:v1",
+    defaultWidth: 288, // matches the previous fixed w-72
+    minWidth: 200,
+    maxWidth: 560,
+  })
   const [tab, setTab] = useState<string>(initialTab)
   const [query, setQuery] = useState("")
   const [searchResults, setSearchResults] = useState<BriefingFile[] | null>(null)
@@ -110,12 +118,13 @@ export function BriefingDashboard() {
 
   return (
     <div data-testid="briefing-dashboard" className="flex h-full">
-      {/* Records list */}
+      {/* Records list (resizable when a file is open) */}
       <div
         data-testid="briefing-records-list"
+        style={selected && !fullSize ? { width: listWidth } : undefined}
         className={cn(
-          "flex-shrink-0 overflow-y-auto border-r transition-all",
-          selected && !fullSize ? "w-72" : "flex-1",
+          "relative flex-shrink-0 overflow-y-auto border-r",
+          !(selected && !fullSize) && "flex-1",
           fullSize && "hidden",
         )}
       >
@@ -166,6 +175,12 @@ export function BriefingDashboard() {
           >
             No matching briefings.
           </p>
+        )}
+        {selected && !fullSize && (
+          <ResizeHandle
+            onPointerDown={startResize}
+            data-testid="briefing-list-resizer"
+          />
         )}
       </div>
 

--- a/apps/web/components/settings/SettingsModal.tsx
+++ b/apps/web/components/settings/SettingsModal.tsx
@@ -1,9 +1,10 @@
 "use client"
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useState } from "react"
 
 import { AppearancePanel } from "@/components/AppearancePanel"
 import { ConfigFilePanel } from "@/components/ConfigFilePanel"
 import { OutputExportPanel } from "@/components/OutputExportPanel"
+import { ResizeHandle } from "@/components/ResizeHandle"
 import { UsageDashboard } from "@/components/screens/UsageDashboard"
 import {
   Dialog,
@@ -11,6 +12,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog"
+import { useResizable } from "@/lib/hooks/useResizable"
 import { cn } from "@/lib/utils"
 
 type Section = {
@@ -27,53 +29,17 @@ const SECTIONS: Section[] = [
   { key: "export", label: "Export data", icon: "📦", render: () => <OutputExportPanel /> },
 ]
 
-const NAV_WIDTH_KEY = "ai-agent:settings-nav-width:v1"
-const NAV_MIN_WIDTH = 140
-const NAV_MAX_WIDTH = 480
-const NAV_DEFAULT_WIDTH = 192 // matches the previous fixed w-48
-
 export function SettingsModal() {
   const [open, setOpen] = useState(false)
   const [active, setActive] = useState<string>(SECTIONS[0].key)
   const current = SECTIONS.find((s) => s.key === active) ?? SECTIONS[0]
 
-  const [navWidth, setNavWidth] = useState(NAV_DEFAULT_WIDTH)
-  const draggingRef = useRef(false)
-
-  // Restore the persisted nav width on mount (client-only to avoid SSR mismatch).
-  useEffect(() => {
-    const saved = Number(localStorage.getItem(NAV_WIDTH_KEY))
-    if (saved >= NAV_MIN_WIDTH && saved <= NAV_MAX_WIDTH) setNavWidth(saved)
-  }, [])
-
-  const clamp = (w: number) => Math.min(NAV_MAX_WIDTH, Math.max(NAV_MIN_WIDTH, w))
-
-  const onDragStart = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    e.preventDefault()
-    draggingRef.current = true
-    const startX = e.clientX
-    const startWidth = navWidth
-
-    const onMove = (ev: PointerEvent) => {
-      if (!draggingRef.current) return
-      setNavWidth(clamp(startWidth + (ev.clientX - startX)))
-    }
-    const onUp = () => {
-      draggingRef.current = false
-      window.removeEventListener("pointermove", onMove)
-      window.removeEventListener("pointerup", onUp)
-      setNavWidth((w) => {
-        try {
-          localStorage.setItem(NAV_WIDTH_KEY, String(w))
-        } catch {
-          // localStorage unavailable (private mode / quota); width still applies
-        }
-        return w
-      })
-    }
-    window.addEventListener("pointermove", onMove)
-    window.addEventListener("pointerup", onUp)
-  }, [navWidth])
+  const { width: navWidth, startResize } = useResizable({
+    storageKey: "ai-agent:settings-nav-width:v1",
+    defaultWidth: 192, // matches the previous fixed w-48
+    minWidth: 140,
+    maxWidth: 480,
+  })
 
   return (
     <Dialog
@@ -109,7 +75,7 @@ export function SettingsModal() {
           aria-orientation="vertical"
           aria-label="Settings sections"
           style={{ width: navWidth }}
-          className="flex shrink-0 flex-col gap-1 border-r bg-card p-3"
+          className="relative flex shrink-0 flex-col gap-1 border-r bg-card p-3"
         >
           <p className="px-2 pb-1 text-xs font-semibold uppercase text-muted-foreground">
             Settings
@@ -135,15 +101,11 @@ export function SettingsModal() {
               <span>{s.label}</span>
             </button>
           ))}
+          <ResizeHandle
+            onPointerDown={startResize}
+            data-testid="settings-nav-resizer"
+          />
         </div>
-        {/* Drag handle to resize the nav */}
-        <div
-          role="separator"
-          aria-orientation="vertical"
-          data-testid="settings-nav-resizer"
-          onPointerDown={onDragStart}
-          className="w-1 shrink-0 cursor-col-resize bg-border transition-colors hover:bg-primary/50"
-        />
         {/* Right: active section content */}
         <div
           role="tabpanel"

--- a/apps/web/components/settings/SettingsModal.tsx
+++ b/apps/web/components/settings/SettingsModal.tsx
@@ -103,6 +103,7 @@ export function SettingsModal() {
           ))}
           <ResizeHandle
             onPointerDown={startResize}
+            ariaLabel="Resize settings navigation"
             data-testid="settings-nav-resizer"
           />
         </div>

--- a/apps/web/lib/hooks/useResizable.ts
+++ b/apps/web/lib/hooks/useResizable.ts
@@ -33,8 +33,13 @@ export function useResizable({
 
   // Restore persisted width on mount (client-only to avoid SSR mismatch).
   useEffect(() => {
-    const saved = Number(localStorage.getItem(storageKey))
-    if (saved >= minWidth && saved <= maxWidth) setWidth(saved)
+    try {
+      const saved = Number(localStorage.getItem(storageKey))
+      if (saved >= minWidth && saved <= maxWidth) setWidth(saved)
+    } catch {
+      // localStorage may throw (Safari private mode / strict iframe policy);
+      // fall back to the default width.
+    }
   }, [storageKey, minWidth, maxWidth])
 
   const startResize = useCallback(

--- a/apps/web/lib/hooks/useResizable.ts
+++ b/apps/web/lib/hooks/useResizable.ts
@@ -1,0 +1,74 @@
+"use client"
+import { useCallback, useEffect, useState } from "react"
+
+type Options = {
+  /** localStorage key the width is persisted under. */
+  storageKey: string
+  defaultWidth: number
+  minWidth: number
+  maxWidth: number
+  /**
+   * Drag direction relative to the resized element:
+   * - "right": handle on the element's right edge (default), drag right = wider
+   * - "left":  handle on the element's left edge, drag left = wider
+   */
+  edge?: "right" | "left"
+}
+
+/**
+ * Reusable horizontal panel resizing. Tracks a pixel width in React state,
+ * restores it from localStorage on mount, and persists it when a drag ends.
+ *
+ * Returns the current `width` (apply via `style={{ width }}`) and a
+ * `startResize` pointer-down handler to wire onto a drag handle.
+ */
+export function useResizable({
+  storageKey,
+  defaultWidth,
+  minWidth,
+  maxWidth,
+  edge = "right",
+}: Options) {
+  const [width, setWidth] = useState(defaultWidth)
+
+  // Restore persisted width on mount (client-only to avoid SSR mismatch).
+  useEffect(() => {
+    const saved = Number(localStorage.getItem(storageKey))
+    if (saved >= minWidth && saved <= maxWidth) setWidth(saved)
+  }, [storageKey, minWidth, maxWidth])
+
+  const startResize = useCallback(
+    (e: React.PointerEvent) => {
+      e.preventDefault()
+      const startX = e.clientX
+      const startWidth = width
+      const dir = edge === "left" ? -1 : 1
+      const clamp = (w: number) => Math.min(maxWidth, Math.max(minWidth, w))
+
+      // AbortController removes every listener in one call, so a drag ended by
+      // pointercancel (OS gesture, context menu) can't leak listeners.
+      const controller = new AbortController()
+      const { signal } = controller
+      let next = startWidth
+
+      const onMove = (ev: PointerEvent) => {
+        next = clamp(startWidth + dir * (ev.clientX - startX))
+        setWidth(next)
+      }
+      const onEnd = () => {
+        controller.abort()
+        try {
+          localStorage.setItem(storageKey, String(next))
+        } catch {
+          // localStorage unavailable (private mode / quota); width still applies
+        }
+      }
+      window.addEventListener("pointermove", onMove, { signal })
+      window.addEventListener("pointerup", onEnd, { signal })
+      window.addEventListener("pointercancel", onEnd, { signal })
+    },
+    [width, storageKey, minWidth, maxWidth, edge],
+  )
+
+  return { width, startResize }
+}


### PR DESCRIPTION
## Summary
- Extract the drag-to-resize logic into a reusable **`useResizable`** hook + **`ResizeHandle`** component
- **Briefing**: the records-list / content split is now resizable by dragging the divider (width persisted, 200–560px)
- Refactor the existing **settings modal** nav and **main sidebar** handles to use the shared component (no behavior change)

## Notes
- `ResizeHandle` has a wide (w-3) transparent hit area with a 1px visible line; uses `AbortController` + `pointercancel` for clean listener teardown.
- The main sidebar keeps its CSS-var width (for pre-hydration no-flash) but now renders the shared `ResizeHandle`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx next lint` clean
- [x] `npx vitest run` — 163 passed (one unrelated flaky `briefing-dashboard` search test passes in isolation)

## Summary by Sourcery

Introduce a reusable horizontal resize hook and handle component and apply it across the web app panels.

New Features:
- Make the briefing dashboard records list panel horizontally resizable with a persisted width.

Enhancements:
- Extract shared drag-to-resize logic into a generic useResizable hook and ResizeHandle UI component.
- Refactor the settings modal navigation panel to use the shared resize hook and handle while preserving existing behavior.
- Refine the main sidebar resize handle to use the shared ResizeHandle component without changing its resize semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable panel resize handle for drag-based resizing in the app.
  * Sidebar, settings navigation, and briefing records panels can now be resized more smoothly, with sizes remembered between sessions.
* **Bug Fixes**
  * Improved drag behavior and accessibility for resize controls.
  * Resizing now stays within reasonable minimum and maximum widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->