### PR TITLE
feat(web): journal brainstorm chat flow + auto-save

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ config/briefing.json   # Portfolio, watch sectors, geopolitical risks
 **Key design decisions**
 
 - No NewsAPI — Claude Code CLI's built-in WebSearch handles real-time search
-- No Anthropic API billing — reuses Claude Code CLI's OAuth authentication
+- No per-token Anthropic API billing — runs on the Claude Code CLI OAuth session, which requires an active paid Claude subscription (Pro/Max); the free plan cannot run this
 - Geopolitical → stock causality is baked into every daily output
 - Degraded mode — if the sector sweep fails, the main analysis is still delivered
 

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -143,6 +143,9 @@ export function JournalScreen() {
     setChatError(null)
     setTurns((prev) => [...prev, { question: q, answer: "" }])
     setQuestion("")
+    // Remove the pending placeholder turn so a failed/empty stream doesn't
+    // leave a permanent "Thinking…" bubble in the transcript.
+    const dropPendingTurn = () => setTurns((prev) => prev.slice(0, -1))
     try {
       const post = await fetch("/api/journal/chat", {
         method: "POST",
@@ -156,12 +159,14 @@ export function JournalScreen() {
             ? "No journal entries yet — record something first."
             : `Brainstorm failed (HTTP ${post.status}): ${body}`,
         )
+        dropPendingTurn()
         return
       }
       const { job_id } = (await post.json()) as { job_id: string }
       const stream = await fetch(`/api/chat/${job_id}/stream`, { cache: "no-store" })
       if (!stream.ok || !stream.body) {
         setChatError(`Stream failed (HTTP ${stream.status})`)
+        dropPendingTurn()
         return
       }
       let answer = ""
@@ -169,25 +174,28 @@ export function JournalScreen() {
         answer = answer ? `${answer}\n${chunk}` : chunk
         appendToLastAnswer(chunk)
       }
-      // Auto-save the completed Q&A turn to today's journal file.
-      if (answer) {
-        const content = `### Brainstorm\n\n**Q:** ${q}\n\n${answer}`
-        const res = await fetch("/api/journal", {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ content }),
-        })
-        if (!res.ok) {
-          const body = await res.text()
-          setChatError(`Auto-save failed (HTTP ${res.status}): ${body}`)
-          return
-        }
-        const { date } = (await res.json()) as { date: string }
-        await loadDates()
-        // Use the live selection (ref) so switching dates mid-stream doesn't
-        // yank the view back to a stale selection.
-        if (selectedRef.current === date) await loadEntry(date)
+      if (!answer) {
+        setChatError("Brainstorm returned an empty answer.")
+        dropPendingTurn()
+        return
       }
+      // Auto-save the completed Q&A turn to today's journal file.
+      const content = `### Brainstorm\n\n**Q:** ${q}\n\n${answer}`
+      const res = await fetch("/api/journal", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content }),
+      })
+      if (!res.ok) {
+        const body = await res.text()
+        setChatError(`Auto-save failed (HTTP ${res.status}): ${body}`)
+        return
+      }
+      const { date } = (await res.json()) as { date: string }
+      await loadDates()
+      // Use the live selection (ref) so switching dates mid-stream doesn't
+      // yank the view back to a stale selection.
+      if (selectedRef.current === date) await loadEntry(date)
     } catch (e) {
       setChatError(String(e))
     } finally {

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -3,8 +3,10 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 
+import { cn } from "@/lib/utils"
+
 type JournalDate = { date: string; size: number }
-type Turn = { question: string; answer: string; saved: boolean }
+type Turn = { question: string; answer: string }
 
 const PROSE =
   "prose prose-sm max-w-none dark:prose-invert prose-a:text-blue-600 " +
@@ -133,7 +135,7 @@ export function JournalScreen() {
     if (!q || brainstorming) return
     setBrainstorming(true)
     setChatError(null)
-    setTurns((prev) => [...prev, { question: q, answer: "", saved: false }])
+    setTurns((prev) => [...prev, { question: q, answer: "" }])
     setQuestion("")
     try {
       const post = await fetch("/api/journal/chat", {
@@ -156,40 +158,31 @@ export function JournalScreen() {
         setChatError(`Stream failed (HTTP ${stream.status})`)
         return
       }
+      let answer = ""
       for await (const chunk of readSse(stream.body)) {
+        answer = answer ? `${answer}\n${chunk}` : chunk
         appendToLastAnswer(chunk)
+      }
+      // Auto-save the completed Q&A turn to today's journal file.
+      if (answer) {
+        const content = `### Brainstorm\n\n**Q:** ${q}\n\n${answer}`
+        const res = await fetch("/api/journal", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ content }),
+        })
+        if (res.ok) {
+          const { date } = (await res.json()) as { date: string }
+          await loadDates()
+          if (selected === date) await loadEntry(date)
+        }
       }
     } catch (e) {
       setChatError(String(e))
     } finally {
       setBrainstorming(false)
     }
-  }, [question, brainstorming, appendToLastAnswer])
-
-  // Persist a brainstorm turn to today's journal file via POST /api/journal.
-  const saveTurn = useCallback(
-    async (index: number) => {
-      const turn = turns[index]
-      if (!turn || turn.saved || !turn.answer) return
-      const content = `### Brainstorm\n\n**Q:** ${turn.question}\n\n${turn.answer}`
-      const res = await fetch("/api/journal", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ content }),
-      })
-      if (!res.ok) {
-        setChatError(`Save to journal failed (HTTP ${res.status})`)
-        return
-      }
-      setTurns((prev) =>
-        prev.map((t, i) => (i === index ? { ...t, saved: true } : t)),
-      )
-      const { date } = (await res.json()) as { date: string }
-      await loadDates()
-      if (selected === date) await loadEntry(date)
-    },
-    [turns, loadDates, loadEntry, selected],
-  )
+  }, [question, brainstorming, appendToLastAnswer, loadDates, loadEntry, selected])
 
   return (
     <div className="flex flex-col gap-6">
@@ -254,55 +247,63 @@ export function JournalScreen() {
           </section>
         )}
 
-        <section className="flex flex-col gap-2 rounded-lg border bg-card p-4">
-          <h3 className="text-sm font-semibold">Brainstorm with Claude</h3>
-          <p className="text-xs text-muted-foreground">
-            Ask anything — Claude uses your recent journal entries as context.
-          </p>
-          <textarea
-            value={question}
-            onChange={(e) => setQuestion(e.target.value)}
-            placeholder="e.g. What should I focus on next based on this week?"
-            rows={3}
-            className="w-full resize-y rounded-md border bg-background p-3 text-sm"
-          />
-          <div className="flex items-center gap-3">
-            <button
-              type="button"
-              onClick={() => void brainstorm()}
-              disabled={brainstorming || question.trim() === ""}
-              className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
-            >
-              {brainstorming ? "Thinking…" : "Brainstorm"}
-            </button>
-            {chatError && <span className="text-sm text-destructive">{chatError}</span>}
+        <section className="flex flex-col gap-3 rounded-lg border bg-card p-4">
+          <div>
+            <h3 className="text-sm font-semibold">Brainstorm with Claude</h3>
+            <p className="text-xs text-muted-foreground">
+              Ask anything — Claude uses your recent journal entries as context.
+              Answers are saved to today&apos;s journal automatically.
+            </p>
           </div>
+
+          {/* Conversation transcript (oldest first, like a chat thread). */}
           {turns.length > 0 && (
-            <div className="mt-2 flex flex-col gap-4">
+            <div className="flex flex-col gap-4">
               {turns.map((turn, i) => (
-                <div key={i} className="flex flex-col gap-2 rounded-md border bg-background p-3">
-                  <p className="text-sm font-medium text-muted-foreground">
-                    Q: {turn.question}
-                  </p>
-                  <div className={PROSE}>
-                    <ReactMarkdown remarkPlugins={[remarkGfm]}>{turn.answer}</ReactMarkdown>
+                <div key={i} className="flex flex-col gap-2">
+                  <div className="self-end rounded-2xl rounded-br-sm bg-primary px-4 py-2 text-sm text-primary-foreground">
+                    {turn.question}
                   </div>
-                  {turn.answer && (
-                    <div>
-                      <button
-                        type="button"
-                        onClick={() => void saveTurn(i)}
-                        disabled={turn.saved}
-                        className="rounded-md border px-3 py-1 text-xs transition-colors hover:bg-accent/50 disabled:opacity-50"
-                      >
-                        {turn.saved ? "Saved to journal ✓" : "Save to journal"}
-                      </button>
-                    </div>
-                  )}
+                  <div className={cn(PROSE, "rounded-2xl rounded-bl-sm border bg-background px-4 py-2")}>
+                    {turn.answer ? (
+                      <ReactMarkdown remarkPlugins={[remarkGfm]}>{turn.answer}</ReactMarkdown>
+                    ) : (
+                      <span className="text-sm text-muted-foreground">Thinking…</span>
+                    )}
+                  </div>
                 </div>
               ))}
             </div>
           )}
+
+          {/* Composer pinned below the transcript, so follow-ups read top-down. */}
+          <div className="flex flex-col gap-2">
+            <textarea
+              value={question}
+              onChange={(e) => setQuestion(e.target.value)}
+              onKeyDown={(e) => {
+                // Enter sends; Shift+Enter inserts a newline.
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault()
+                  void brainstorm()
+                }
+              }}
+              placeholder="e.g. What should I focus on next based on this week?"
+              rows={3}
+              className="w-full resize-y rounded-md border bg-background p-3 text-sm"
+            />
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={() => void brainstorm()}
+                disabled={brainstorming || question.trim() === ""}
+                className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
+              >
+                {brainstorming ? "Thinking…" : "Brainstorm"}
+              </button>
+              {chatError && <span className="text-sm text-destructive">{chatError}</span>}
+            </div>
+          </div>
         </section>
       </div>
     </div>

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -46,6 +46,12 @@ export function JournalScreen() {
   const [dates, setDates] = useState<JournalDate[]>([])
   const [datesError, setDatesError] = useState<string | null>(null)
   const [selected, setSelected] = useState<string | null>(null)
+  // Mirror of `selected` so async callbacks (brainstorm streaming) read the
+  // live selection instead of the value captured when they started.
+  const selectedRef = useRef<string | null>(null)
+  useEffect(() => {
+    selectedRef.current = selected
+  }, [selected])
   const [content, setContent] = useState("")
   // Monotonic id so a slow earlier loadEntry can't overwrite a newer selection.
   const entryReqSeq = useRef(0)
@@ -171,18 +177,23 @@ export function JournalScreen() {
           headers: { "content-type": "application/json" },
           body: JSON.stringify({ content }),
         })
-        if (res.ok) {
-          const { date } = (await res.json()) as { date: string }
-          await loadDates()
-          if (selected === date) await loadEntry(date)
+        if (!res.ok) {
+          const body = await res.text()
+          setChatError(`Auto-save failed (HTTP ${res.status}): ${body}`)
+          return
         }
+        const { date } = (await res.json()) as { date: string }
+        await loadDates()
+        // Use the live selection (ref) so switching dates mid-stream doesn't
+        // yank the view back to a stale selection.
+        if (selectedRef.current === date) await loadEntry(date)
       }
     } catch (e) {
       setChatError(String(e))
     } finally {
       setBrainstorming(false)
     }
-  }, [question, brainstorming, appendToLastAnswer, loadDates, loadEntry, selected])
+  }, [question, brainstorming, appendToLastAnswer, loadDates, loadEntry])
 
   return (
     <div className="flex flex-col gap-6">
@@ -282,8 +293,13 @@ export function JournalScreen() {
               value={question}
               onChange={(e) => setQuestion(e.target.value)}
               onKeyDown={(e) => {
-                // Enter sends; Shift+Enter inserts a newline.
-                if (e.key === "Enter" && !e.shiftKey) {
+                // Enter sends; Shift+Enter inserts a newline. Ignore Enter
+                // while an IME is composing (Japanese/CJK candidate confirm).
+                if (
+                  e.key === "Enter" &&
+                  !e.shiftKey &&
+                  !e.nativeEvent.isComposing
+                ) {
                   e.preventDefault()
                   void brainstorm()
                 }


### PR DESCRIPTION
## Summary
- Restructure the journal brainstorm into a **chat flow**: the Q&A transcript renders above a composer pinned at the bottom, so 2nd+ turns read top-down naturally (previously the input sat above the answers).
- **Enter** sends; **Shift+Enter** inserts a newline.
- **Auto-save**: each completed answer is appended to today's journal automatically; removed the manual "Save to journal" button (it was the only persistence before, which was unintuitive).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx next lint` clean
- [x] `npx vitest run` — 163 passed

## Summary by Sourcery

Restructure the journal brainstorm feature into a chat-style experience with automatic persistence of answers into the daily journal.

New Features:
- Display journal brainstorm interactions as a chat-like transcript with messages ordered top-down.
- Support sending brainstorm questions with Enter and inserting newlines with Shift+Enter.
- Automatically append each completed brainstorm Q&A turn to today’s journal entry without a separate save action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an auto-saving chat flow for “Brainstorm with Claude,” saving completed results to today’s journal automatically.
  * Redesigned the brainstorm experience as a chat transcript with pinned composer input and markdown-formatted answers.

* **Bug Fixes**
  * Improved SSE streaming so responses render progressively as they’re generated.
  * Prevented “Thinking…” placeholders from persisting on failures or empty results.
  * Updated input behavior to send on Enter and use Shift+Enter for new lines, removing the separate per-turn save action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->