### PR TITLE
feat: log Claude usage for chat and journal turns

### DIFF
--- a/apps/python/tests/test_api_chat.py
+++ b/apps/python/tests/test_api_chat.py
@@ -14,6 +14,7 @@ which makes the GET-stream assertions deterministic without sleeps.
 """
 import asyncio
 import io
+import json
 import time
 from unittest.mock import MagicMock
 
@@ -22,6 +23,38 @@ import pytest
 from src import chat_job_store, credentials, state as state_mod
 
 pytestmark = pytest.mark.usefixtures("isolated_state")
+
+
+def _delta_line(text: str) -> bytes:
+    """Build one --output-format stream-json line carrying an assistant
+    ``text_delta`` (the user-facing output the SSE stream surfaces)."""
+    return (
+        json.dumps(
+            {
+                "type": "stream_event",
+                "event": {
+                    "type": "content_block_delta",
+                    "delta": {"type": "text_delta", "text": text},
+                },
+            }
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _result_line(
+    *, usage: dict | None = None, cost_usd: float | None = None,
+    duration_ms: int | None = None, result: str = "",
+) -> bytes:
+    """Build the terminal stream-json ``result`` record (carries usage)."""
+    rec: dict = {"type": "result", "subtype": "success", "result": result}
+    if usage is not None:
+        rec["usage"] = usage
+    if cost_usd is not None:
+        rec["total_cost_usd"] = cost_usd
+    if duration_ms is not None:
+        rec["duration_ms"] = duration_ms
+    return (json.dumps(rec) + "\n").encode("utf-8")
 
 
 @pytest.fixture(autouse=True)
@@ -276,7 +309,7 @@ async def test_chat_subprocess_env_includes_keychain_key_in_api_mode(
 async def test_chat_stream_returns_sse_content_type(
     authed_client, briefing_setup, monkeypatch
 ):
-    factory = _make_popen(stdout_lines=[b"hello\n"])
+    factory = _make_popen(stdout_lines=[_delta_line("hello"), _result_line()])
     monkeypatch.setattr("web.routers.chat.subprocess.Popen", factory)
 
     _, _ = await _post_and_drain_stream(
@@ -292,7 +325,9 @@ async def test_chat_stream_returns_sse_content_type(
 async def test_chat_stream_replays_stdout_lines_as_data_events(
     authed_client, briefing_setup, monkeypatch
 ):
-    factory = _make_popen(stdout_lines=[b"line1\n", b"line2\n", b"line3\n"])
+    factory = _make_popen(
+        stdout_lines=[_delta_line("line1\nline2\nline3"), _result_line()]
+    )
     monkeypatch.setattr("web.routers.chat.subprocess.Popen", factory)
 
     _, body = await _post_and_drain_stream(
@@ -304,13 +339,66 @@ async def test_chat_stream_replays_stdout_lines_as_data_events(
     assert "data: line3\n\n" in body
 
 
+async def test_chat_cmd_includes_stream_json_flags(
+    authed_client, briefing_setup, monkeypatch
+):
+    """The chat subprocess must request stream-json output so usage (token
+    counts) is captured, while keeping incremental partial-message streaming."""
+    factory = _make_popen()
+    monkeypatch.setattr("web.routers.chat.subprocess.Popen", factory)
+
+    await authed_client.post(
+        "/api/chat", json={"date": "2026-05-30", "question": "Q?"}
+    )
+
+    cmd, _ = factory.calls[0]
+    assert "stream-json" in cmd
+    assert "--verbose" in cmd
+    assert "--include-partial-messages" in cmd
+
+
+async def test_chat_logs_usage_with_chat_label(
+    authed_client, briefing_setup, monkeypatch
+):
+    """A completed chat turn records a usage-log entry labeled ``chat`` with the
+    token counts / cost from the stream-json ``result`` record."""
+    captured: list[dict] = []
+    monkeypatch.setattr(
+        "web.routers.chat.log_usage", lambda **kw: captured.append(kw)
+    )
+    usage = {
+        "input_tokens": 10,
+        "output_tokens": 20,
+        "cache_read_input_tokens": 5,
+        "cache_creation_input_tokens": 3,
+    }
+    factory = _make_popen(
+        stdout_lines=[
+            _delta_line("the answer"),
+            _result_line(usage=usage, cost_usd=0.012, duration_ms=1234),
+        ]
+    )
+    monkeypatch.setattr("web.routers.chat.subprocess.Popen", factory)
+
+    _, body = await _post_and_drain_stream(
+        authed_client, {"date": "2026-05-30", "question": "Q?"}
+    )
+
+    assert "data: the answer\n\n" in body
+    assert len(captured) == 1
+    assert captured[0]["label"] == "chat"
+    assert captured[0]["usage"]["output_tokens"] == 20
+    assert captured[0]["cost_usd"] == 0.012
+    assert captured[0]["duration_ms"] == 1234
+
+
 async def test_chat_stream_supports_concurrent_attaches(
     authed_client, briefing_setup, monkeypatch
 ):
     """Two simultaneous GET streams against the same job both see the full
     transcript. Guards the snapshot path against deque-mutation races and
     confirms a second attach isn't starved by the first."""
-    factory = _make_popen(stdout_lines=[b"x\n", b"y\n"])
+    factory = _make_popen(stdout_lines=[_delta_line("x\ny"), _result_line()])
     monkeypatch.setattr("web.routers.chat.subprocess.Popen", factory)
 
     post = await authed_client.post(
@@ -366,7 +454,7 @@ async def test_chat_stream_can_be_reattached_to_replay_buffer(
     """Survives a client disconnect: a second GET against the same job_id
     sees every event from the start. This is the core #112 / #126 win —
     a tab switch or page reload no longer drops the in-flight answer."""
-    factory = _make_popen(stdout_lines=[b"a\n", b"b\n"])
+    factory = _make_popen(stdout_lines=[_delta_line("a\nb"), _result_line()])
     monkeypatch.setattr("web.routers.chat.subprocess.Popen", factory)
 
     job_id, first = await _post_and_drain_stream(
@@ -390,8 +478,14 @@ async def test_get_chat_stream_404_when_job_unknown(authed_client, briefing_setu
 async def test_chat_stream_strips_trailing_cr_from_stdout_lines(
     authed_client, briefing_setup, monkeypatch
 ):
-    """Windows-style \\r\\n line endings must not leak into the SSE event."""
-    factory = _make_popen(stdout_lines=[b"hello world\r\n", b"line2\r\n"])
+    """Windows-style \\r\\n JSON-line endings must not leak into the SSE event."""
+    # Terminate each stream-json line with \r\n to mimic a Windows pipe.
+    factory = _make_popen(
+        stdout_lines=[
+            _delta_line("hello world\nline2").rstrip(b"\n") + b"\r\n",
+            _result_line(),
+        ]
+    )
     monkeypatch.setattr("web.routers.chat.subprocess.Popen", factory)
 
     _, body = await _post_and_drain_stream(

--- a/apps/python/tests/test_api_journal_chat.py
+++ b/apps/python/tests/test_api_journal_chat.py
@@ -205,8 +205,10 @@ async def test_journal_logs_usage_with_journal_label(
 
     post = await authed_client.post("/api/journal/chat", json={"question": "q"})
     job_id = post.json()["job_id"]
-    await authed_client.get(f"/api/chat/{job_id}/stream")
+    stream = await authed_client.get(f"/api/chat/{job_id}/stream")
 
+    # Verify streaming still delivers assistant text even when usage logging is active.
+    assert "an idea" in stream.text
     assert len(captured) == 1
     assert captured[0]["label"] == "journal"
     assert captured[0]["usage"]["output_tokens"] == 11

--- a/apps/python/tests/test_api_journal_chat.py
+++ b/apps/python/tests/test_api_journal_chat.py
@@ -11,12 +11,35 @@ Mirrors test_api_chat.py: in test mode the BackgroundTask runs
 synchronously, so the FakePopen has completed by the time POST returns.
 """
 import io
+import json
 
 import pytest
 
 from src import chat_job_store, journal_store
 
 pytestmark = pytest.mark.usefixtures("isolated_state")
+
+
+def _delta_line(text: str) -> bytes:
+    return (
+        json.dumps(
+            {
+                "type": "stream_event",
+                "event": {
+                    "type": "content_block_delta",
+                    "delta": {"type": "text_delta", "text": text},
+                },
+            }
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _result_line(*, usage: dict | None = None, result: str = "") -> bytes:
+    rec: dict = {"type": "result", "subtype": "success", "result": result}
+    if usage is not None:
+        rec["usage"] = usage
+    return (json.dumps(rec) + "\n").encode("utf-8")
 
 
 @pytest.fixture(autouse=True)
@@ -154,7 +177,9 @@ async def test_context_capped_at_max_chars(authed_client, journal_dir, monkeypat
 
 
 async def test_stream_reuses_chat_endpoint(authed_client, journal_dir, monkeypatch):
-    factory = _make_popen(stdout_lines=[b"Brainstorm idea\n"])
+    factory = _make_popen(
+        stdout_lines=[_delta_line("Brainstorm idea"), _result_line()]
+    )
     monkeypatch.setattr("web.routers.chat.subprocess.Popen", factory)
 
     post = await authed_client.post("/api/journal/chat", json={"question": "q"})
@@ -162,3 +187,26 @@ async def test_stream_reuses_chat_endpoint(authed_client, journal_dir, monkeypat
     stream = await authed_client.get(f"/api/chat/{job_id}/stream")
     assert stream.status_code == 200
     assert "Brainstorm idea" in stream.text
+
+
+async def test_journal_logs_usage_with_journal_label(
+    authed_client, journal_dir, monkeypatch
+):
+    """A journal brainstorm turn records a usage-log entry labeled ``journal``."""
+    captured: list[dict] = []
+    monkeypatch.setattr(
+        "web.routers.chat.log_usage", lambda **kw: captured.append(kw)
+    )
+    usage = {"input_tokens": 7, "output_tokens": 11}
+    factory = _make_popen(
+        stdout_lines=[_delta_line("an idea"), _result_line(usage=usage)]
+    )
+    monkeypatch.setattr("web.routers.chat.subprocess.Popen", factory)
+
+    post = await authed_client.post("/api/journal/chat", json={"question": "q"})
+    job_id = post.json()["job_id"]
+    await authed_client.get(f"/api/chat/{job_id}/stream")
+
+    assert len(captured) == 1
+    assert captured[0]["label"] == "journal"
+    assert captured[0]["usage"]["output_tokens"] == 11

--- a/apps/python/web/routers/chat.py
+++ b/apps/python/web/routers/chat.py
@@ -160,6 +160,7 @@ def _consume_stream_line(line: str, state: _StreamState) -> list[str]:
     try:
         obj = json.loads(line)
     except json.JSONDecodeError:
+        logger.debug("stream-json: non-JSON line (truncated): %.120s", line)
         return []
 
     obj_type = obj.get("type")
@@ -182,7 +183,12 @@ def _consume_stream_line(line: str, state: _StreamState) -> list[str]:
         if not state.saw_text and not state.text_buf:
             result_text = obj.get("result")
             if isinstance(result_text, str):
-                state.text_buf = result_text
+                # Split on newlines so multi-line results are line-buffered the
+                # same way text_delta output is: all complete lines go directly
+                # to the caller, the final partial fragment stays in text_buf.
+                parts = result_text.split("\n")
+                state.text_buf = parts.pop()
+                return parts
     return []
 
 
@@ -239,14 +245,17 @@ def _run_chat_job(
         # Flush the final partial line (a text block with no trailing newline).
         if state.text_buf:
             chat_job_store.append_event(job_id, _sse_event(state.text_buf))
-        # Record token usage for this turn (best-effort; never fails the job).
+        # Record token usage for this turn (best-effort; must never fail the job).
         if state.usage is not None:
-            log_usage(
-                label=label,
-                usage=state.usage,
-                cost_usd=state.cost_usd,
-                duration_ms=state.duration_ms,
-            )
+            try:
+                log_usage(
+                    label=label,
+                    usage=state.usage,
+                    cost_usd=state.cost_usd,
+                    duration_ms=state.duration_ms,
+                )
+            except Exception:  # noqa: BLE001
+                logger.warning("failed to record usage log [%s]", label, exc_info=True)
 
         if proc.returncode != 0:
             stderr = b"".join(stderr_chunks).decode("utf-8", errors="replace")
@@ -330,11 +339,7 @@ def post_chat(body: ChatBody, background_tasks: BackgroundTasks) -> ChatPostResp
         raise HTTPException(status_code=404, detail=f"no briefing for {body.date}")
 
     SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
-    cmd = (
-        build_cmd(body.date, briefing_file, session_file)
-        + ["-p", body.question]
-        + CHAT_STREAM_FLAGS
-    )
+    cmd = [*build_cmd(body.date, briefing_file, session_file), "-p", body.question, *CHAT_STREAM_FLAGS]
     env = build_env(auth_mode=state_mod.read_state().auth_mode)
 
     job = chat_job_store.create_job()
@@ -400,11 +405,7 @@ def post_journal_chat(
     sessions_dir.mkdir(parents=True, exist_ok=True)
     session_file = sessions_dir / today
 
-    cmd = (
-        build_journal_cmd(today, context, session_file)
-        + ["-p", body.question]
-        + CHAT_STREAM_FLAGS
-    )
+    cmd = [*build_journal_cmd(today, context, session_file), "-p", body.question, *CHAT_STREAM_FLAGS]
     env = build_env(auth_mode=state_mod.read_state().auth_mode)
 
     job = chat_job_store.create_job()

--- a/apps/python/web/routers/chat.py
+++ b/apps/python/web/routers/chat.py
@@ -66,6 +66,7 @@ from src import state as state_mod
 from src.chat_session import build_cmd, build_journal_cmd
 from src.claude_runner import build_env
 from src.logger import get_logger
+from src.usage_logger import log_usage
 from web.auth import require_bearer
 
 logger = get_logger(__name__)
@@ -90,6 +91,17 @@ CHAT_JOB_GC_GRACE_SEC = 120.0
 # events on a running job. Small enough to feel live, large enough not
 # to spin a CPU per attached client.
 _TAIL_POLL_INTERVAL_SEC = 0.05
+
+# --output-format stream-json lets us capture the per-call ``usage`` record
+# (token counts + cost) that plain-text output discards, so chat/journal turns
+# can be surfaced in the usage dashboard. ``--verbose`` is required by the CLI
+# for stream-json under ``-p``; ``--include-partial-messages`` preserves the
+# incremental (line-by-line) streaming the SSE client already expects.
+CHAT_STREAM_FLAGS = [
+    "--output-format", "stream-json",
+    "--verbose",
+    "--include-partial-messages",
+]
 
 router = APIRouter(dependencies=[Depends(require_bearer)])
 
@@ -119,11 +131,67 @@ def _sse_event(content: str, event: str | None = None) -> bytes:
     return ("\n".join(out) + "\n\n").encode("utf-8")
 
 
+class _StreamState:
+    """Accumulator for parsing a ``--output-format stream-json`` stream.
+
+    Buffers partial assistant text into whole lines (so the SSE client's
+    join-by-newline contract is preserved) and captures the final ``usage``
+    record (token counts, cost, duration) for usage logging.
+    """
+
+    def __init__(self) -> None:
+        self.text_buf = ""
+        self.saw_text = False
+        self.usage: dict | None = None
+        self.cost_usd: float | None = None
+        self.duration_ms: int | None = None
+
+
+def _consume_stream_line(line: str, state: _StreamState) -> list[str]:
+    """Parse one stream-json line, returning newly-completed text lines.
+
+    Only user-facing assistant text (``text_delta``) is surfaced — thinking
+    deltas, hook/system events, and tool use are ignored so the streamed
+    output matches the pre-stream-json plain-text behavior. The final
+    ``result`` record's usage is stashed on ``state``; if partial-message
+    deltas never produced text (older CLI), the result text is used as a
+    fallback so the answer is never dropped.
+    """
+    try:
+        obj = json.loads(line)
+    except json.JSONDecodeError:
+        return []
+
+    obj_type = obj.get("type")
+    if obj_type == "stream_event":
+        event = obj.get("event") or {}
+        if event.get("type") == "content_block_delta":
+            delta = event.get("delta") or {}
+            if delta.get("type") == "text_delta":
+                state.saw_text = True
+                state.text_buf += delta.get("text", "")
+                parts = state.text_buf.split("\n")
+                state.text_buf = parts.pop()
+                return parts
+    elif obj_type == "result":
+        usage = obj.get("usage")
+        if isinstance(usage, dict):
+            state.usage = usage
+            state.cost_usd = obj.get("total_cost_usd")
+            state.duration_ms = obj.get("duration_ms")
+        if not state.saw_text and not state.text_buf:
+            result_text = obj.get("result")
+            if isinstance(result_text, str):
+                state.text_buf = result_text
+    return []
+
+
 def _run_chat_job(
     job_id: str,
     cmd: list[str],
     session_file: Path,
     env: dict[str, str],
+    label: str,
 ) -> None:
     """Background task: drive the claude subprocess to completion and
     append each stdout line into the job's replay buffer.
@@ -154,15 +222,31 @@ def _run_chat_job(
         stderr_thread = threading.Thread(target=_drain_stderr, daemon=True)
         stderr_thread.start()
 
+        state = _StreamState()
         try:
             assert proc.stdout is not None
             for line_bytes in proc.stdout:
                 line = line_bytes.decode("utf-8", errors="replace").rstrip("\r\n")
-                chat_job_store.append_event(job_id, _sse_event(line))
+                if not line:
+                    continue
+                for text_line in _consume_stream_line(line, state):
+                    chat_job_store.append_event(job_id, _sse_event(text_line))
         finally:
             proc.wait()
             stderr_thread.join(timeout=2)
             chat_job_store.detach_process(job_id)
+
+        # Flush the final partial line (a text block with no trailing newline).
+        if state.text_buf:
+            chat_job_store.append_event(job_id, _sse_event(state.text_buf))
+        # Record token usage for this turn (best-effort; never fails the job).
+        if state.usage is not None:
+            log_usage(
+                label=label,
+                usage=state.usage,
+                cost_usd=state.cost_usd,
+                duration_ms=state.duration_ms,
+            )
 
         if proc.returncode != 0:
             stderr = b"".join(stderr_chunks).decode("utf-8", errors="replace")
@@ -246,11 +330,15 @@ def post_chat(body: ChatBody, background_tasks: BackgroundTasks) -> ChatPostResp
         raise HTTPException(status_code=404, detail=f"no briefing for {body.date}")
 
     SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
-    cmd = build_cmd(body.date, briefing_file, session_file) + ["-p", body.question]
+    cmd = (
+        build_cmd(body.date, briefing_file, session_file)
+        + ["-p", body.question]
+        + CHAT_STREAM_FLAGS
+    )
     env = build_env(auth_mode=state_mod.read_state().auth_mode)
 
     job = chat_job_store.create_job()
-    background_tasks.add_task(_run_chat_job, job.job_id, cmd, session_file, env)
+    background_tasks.add_task(_run_chat_job, job.job_id, cmd, session_file, env, "chat")
     return ChatPostResponse(job_id=job.job_id, status=job.status)
 
 
@@ -312,11 +400,15 @@ def post_journal_chat(
     sessions_dir.mkdir(parents=True, exist_ok=True)
     session_file = sessions_dir / today
 
-    cmd = build_journal_cmd(today, context, session_file) + ["-p", body.question]
+    cmd = (
+        build_journal_cmd(today, context, session_file)
+        + ["-p", body.question]
+        + CHAT_STREAM_FLAGS
+    )
     env = build_env(auth_mode=state_mod.read_state().auth_mode)
 
     job = chat_job_store.create_job()
-    background_tasks.add_task(_run_chat_job, job.job_id, cmd, session_file, env)
+    background_tasks.add_task(_run_chat_job, job.job_id, cmd, session_file, env, "journal")
     return ChatPostResponse(job_id=job.job_id, status=job.status)
 
 


### PR DESCRIPTION
## Summary
- Chat / journal subprocesses now use `--output-format stream-json`, so each turn's `usage` (tokens, cost, duration) is captured and logged via `log_usage` with `label="chat"` / `"journal"`.
- A server-side parser line-buffers assistant `text_delta` output, preserving the SSE join-by-newline contract and incremental streaming. The usage dashboard/report surface the new entries with no further changes.

## Test plan
- [x] `pytest` (637 passed)
- [x] ruff clean on changed files
- [x] New tests assert the stream-json flags and `chat`/`journal` usage-log call sites

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Log Claude usage metrics for chat and journal turns while preserving existing SSE streaming behavior.

New Features:
- Capture and log per-turn usage metrics (tokens, cost, duration) for chat and journal subprocess calls labeled as `chat` and `journal`.

Enhancements:
- Switch chat and journal subprocesses to use stream-json output and parse assistant text deltas server-side to maintain line-buffered SSE streaming.
- Ensure Windows-style CRLF handling and incremental streaming semantics remain compatible with the new stream-json format.

Tests:
- Expand chat and journal API tests to exercise stream-json parsing, subprocess flag configuration, and usage logging for both chat and journal flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat and journal conversations now stream responses in a more structured, reliable way.
  * Streaming now supports smoother replay and reattachment to in-progress responses.

* **Bug Fixes**
  * Fixed issues where streamed text could include unwanted line-ending artifacts.
  * Improved handling of usage details so chat and journal activity is tracked more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->