### PR TITLE
refactor(usage): add log_usage_from_result shared helper

### DIFF
--- a/apps/python/src/claude_runner.py
+++ b/apps/python/src/claude_runner.py
@@ -15,7 +15,7 @@ from src.constants import (
 )
 from src.logger import get_logger
 from src.transient_errors import is_transient
-from src.usage_logger import log_usage
+from src.usage_logger import log_usage_from_result
 
 logger = get_logger(__name__)
 
@@ -36,15 +36,7 @@ def _parse_and_log_usage(stdout: str, label: str) -> str:
         )
         return stdout.strip()
 
-    usage = parsed.get("usage")
-    if isinstance(usage, dict):
-        log_usage(
-            label=label,
-            usage=usage,
-            cost_usd=parsed.get("total_cost_usd"),
-            duration_ms=parsed.get("duration_ms"),
-        )
-    else:
+    if not log_usage_from_result(label, parsed):
         # Calls without usage can happen in normal operation, so keep this at debug (avoid noise).
         logger.debug("no usage in claude CLI output, skipping usage log [%s]", label)
 

--- a/apps/python/src/usage_logger.py
+++ b/apps/python/src/usage_logger.py
@@ -86,3 +86,27 @@ def log_usage(label: str, usage: dict, cost_usd: float | None, duration_ms: int 
             f.write(json.dumps(record, ensure_ascii=False) + "\n")
     except Exception:  # noqa: BLE001 — a usage-log failure must not stop the main task
         logger.warning("failed to record usage log [%s]", label, exc_info=True)
+
+
+def log_usage_from_result(label: str, result_obj: object) -> bool:
+    """Log usage from a claude CLI ``result`` record (token-consuming call).
+
+    ``result_obj`` is the parsed terminal object of a ``--output-format json``
+    or ``--output-format stream-json`` run — it carries ``usage`` plus
+    ``total_cost_usd`` / ``duration_ms``. This is the single entry point every
+    cost-consuming call site should funnel through so the usage-log format
+    stays uniform.
+
+    Returns ``True`` when a usage record was logged, ``False`` when the object
+    has no ``usage`` dict (a no-op the caller can branch on for logging).
+    """
+    usage = result_obj.get("usage") if isinstance(result_obj, dict) else None
+    if not isinstance(usage, dict):
+        return False
+    log_usage(
+        label=label,
+        usage=usage,
+        cost_usd=result_obj.get("total_cost_usd"),
+        duration_ms=result_obj.get("duration_ms"),
+    )
+    return True

--- a/apps/python/src/usage_logger.py
+++ b/apps/python/src/usage_logger.py
@@ -5,8 +5,10 @@ Exceptions are swallowed because a logging failure must never break the
 original task.
 """
 import json
+from collections.abc import Mapping
 from datetime import datetime, timedelta
 from pathlib import Path
+from typing import Any
 
 from src.constants import LOG_RETENTION_DAYS
 from src.logger import get_logger
@@ -88,7 +90,7 @@ def log_usage(label: str, usage: dict, cost_usd: float | None, duration_ms: int 
         logger.warning("failed to record usage log [%s]", label, exc_info=True)
 
 
-def log_usage_from_result(label: str, result_obj: object) -> bool:
+def log_usage_from_result(label: str, result_obj: Mapping[str, Any] | None) -> bool:
     """Log usage from a claude CLI ``result`` record (token-consuming call).
 
     ``result_obj`` is the parsed terminal object of a ``--output-format json``
@@ -98,10 +100,11 @@ def log_usage_from_result(label: str, result_obj: object) -> bool:
     stays uniform.
 
     Returns ``True`` when a usage record was logged, ``False`` when the object
-    has no ``usage`` dict (a no-op the caller can branch on for logging).
+    has no ``usage`` dict (a no-op the caller can branch on for debug logging).
     """
-    usage = result_obj.get("usage") if isinstance(result_obj, dict) else None
+    usage = result_obj.get("usage") if result_obj is not None else None
     if not isinstance(usage, dict):
+        logger.debug("no usage in result object, skipping usage log [%s]", label)
         return False
     log_usage(
         label=label,

--- a/apps/python/tests/test_claude_runner.py
+++ b/apps/python/tests/test_claude_runner.py
@@ -119,7 +119,7 @@ class TestRunClaudeUsageLogging:
         })
         with patch("src.claude_runner.shutil.which", return_value="/usr/bin/claude"):
             with patch("src.claude_runner.subprocess.run", return_value=_make_result(stdout=payload)):
-                with patch("src.claude_runner.log_usage") as mock_log:
+                with patch("src.usage_logger.log_usage") as mock_log:
                     result = run_claude("prompt", "briefing")
 
         assert result == "the answer"
@@ -134,7 +134,7 @@ class TestRunClaudeUsageLogging:
         """JSON でない stdout はそのまま（strip して）返し、例外を出さず使用量も記録しない。"""
         with patch("src.claude_runner.shutil.which", return_value="/usr/bin/claude"):
             with patch("src.claude_runner.subprocess.run", return_value=_make_result(stdout="  plain text  ")):
-                with patch("src.claude_runner.log_usage") as mock_log:
+                with patch("src.usage_logger.log_usage") as mock_log:
                     result = run_claude("prompt", "test")
 
         assert result == "plain text"
@@ -144,7 +144,7 @@ class TestRunClaudeUsageLogging:
         payload = json.dumps({"result": "ok"})
         with patch("src.claude_runner.shutil.which", return_value="/usr/bin/claude"):
             with patch("src.claude_runner.subprocess.run", return_value=_make_result(stdout=payload)):
-                with patch("src.claude_runner.log_usage") as mock_log:
+                with patch("src.usage_logger.log_usage") as mock_log:
                     result = run_claude("prompt", "test")
 
         assert result == "ok"
@@ -155,7 +155,7 @@ class TestRunClaudeUsageLogging:
         payload = json.dumps({"foo": 1})
         with patch("src.claude_runner.shutil.which", return_value="/usr/bin/claude"):
             with patch("src.claude_runner.subprocess.run", return_value=_make_result(stdout=payload)):
-                with patch("src.claude_runner.log_usage") as mock_log:
+                with patch("src.usage_logger.log_usage") as mock_log:
                     result = run_claude("prompt", "test")
 
         assert result == payload
@@ -166,7 +166,7 @@ class TestRunClaudeUsageLogging:
         payload = json.dumps({"result": ["x", "y"], "usage": {"input_tokens": 5, "output_tokens": 6}})
         with patch("src.claude_runner.shutil.which", return_value="/usr/bin/claude"):
             with patch("src.claude_runner.subprocess.run", return_value=_make_result(stdout=payload)):
-                with patch("src.claude_runner.log_usage") as mock_log:
+                with patch("src.usage_logger.log_usage") as mock_log:
                     result = run_claude("prompt", "test")
 
         assert result == str(["x", "y"])

--- a/apps/python/tests/test_usage_logger.py
+++ b/apps/python/tests/test_usage_logger.py
@@ -85,3 +85,42 @@ def test_log_usage_swallows_errors(monkeypatch, tmp_path):
     # json.dumps が落ちるようにして書き込み前に例外を起こす
     monkeypatch.setattr(usage_logger.json, "dumps", lambda *a, **k: (_ for _ in ()).throw(ValueError("boom")))
     usage_logger.log_usage(label="x", usage={}, cost_usd=None, duration_ms=None)  # 例外が出なければOK
+
+
+def test_log_usage_from_result_logs_when_usage_present(monkeypatch):
+    """A result record with a usage dict is forwarded to log_usage with its
+    cost / duration fields."""
+    captured = {}
+
+    def fake_log_usage(label, usage, cost_usd, duration_ms):
+        captured.update(
+            label=label, usage=usage, cost_usd=cost_usd, duration_ms=duration_ms
+        )
+
+    monkeypatch.setattr(usage_logger, "log_usage", fake_log_usage)
+
+    result = {
+        "usage": {"input_tokens": 3, "output_tokens": 5},
+        "total_cost_usd": 0.01,
+        "duration_ms": 42,
+    }
+    assert usage_logger.log_usage_from_result("chat", result) is True
+    assert captured["label"] == "chat"
+    assert captured["usage"]["output_tokens"] == 5
+    assert captured["cost_usd"] == 0.01
+    assert captured["duration_ms"] == 42
+
+
+def test_log_usage_from_result_noop_without_usage(monkeypatch):
+    """No usage dict → returns False and never calls log_usage."""
+    called = False
+
+    def fake_log_usage(*a, **k):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(usage_logger, "log_usage", fake_log_usage)
+
+    assert usage_logger.log_usage_from_result("chat", {"result": "hi"}) is False
+    assert usage_logger.log_usage_from_result("chat", None) is False
+    assert called is False


### PR DESCRIPTION
## Summary
Step **1 of 2** of the usage-logging refactor. Funnels the "parse a claude result record → log usage" logic into one shared helper so every cost-consuming call site emits the same usage-log format.

| Unit | Concern | LOC |
|---|---|---|
| `usage_logger.log_usage_from_result` | result-record → usage/cost/duration → `log_usage` | ~25 |

`claude_runner._parse_and_log_usage` now delegates to it. No behavior change; the existing mock seam moved from `claude_runner.log_usage` to `usage_logger.log_usage` (same assertions).

## Test plan
- [x] `pytest` — 636 pass (634 baseline + 2 new helper tests)
- [x] `ruff check` — clean
- [ ] No behavior change

## Refactor sequence (for context)
1. **This PR** — `log_usage_from_result` helper ✅
2. Extract the stream-json text parser into `src/claude_stream.py` + adopt the helper in `web/routers/chat.py` (stacks on #283)
3. (follow-up feature, separate) close the notion-import usage-log gap using the new module

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a shared helper to log usage data from Claude CLI result objects and update the runner to use it for consistent usage logging.

Enhancements:
- Add a centralized log_usage_from_result helper to extract usage, cost, and duration from result records and delegate to the existing logging function.
- Refactor claude_runner to rely on the new helper for parsing and logging usage from CLI output, keeping behavior the same while centralizing formatting logic.

Tests:
- Add unit tests for log_usage_from_result to cover both logging when usage is present and no-op behavior when it is absent.
- Update claude_runner tests to patch the usage_logger logging function at its new call site.