### PR TITLE
refactor(chat): extract stream-json parser into src/claude_stream

### DIFF
--- a/apps/python/src/claude_stream.py
+++ b/apps/python/src/claude_stream.py
@@ -1,0 +1,76 @@
+"""Parser for the claude CLI ``--output-format stream-json`` output.
+
+Token-consuming streaming call sites (chat, journal, …) share one concern:
+turn the per-line JSON stream into user-facing assistant text while capturing
+the terminal ``result`` record's usage (token counts, cost, duration). This
+module owns that concern so the parsing logic isn't duplicated per endpoint.
+
+``StreamState`` accumulates partial assistant text into whole lines (so an
+SSE client's join-by-newline contract is preserved) and stashes the final
+usage. ``consume_stream_line`` feeds it one JSON line at a time.
+"""
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class StreamState:
+    """Accumulator for parsing a ``--output-format stream-json`` stream.
+
+    Buffers partial assistant text into whole lines (so the SSE client's
+    join-by-newline contract is preserved) and captures the final ``usage``
+    record (token counts, cost, duration) for usage logging.
+    """
+
+    def __init__(self) -> None:
+        self.text_buf = ""
+        self.saw_text = False
+        self.usage: dict | None = None
+        self.cost_usd: float | None = None
+        self.duration_ms: int | None = None
+
+
+def consume_stream_line(line: str, state: StreamState) -> list[str]:
+    """Parse one stream-json line, returning newly-completed text lines.
+
+    Only user-facing assistant text (``text_delta``) is surfaced — thinking
+    deltas, hook/system events, and tool use are ignored so the streamed
+    output matches the pre-stream-json plain-text behavior. The final
+    ``result`` record's usage is stashed on ``state``; if partial-message
+    deltas never produced text (older CLI), the result text is used as a
+    fallback so the answer is never dropped.
+    """
+    try:
+        obj = json.loads(line)
+    except json.JSONDecodeError:
+        logger.debug("stream-json: non-JSON line (truncated): %.120s", line)
+        return []
+
+    obj_type = obj.get("type")
+    if obj_type == "stream_event":
+        event = obj.get("event") or {}
+        if event.get("type") == "content_block_delta":
+            delta = event.get("delta") or {}
+            if delta.get("type") == "text_delta":
+                state.saw_text = True
+                state.text_buf += delta.get("text", "")
+                parts = state.text_buf.split("\n")
+                state.text_buf = parts.pop()
+                return parts
+    elif obj_type == "result":
+        usage = obj.get("usage")
+        if isinstance(usage, dict):
+            state.usage = usage
+            state.cost_usd = obj.get("total_cost_usd")
+            state.duration_ms = obj.get("duration_ms")
+        if not state.saw_text and not state.text_buf:
+            result_text = obj.get("result")
+            if isinstance(result_text, str):
+                # Split on newlines so multi-line results are line-buffered the
+                # same way text_delta output is: all complete lines go directly
+                # to the caller, the final partial fragment stays in text_buf.
+                parts = result_text.split("\n")
+                state.text_buf = parts.pop()
+                return parts
+    return []

--- a/apps/python/tests/test_claude_stream.py
+++ b/apps/python/tests/test_claude_stream.py
@@ -1,0 +1,71 @@
+"""Unit tests for src.claude_stream — the stream-json output parser."""
+import json
+
+from src.claude_stream import StreamState, consume_stream_line
+
+
+def _delta(text: str) -> str:
+    return json.dumps(
+        {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": text},
+            },
+        }
+    )
+
+
+def _result(**fields) -> str:
+    return json.dumps({"type": "result", "subtype": "success", **fields})
+
+
+def test_text_deltas_flush_on_newline_and_buffer_trailing():
+    state = StreamState()
+    assert consume_stream_line(_delta("hello "), state) == []
+    # A newline completes the first line; the rest stays buffered.
+    assert consume_stream_line(_delta("world\nbye"), state) == ["hello world"]
+    assert state.text_buf == "bye"
+    assert state.saw_text is True
+
+
+def test_result_record_captures_usage():
+    state = StreamState()
+    consume_stream_line(_delta("answer"), state)
+    usage = {"input_tokens": 3, "output_tokens": 5}
+    consume_stream_line(
+        _result(usage=usage, total_cost_usd=0.02, duration_ms=99, result="answer"),
+        state,
+    )
+    assert state.usage == usage
+    assert state.cost_usd == 0.02
+    assert state.duration_ms == 99
+
+
+def test_thinking_deltas_are_ignored():
+    state = StreamState()
+    line = json.dumps(
+        {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "thinking_delta", "thinking": "hmm"},
+            },
+        }
+    )
+    assert consume_stream_line(line, state) == []
+    assert state.saw_text is False
+    assert state.text_buf == ""
+
+
+def test_result_text_fallback_when_no_deltas():
+    """Older CLI without partial messages: the result text is surfaced so the
+    answer is never dropped."""
+    state = StreamState()
+    consume_stream_line(_result(result="the whole answer"), state)
+    assert state.text_buf == "the whole answer"
+
+
+def test_non_json_line_is_skipped():
+    state = StreamState()
+    assert consume_stream_line("not json", state) == []

--- a/apps/python/tests/test_claude_stream.py
+++ b/apps/python/tests/test_claude_stream.py
@@ -29,6 +29,14 @@ def test_text_deltas_flush_on_newline_and_buffer_trailing():
     assert state.saw_text is True
 
 
+def test_text_delta_with_multiple_newlines_emits_all_complete_lines():
+    state = StreamState()
+    # All complete lines (a, ' b') are returned; the trailing fragment stays buffered.
+    result = consume_stream_line(_delta("a\n b\n c"), state)
+    assert result == ["a", " b"]
+    assert state.text_buf == " c"
+
+
 def test_result_record_captures_usage():
     state = StreamState()
     consume_stream_line(_delta("answer"), state)

--- a/apps/python/web/routers/chat.py
+++ b/apps/python/web/routers/chat.py
@@ -65,6 +65,7 @@ from src import journal_store
 from src import state as state_mod
 from src.chat_session import build_cmd, build_journal_cmd
 from src.claude_runner import build_env
+from src.claude_stream import StreamState, consume_stream_line
 from src.logger import get_logger
 from src.usage_logger import log_usage
 from web.auth import require_bearer
@@ -131,66 +132,6 @@ def _sse_event(content: str, event: str | None = None) -> bytes:
     return ("\n".join(out) + "\n\n").encode("utf-8")
 
 
-class _StreamState:
-    """Accumulator for parsing a ``--output-format stream-json`` stream.
-
-    Buffers partial assistant text into whole lines (so the SSE client's
-    join-by-newline contract is preserved) and captures the final ``usage``
-    record (token counts, cost, duration) for usage logging.
-    """
-
-    def __init__(self) -> None:
-        self.text_buf = ""
-        self.saw_text = False
-        self.usage: dict | None = None
-        self.cost_usd: float | None = None
-        self.duration_ms: int | None = None
-
-
-def _consume_stream_line(line: str, state: _StreamState) -> list[str]:
-    """Parse one stream-json line, returning newly-completed text lines.
-
-    Only user-facing assistant text (``text_delta``) is surfaced — thinking
-    deltas, hook/system events, and tool use are ignored so the streamed
-    output matches the pre-stream-json plain-text behavior. The final
-    ``result`` record's usage is stashed on ``state``; if partial-message
-    deltas never produced text (older CLI), the result text is used as a
-    fallback so the answer is never dropped.
-    """
-    try:
-        obj = json.loads(line)
-    except json.JSONDecodeError:
-        logger.debug("stream-json: non-JSON line (truncated): %.120s", line)
-        return []
-
-    obj_type = obj.get("type")
-    if obj_type == "stream_event":
-        event = obj.get("event") or {}
-        if event.get("type") == "content_block_delta":
-            delta = event.get("delta") or {}
-            if delta.get("type") == "text_delta":
-                state.saw_text = True
-                state.text_buf += delta.get("text", "")
-                parts = state.text_buf.split("\n")
-                state.text_buf = parts.pop()
-                return parts
-    elif obj_type == "result":
-        usage = obj.get("usage")
-        if isinstance(usage, dict):
-            state.usage = usage
-            state.cost_usd = obj.get("total_cost_usd")
-            state.duration_ms = obj.get("duration_ms")
-        if not state.saw_text and not state.text_buf:
-            result_text = obj.get("result")
-            if isinstance(result_text, str):
-                # Split on newlines so multi-line results are line-buffered the
-                # same way text_delta output is: all complete lines go directly
-                # to the caller, the final partial fragment stays in text_buf.
-                parts = result_text.split("\n")
-                state.text_buf = parts.pop()
-                return parts
-    return []
-
 
 def _run_chat_job(
     job_id: str,
@@ -228,14 +169,14 @@ def _run_chat_job(
         stderr_thread = threading.Thread(target=_drain_stderr, daemon=True)
         stderr_thread.start()
 
-        state = _StreamState()
+        state = StreamState()
         try:
             assert proc.stdout is not None
             for line_bytes in proc.stdout:
                 line = line_bytes.decode("utf-8", errors="replace").rstrip("\r\n")
                 if not line:
                     continue
-                for text_line in _consume_stream_line(line, state):
+                for text_line in consume_stream_line(line, state):
                     chat_job_store.append_event(job_id, _sse_event(text_line))
         finally:
             proc.wait()


### PR DESCRIPTION
## Summary
Step **2 of 2** of the usage-logging refactor (follows #285). Moves the stream-json text/usage parser out of the chat router into a reusable module so other streaming token-consuming call sites can share it.

| Unit | Concern | LOC |
|---|---|---|
| `src/claude_stream.py` (`StreamState`, `consume_stream_line`) | stream-json line → assistant text + captured usage | ~75 |

`web/routers/chat.py` now imports them. The extracted module also incorporates the review fixes from #283 (`logger.debug` on non-JSON lines, multi-line fallback `result_text` split). No behavior change.

## Test plan
- [x] `pytest` — 642 pass (637 baseline + 5 new parser unit tests)
- [x] `ruff check` — clean
- [ ] No behavior change

## Refactor sequence (for context)
1. `log_usage_from_result` helper — #285 ✅
2. **This PR** — extract `src/claude_stream.py` ✅
3. (follow-up) adopt `log_usage_from_result` in `chat.py` + close the notion-import usage-log gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extract the Claude CLI stream-json parsing logic into a shared module and update the chat router to consume it.

Enhancements:
- Introduce a reusable src/claude_stream module that encapsulates StreamState and stream-json line parsing for assistant text and usage metadata.

Tests:
- Add unit tests for the claude_stream parser covering text buffering, usage capture, ignoring non-text deltas, result-text fallback, and non-JSON input handling.