### PR TITLE
feat(web): move Credentials & Auth into Config modal; keep Config visible when collapsed

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -108,7 +108,6 @@ html[data-sidebar-collapsed="true"] [data-sidebar-rail] {
   white-space: nowrap;
 }
 html[data-sidebar-collapsed="true"] [data-sidebar-label],
-html[data-sidebar-collapsed="true"] [data-sidebar-section="config"],
 html[data-sidebar-collapsed="true"] [data-sidebar-brand] {
   display: none;
 }

--- a/apps/web/components/Sidebar.tsx
+++ b/apps/web/components/Sidebar.tsx
@@ -23,8 +23,6 @@ const ITEMS: Item[] = [
   { href: "/portfolio", label: "Portfolio", icon: "📊" },
   { href: "/watch-sectors", label: "Watch Sectors", icon: "🌐" },
   { href: "/geopolitical", label: "Geopolitical Risks", icon: "🗺️" },
-  { href: "/credentials", label: "Credentials", icon: "📨" },
-  { href: "/auth", label: "Auth", icon: "🔑" },
   { href: "/run", label: "Run", icon: "▶️" },
   { href: "/chat", label: "Q&A Chat", icon: "💬" },
   { href: "/journal", label: "Journal", icon: "📓" },

--- a/apps/web/components/settings/AuthPanel.tsx
+++ b/apps/web/components/settings/AuthPanel.tsx
@@ -1,0 +1,44 @@
+"use client"
+import { useEffect, useState } from "react"
+
+import { AuthModeForm } from "@/components/screens/AuthModeForm"
+import { apiFetch } from "@/lib/api"
+
+type Initial = { authMode: "cli" | "api"; anthropicKeySet: boolean }
+
+export function AuthPanel() {
+  const [initial, setInitial] = useState<Initial | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    Promise.all([apiFetch("/api/auth/mode"), apiFetch("/api/credentials")])
+      .then(async ([modeRes, credsRes]) => {
+        if (!modeRes.ok) throw new Error(`GET /api/auth/mode HTTP ${modeRes.status}`)
+        if (!credsRes.ok) throw new Error(`GET /api/credentials HTTP ${credsRes.status}`)
+        const mode = (await modeRes.json()) as { auth_mode: "cli" | "api" }
+        const creds = (await credsRes.json()) as Record<string, boolean>
+        setInitial({
+          authMode: mode.auth_mode,
+          anthropicKeySet: Boolean(creds.ANTHROPIC_API_KEY),
+        })
+      })
+      .catch((e: unknown) => setError(String(e)))
+  }, [])
+
+  if (error) return <p className="text-sm text-destructive">{error}</p>
+  if (!initial) return <p className="text-sm text-muted-foreground">Loading…</p>
+  return (
+    <div className="space-y-4">
+      <header>
+        <h2 className="text-xl font-semibold">Auth</h2>
+        <p className="text-sm text-muted-foreground">
+          How ai-agent talks to Claude. Switch any time.
+        </p>
+      </header>
+      <AuthModeForm
+        initialAuthMode={initial.authMode}
+        anthropicKeySet={initial.anthropicKeySet}
+      />
+    </div>
+  )
+}

--- a/apps/web/components/settings/AuthPanel.tsx
+++ b/apps/web/components/settings/AuthPanel.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react"
 
 import { AuthModeForm } from "@/components/screens/AuthModeForm"
-import { apiFetch } from "@/lib/api"
+import { fetchCredentials } from "@/lib/credentials"
 
 type Initial = { authMode: "cli" | "api"; anthropicKeySet: boolean }
 
@@ -11,18 +11,16 @@ export function AuthPanel() {
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    Promise.all([apiFetch("/api/auth/mode"), apiFetch("/api/credentials")])
-      .then(async ([modeRes, credsRes]) => {
+    Promise.all([fetch("/api/auth/mode"), fetchCredentials()])
+      .then(async ([modeRes, creds]) => {
         if (!modeRes.ok) throw new Error(`GET /api/auth/mode HTTP ${modeRes.status}`)
-        if (!credsRes.ok) throw new Error(`GET /api/credentials HTTP ${credsRes.status}`)
         const mode = (await modeRes.json()) as { auth_mode: "cli" | "api" }
-        const creds = (await credsRes.json()) as Record<string, boolean>
         setInitial({
           authMode: mode.auth_mode,
           anthropicKeySet: Boolean(creds.ANTHROPIC_API_KEY),
         })
       })
-      .catch((e: unknown) => setError(String(e)))
+      .catch(() => setError("Failed to load auth settings."))
   }, [])
 
   if (error) return <p className="text-sm text-destructive">{error}</p>

--- a/apps/web/components/settings/CredentialsPanel.tsx
+++ b/apps/web/components/settings/CredentialsPanel.tsx
@@ -1,0 +1,35 @@
+"use client"
+import { useEffect, useState } from "react"
+
+import { CredentialsForm } from "@/components/screens/CredentialsForm"
+import { apiFetch } from "@/lib/api"
+
+export function CredentialsPanel() {
+  const [status, setStatus] = useState<Record<string, boolean> | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    apiFetch("/api/credentials")
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`)
+        return r.json() as Promise<Record<string, boolean>>
+      })
+      .then(setStatus)
+      .catch((e: unknown) => setError(String(e)))
+  }, [])
+
+  if (error) return <p className="text-sm text-destructive">{error}</p>
+  if (!status) return <p className="text-sm text-muted-foreground">Loading…</p>
+  return (
+    <div className="space-y-4">
+      <header>
+        <h2 className="text-xl font-semibold">Credentials</h2>
+        <p className="text-sm text-muted-foreground">
+          Stored in the OS keychain. Existing values are never shown — only
+          whether each key is set.
+        </p>
+      </header>
+      <CredentialsForm initial={status} />
+    </div>
+  )
+}

--- a/apps/web/components/settings/CredentialsPanel.tsx
+++ b/apps/web/components/settings/CredentialsPanel.tsx
@@ -2,20 +2,16 @@
 import { useEffect, useState } from "react"
 
 import { CredentialsForm } from "@/components/screens/CredentialsForm"
-import { apiFetch } from "@/lib/api"
+import { fetchCredentials } from "@/lib/credentials"
 
 export function CredentialsPanel() {
   const [status, setStatus] = useState<Record<string, boolean> | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    apiFetch("/api/credentials")
-      .then((r) => {
-        if (!r.ok) throw new Error(`HTTP ${r.status}`)
-        return r.json() as Promise<Record<string, boolean>>
-      })
+    fetchCredentials()
       .then(setStatus)
-      .catch((e: unknown) => setError(String(e)))
+      .catch(() => setError("Failed to load credentials."))
   }, [])
 
   if (error) return <p className="text-sm text-destructive">{error}</p>

--- a/apps/web/components/settings/SettingsModal.tsx
+++ b/apps/web/components/settings/SettingsModal.tsx
@@ -6,6 +6,8 @@ import { ConfigFilePanel } from "@/components/ConfigFilePanel"
 import { OutputExportPanel } from "@/components/OutputExportPanel"
 import { ResizeHandle } from "@/components/ResizeHandle"
 import { UsageDashboard } from "@/components/screens/UsageDashboard"
+import { AuthPanel } from "@/components/settings/AuthPanel"
+import { CredentialsPanel } from "@/components/settings/CredentialsPanel"
 import {
   Dialog,
   DialogContent,
@@ -27,6 +29,8 @@ const SECTIONS: Section[] = [
   { key: "appearance", label: "Appearance", icon: "🎨", render: () => <AppearancePanel /> },
   { key: "config-file", label: "Config file", icon: "📁", render: () => <ConfigFilePanel /> },
   { key: "export", label: "Export data", icon: "📦", render: () => <OutputExportPanel /> },
+  { key: "credentials", label: "Credentials", icon: "📨", render: () => <CredentialsPanel /> },
+  { key: "auth", label: "Auth", icon: "🔑", render: () => <AuthPanel /> },
 ]
 
 export function SettingsModal() {

--- a/apps/web/lib/credentials.ts
+++ b/apps/web/lib/credentials.ts
@@ -1,0 +1,5 @@
+export async function fetchCredentials(): Promise<Record<string, boolean>> {
+  const res = await fetch("/api/credentials")
+  if (!res.ok) throw new Error(`GET /api/credentials HTTP ${res.status}`)
+  return (await res.json()) as Record<string, boolean>
+}


### PR DESCRIPTION
## Summary
- Remove `Credentials` and `Auth` from top-level sidebar nav (`ITEMS` in `Sidebar.tsx`)
- Add `CredentialsPanel` and `AuthPanel` client components that fetch their own data and render inside `SettingsModal`
- Config (⚙️) entry already renders icon-only when sidebar is collapsed via existing `data-sidebar-label` CSS rule

## Test plan
- [ ] All 163 existing tests pass (`npm test` in `apps/web`)
- [ ] TypeScript compiles without errors
- [ ] Sidebar collapsed: Config ⚙️ icon visible, no label
- [ ] Config modal: Credentials and Auth sections reachable and functional
- [ ] `/credentials` and `/auth` routes still work (pages untouched)

Closes #284

## Summary by Sourcery

Move credentials and auth management into the settings modal while keeping the config entry available when the sidebar is collapsed.

New Features:
- Add credentials and auth sections within the settings modal via dedicated panels that fetch and display their own data.

Enhancements:
- Remove top-level sidebar navigation items for credentials and auth to consolidate configuration-related options under the settings modal.