### PR TITLE
feat(web): migrate Journal page to Briefing-style table layout with date column

### DIFF
--- a/apps/web/components/screens/BriefingDashboard.tsx
+++ b/apps/web/components/screens/BriefingDashboard.tsx
@@ -7,6 +7,7 @@ import { BriefingRow } from "@/components/briefing/BriefingRow"
 import { BriefingSearch } from "@/components/briefing/BriefingSearch"
 import { ALL_TAB, BriefingTabs } from "@/components/briefing/BriefingTabs"
 import { ResizeHandle } from "@/components/ResizeHandle"
+import { RecordsTable } from "@/components/ui/records-table"
 import { BriefingFile, BriefingListResponse } from "@/lib/briefing-types"
 import { useBriefingData } from "@/lib/hooks/useBriefingData"
 import { useResizable } from "@/lib/hooks/useResizable"
@@ -131,27 +132,24 @@ export function BriefingDashboard() {
         <ArchiveButton />
         <BriefingSearch onSearch={setQuery} />
         <BriefingTabs files={files} selected={tab} onSelect={setTab} />
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b bg-muted/50 text-left text-xs text-muted-foreground">
-              <th className="px-3 py-2">Name</th>
-              <th className="px-3 py-2">Type</th>
-              <th className="px-3 py-2">Date</th>
-              <th className="w-8 px-3 py-2" />
-            </tr>
-          </thead>
-          <tbody>
-            {visibleFiles.map((file) => (
-              <BriefingRow
-                key={file.name}
-                file={file}
-                selected={selected?.name === file.name}
-                onOpen={fetchContent}
-                onHover={prefetch}
-              />
-            ))}
-          </tbody>
-        </table>
+        <RecordsTable
+          columns={[
+            { label: "Name" },
+            { label: "Type" },
+            { label: "Date" },
+            { label: "", className: "w-8 px-3 py-2" },
+          ]}
+        >
+          {visibleFiles.map((file) => (
+            <BriefingRow
+              key={file.name}
+              file={file}
+              selected={selected?.name === file.name}
+              onOpen={fetchContent}
+              onHover={prefetch}
+            />
+          ))}
+        </RecordsTable>
         {searching && (
           <p
             data-testid="briefing-search-loading"

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 
+import { RecordsTable } from "@/components/ui/records-table"
 import { cn } from "@/lib/utils"
 
 type JournalDate = { date: string; size: number }
@@ -203,35 +204,49 @@ export function JournalScreen() {
     }
   }, [question, brainstorming, appendToLastAnswer, loadDates, loadEntry])
 
+  const sortedDates = [...dates].sort((a, b) => b.date.localeCompare(a.date))
+
   return (
     <div className="flex flex-col gap-6">
-      {/* Top: date picker */}
-      <div className="flex items-center gap-3">
-        <label htmlFor="journal-date" className="text-sm font-semibold text-muted-foreground">
-          Entries
-        </label>
+      {/* Entries table */}
+      <section className="rounded-lg border bg-card">
+        <div className="px-4 pt-4 pb-2">
+          <h3 className="text-sm font-semibold">Entries</h3>
+        </div>
         {datesError ? (
-          <span className="text-sm text-destructive">{datesError}</span>
+          <p className="px-4 pb-4 text-sm text-destructive">{datesError}</p>
         ) : dates.length === 0 ? (
-          <span className="text-sm text-muted-foreground">No entries yet.</span>
+          <p className="px-4 pb-4 text-sm text-muted-foreground">No entries yet.</p>
         ) : (
-          <select
-            id="journal-date"
-            value={selected ?? ""}
-            onChange={(e) => void loadEntry(e.target.value)}
-            className="rounded-md border bg-background px-3 py-2 text-sm"
-          >
-            <option value="" disabled>
-              Select a date…
-            </option>
-            {dates.map((d) => (
-              <option key={d.date} value={d.date}>
-                {d.date}
-              </option>
+          <RecordsTable columns={[{ label: "Date" }, { label: "Size (KB)" }]}>
+            {sortedDates.map((d) => (
+              <tr
+                key={d.date}
+                tabIndex={0}
+                aria-selected={selected === d.date}
+                onClick={() => void loadEntry(d.date)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault()
+                    void loadEntry(d.date)
+                  }
+                }}
+                className={cn(
+                  "cursor-pointer border-b text-xs transition-colors last:border-0",
+                  selected === d.date
+                    ? "bg-accent font-medium text-accent-foreground"
+                    : "hover:bg-accent/50",
+                )}
+              >
+                <td className="px-3 py-2 tabular-nums">{d.date}</td>
+                <td className="px-3 py-2 tabular-nums text-muted-foreground">
+                  {(d.size / 1024).toFixed(1)}
+                </td>
+              </tr>
             ))}
-          </select>
+          </RecordsTable>
         )}
-      </div>
+      </section>
 
       {/* Full-width: record + view + brainstorm */}
       <div className="flex flex-col gap-6">

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -223,7 +223,6 @@ export function JournalScreen() {
               <tr
                 key={d.date}
                 tabIndex={0}
-                aria-selected={selected === d.date}
                 onClick={() => void loadEntry(d.date)}
                 onKeyDown={(e) => {
                   if (e.key === "Enter" || e.key === " ") {
@@ -238,8 +237,13 @@ export function JournalScreen() {
                     : "hover:bg-accent/50",
                 )}
               >
-                <td className="px-3 py-2 tabular-nums">{d.date}</td>
-                <td className="px-3 py-2 tabular-nums text-muted-foreground">
+                <td aria-selected={selected === d.date} className="px-3 py-2 tabular-nums">
+                  {d.date}
+                </td>
+                <td
+                  aria-selected={selected === d.date}
+                  className="px-3 py-2 tabular-nums text-muted-foreground"
+                >
                   {(d.size / 1024).toFixed(1)}
                 </td>
               </tr>

--- a/apps/web/components/ui/records-table.tsx
+++ b/apps/web/components/ui/records-table.tsx
@@ -16,8 +16,8 @@ export function RecordsTable({ columns, children }: RecordsTableProps) {
     <table className="w-full text-sm">
       <thead>
         <tr className="border-b bg-muted/50 text-left text-xs text-muted-foreground">
-          {columns.map((col) => (
-            <th key={col.label} className={col.className ?? "px-3 py-2"}>
+          {columns.map((col, i) => (
+            <th key={i} className={col.className ?? "px-3 py-2"}>
               {col.label}
             </th>
           ))}

--- a/apps/web/components/ui/records-table.tsx
+++ b/apps/web/components/ui/records-table.tsx
@@ -1,0 +1,29 @@
+import { ReactNode } from "react"
+
+interface Column {
+  label: string
+  className?: string
+}
+
+interface RecordsTableProps {
+  columns: Column[]
+  children: ReactNode
+}
+
+/** Shared table shell used by Briefing and Journal record lists. */
+export function RecordsTable({ columns, children }: RecordsTableProps) {
+  return (
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="border-b bg-muted/50 text-left text-xs text-muted-foreground">
+          {columns.map((col) => (
+            <th key={col.label} className={col.className ?? "px-3 py-2"}>
+              {col.label}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>{children}</tbody>
+    </table>
+  )
+}


### PR DESCRIPTION
## Summary
- Extract `RecordsTable` shared component (table shell + thead) from `BriefingDashboard`
- Replace Journal entries dropdown with a table (Date, Size KB columns, sorted descending)
- `BriefingDashboard` now consumes `RecordsTable`; appearance unchanged

## Test plan
- [ ] Journal page shows entries in a table with Date and Size columns, newest first
- [ ] Clicking a row selects and loads the entry (highlights in accent color)
- [ ] Briefing page appearance is unchanged
- [ ] All 163 vitest tests pass

Closes #291

## Summary by Sourcery

Introduce a shared records table layout and apply it to both Journal and Briefing pages.

New Features:
- Show journal entries in a table layout with sortable date and size columns instead of a dropdown.

Enhancements:
- Extract a reusable RecordsTable component for shared table shell and headers across record lists.
- Update BriefingDashboard to consume the shared RecordsTable while preserving its existing appearance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a reusable table layout for record lists, giving briefing and journal screens a more consistent, structured view.
  * Journal entries now display in a table with date and file size, and can be selected with mouse or keyboard.
* **Bug Fixes**
  * Improved list interactions and navigation in the journal view.
  * Kept existing briefing row behavior while updating the layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->