### PR TITLE
feat(journal): migrate storage to one-file-per-entry model

### DIFF
--- a/apps/python/src/journal_store.py
+++ b/apps/python/src/journal_store.py
@@ -1,11 +1,14 @@
-"""Journal store — append and read daily Markdown notes.
+"""Journal store — one Markdown file per entry.
 
-The journaling agent accumulates free-form daily notes (thoughts, what
-happened today) so they can later be used as context for brainstorming.
+Each journal entry is a standalone Markdown file under ``JOURNAL_DIR`` named
+``YYYY-MM-DD_HHMMSS.md`` (the file stem is the entry id). A single day can
+therefore hold many independent entries, and an entry can be removed by
+deleting its file.
 
-Storage layout: one Markdown file per day under ``JOURNAL_DIR`` named
-``YYYY-MM-DD.md``. Each appended note becomes a timestamped section so a
-single day can hold many entries while staying human-readable.
+Backward compatibility: legacy day-based files named ``YYYY-MM-DD.md`` (one
+file per day from the previous append-only model) are still listed and
+readable. Their entry id is the bare date. No one-shot migration is required —
+old files are picked up on read, new entries use the per-entry naming.
 
 ``JOURNAL_DIR`` lives under ``output/`` which is gitignored, so personal
 notes are never committed (matches the briefing output convention).
@@ -16,8 +19,9 @@ from pathlib import Path
 
 JOURNAL_DIR = Path(__file__).parents[1] / "output" / "journal"
 
-# Journal file names are exactly a date: YYYY-MM-DD.md (no path separators).
-_FILE_RE = re.compile(r"^(\d{4}-\d{2}-\d{2})\.md$")
+# Entry id: a date, optionally followed by "_<suffix>" (time and/or collision
+# counter). Legacy day files (bare "YYYY-MM-DD") match with no suffix.
+_ENTRY_RE = re.compile(r"^(\d{4}-\d{2}-\d{2})(?:_[0-9A-Za-z-]+)?$")
 _DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
@@ -26,72 +30,79 @@ def today() -> str:
     return datetime.now().strftime("%Y-%m-%d")
 
 
-def _path_for(date: str) -> Path:
-    """Return the file path for a date, validating the date format first."""
-    if not _DATE_RE.match(date):
-        raise ValueError(f"Invalid journal date: {date!r}")
-    return JOURNAL_DIR / f"{date}.md"
+def date_of(entry_id: str) -> str:
+    """Return the date (YYYY-MM-DD) embedded in an entry id."""
+    m = _ENTRY_RE.match(entry_id)
+    if not m:
+        raise ValueError(f"Invalid journal entry id: {entry_id!r}")
+    return m.group(1)
+
+
+def _path_for(entry_id: str) -> Path:
+    """Return the file path for an entry id, validating its format first."""
+    if not _ENTRY_RE.match(entry_id):
+        raise ValueError(f"Invalid journal entry id: {entry_id!r}")
+    return JOURNAL_DIR / f"{entry_id}.md"
 
 
 def append_entry(content: str, date: str | None = None) -> str:
-    """Append a timestamped note to the day's file, creating it if absent.
+    """Create a new entry file for the given date and return its entry id.
 
-    Returns the date (YYYY-MM-DD) the note was written to. A new file is
-    seeded with a ``# Journal {date}`` heading before the first section.
+    Each call writes a distinct file named ``{date}_{HHMMSS}.md``; if that name
+    is already taken (two entries within the same second), a ``-N`` counter is
+    appended so no entry overwrites another.
     """
     text = content.strip()
     if not text:
         raise ValueError("Journal entry content must not be empty")
 
     date = date or today()
-    path = _path_for(date)
+    if not _DATE_RE.match(date):
+        raise ValueError(f"Invalid journal date: {date!r}")
     JOURNAL_DIR.mkdir(parents=True, exist_ok=True)
 
-    timestamp = datetime.now().strftime("%H:%M:%S")
-    section = f"## {timestamp}\n\n{text}\n"
+    now = datetime.now()
+    base = f"{date}_{now.strftime('%H%M%S')}"
+    timestamp = now.strftime("%H:%M:%S")
+    body = f"# Journal {date}\n\n## {timestamp}\n\n{text}\n"
 
-    # Append-only writes so concurrent appends cannot read-modify-write over
-    # each other and silently drop entries. The day heading is seeded once,
-    # on first creation, via exclusive-create ("x") which no-ops if the file
-    # already exists.
-    try:
-        with open(path, "x", encoding="utf-8") as fh:
-            fh.write(f"# Journal {date}\n")
-    except FileExistsError:
-        pass
-
-    with open(path, "a", encoding="utf-8") as fh:
-        fh.write(f"\n{section}")
-    return date
+    # Exclusive create ("x") guarantees a fresh file; on collision bump the
+    # counter and retry so concurrent appends within the same second don't
+    # clobber each other.
+    entry_id = base
+    n = 1
+    while True:
+        try:
+            with open(JOURNAL_DIR / f"{entry_id}.md", "x", encoding="utf-8") as fh:
+                fh.write(body)
+            return entry_id
+        except FileExistsError:
+            entry_id = f"{base}-{n}"
+            n += 1
 
 
 def list_files() -> list[tuple[str, Path]]:
-    """Return (date, path) for available journal files, newest first.
+    """Return (entry_id, path) for available entries, newest first.
 
-    Returning the globbed ``Path`` lets callers reuse it (e.g. for ``stat()``)
-    instead of rebuilding the path from the date string.
+    Entry ids start with the date and embed the time, so a reverse
+    lexicographic sort yields newest-first ordering.
     """
     if not JOURNAL_DIR.exists():
         return []
     files = [
-        (m.group(1), path)
+        (path.stem, path)
         for path in JOURNAL_DIR.glob("*.md")
-        if path.is_file() and (m := _FILE_RE.match(path.name))
+        if path.is_file() and _ENTRY_RE.match(path.stem)
     ]
     files.sort(key=lambda f: f[0], reverse=True)
     return files
 
 
-def list_dates() -> list[str]:
-    """Return available journal dates, newest first."""
-    return [date for date, _ in list_files()]
-
-
-def read_entry(date: str) -> str | None:
-    """Return the Markdown body for a date, or None if it does not exist."""
-    if not _DATE_RE.match(date):
+def read_entry(entry_id: str) -> str | None:
+    """Return the Markdown body for an entry id, or None if it does not exist."""
+    if not _ENTRY_RE.match(entry_id):
         return None
-    path = JOURNAL_DIR / f"{date}.md"
+    path = JOURNAL_DIR / f"{entry_id}.md"
     if not path.exists() or not path.is_file():
         return None
     return path.read_text(encoding="utf-8")

--- a/apps/python/src/journal_store.py
+++ b/apps/python/src/journal_store.py
@@ -30,6 +30,16 @@ def today() -> str:
     return datetime.now().strftime("%Y-%m-%d")
 
 
+def _validate_date(value: str) -> None:
+    """Raise ValueError unless value is a real calendar date (YYYY-MM-DD)."""
+    if not _DATE_RE.match(value):
+        raise ValueError(f"Invalid journal date: {value!r}")
+    try:
+        datetime.strptime(value, "%Y-%m-%d")
+    except ValueError as exc:
+        raise ValueError(f"Invalid journal date: {value!r}") from exc
+
+
 def date_of(entry_id: str) -> str:
     """Return the date (YYYY-MM-DD) embedded in an entry id."""
     m = _ENTRY_RE.match(entry_id)
@@ -57,8 +67,7 @@ def append_entry(content: str, date: str | None = None) -> str:
         raise ValueError("Journal entry content must not be empty")
 
     date = date or today()
-    if not _DATE_RE.match(date):
-        raise ValueError(f"Invalid journal date: {date!r}")
+    _validate_date(date)
     JOURNAL_DIR.mkdir(parents=True, exist_ok=True)
 
     now = datetime.now()
@@ -77,7 +86,9 @@ def append_entry(content: str, date: str | None = None) -> str:
                 fh.write(body)
             return entry_id
         except FileExistsError:
-            entry_id = f"{base}-{n}"
+            # Zero-pad so reverse-lexicographic listing keeps creation order
+            # even past 9 entries in the same second (-000010 sorts after -000009).
+            entry_id = f"{base}-{n:06d}"
             n += 1
 
 

--- a/apps/python/tests/test_api_journal.py
+++ b/apps/python/tests/test_api_journal.py
@@ -142,3 +142,11 @@ async def test_legacy_day_file_is_listed_and_readable(authed_client, journal_dir
     got = await authed_client.get("/api/journal/2026-06-20")
     assert got.status_code == 200
     assert "legacy note" in got.json()["content"]
+
+
+async def test_append_nonexistent_calendar_date_rejected(authed_client, journal_dir):
+    """A well-formed but impossible date (2026-99-99) is rejected."""
+    response = await authed_client.post(
+        "/api/journal", json={"content": "x", "date": "2026-99-99"}
+    )
+    assert response.status_code == 400

--- a/apps/python/tests/test_api_journal.py
+++ b/apps/python/tests/test_api_journal.py
@@ -1,12 +1,12 @@
-"""Tests for /api/journal — daily Markdown journal append + read (#271).
+"""Tests for /api/journal — per-entry Markdown journal (#271, #295).
 
 Contract:
-- ``POST /api/journal`` appends a timestamped note to the day's file,
-  creating the file if absent; returns {date}.
-- ``GET /api/journal`` returns newest-first list of {date, size}.
-- ``GET /api/journal/{date}`` returns {date, content} (raw markdown).
-- Unknown / invalid date returns 404.
+- ``POST /api/journal`` creates a new entry file; returns {id, date}.
+- ``GET /api/journal`` returns newest-first list of {id, date, size}.
+- ``GET /api/journal/{entry_id}`` returns {id, date, content} (raw markdown).
+- Unknown / invalid id returns 404.
 - Auth is required (Bearer) on all endpoints.
+- Legacy day-based files (YYYY-MM-DD.md) remain listable and readable.
 """
 import pytest
 
@@ -36,21 +36,31 @@ async def test_append_creates_file(authed_client, journal_dir):
         "/api/journal", json={"content": "First thought", "date": "2026-06-24"}
     )
     assert response.status_code == 200
-    assert response.json()["date"] == "2026-06-24"
-    path = journal_dir / "2026-06-24.md"
+    body = response.json()
+    assert body["date"] == "2026-06-24"
+    assert body["id"].startswith("2026-06-24")
+    path = journal_dir / f"{body['id']}.md"
     assert path.exists()
-    body = path.read_text(encoding="utf-8")
-    assert "# Journal 2026-06-24" in body
-    assert "First thought" in body
+    text = path.read_text(encoding="utf-8")
+    assert "# Journal 2026-06-24" in text
+    assert "First thought" in text
 
 
-async def test_append_twice_keeps_both(authed_client, journal_dir):
-    await authed_client.post("/api/journal", json={"content": "one", "date": "2026-06-24"})
-    await authed_client.post("/api/journal", json={"content": "two", "date": "2026-06-24"})
-    body = (journal_dir / "2026-06-24.md").read_text(encoding="utf-8")
-    assert "one" in body and "two" in body
-    # only one top-level heading
-    assert body.count("# Journal 2026-06-24") == 1
+async def test_append_twice_same_date_creates_two_entries(authed_client, journal_dir):
+    r1 = await authed_client.post(
+        "/api/journal", json={"content": "one", "date": "2026-06-24"}
+    )
+    r2 = await authed_client.post(
+        "/api/journal", json={"content": "two", "date": "2026-06-24"}
+    )
+    id1, id2 = r1.json()["id"], r2.json()["id"]
+    assert id1 != id2
+    # Two separate files, each with its own content.
+    files = list(journal_dir.glob("2026-06-24*.md"))
+    assert len(files) == 2
+    response = await authed_client.get("/api/journal")
+    ids = [e["id"] for e in response.json()["entries"]]
+    assert id1 in ids and id2 in ids
 
 
 async def test_append_defaults_to_today(authed_client, journal_dir):
@@ -81,36 +91,54 @@ async def test_list_newest_first(authed_client, journal_dir):
         await authed_client.post("/api/journal", json={"content": "x", "date": date})
     response = await authed_client.get("/api/journal")
     assert response.status_code == 200
-    dates = [d["date"] for d in response.json()["dates"]]
+    dates = [e["date"] for e in response.json()["entries"]]
     assert dates == ["2026-06-24", "2026-06-23", "2026-06-22"]
 
 
 async def test_list_includes_size(authed_client, journal_dir):
     await authed_client.post("/api/journal", json={"content": "x", "date": "2026-06-24"})
     response = await authed_client.get("/api/journal")
-    assert response.json()["dates"][0]["size"] > 0
+    assert response.json()["entries"][0]["size"] > 0
 
 
 async def test_list_empty_when_dir_missing(authed_client, journal_dir):
     response = await authed_client.get("/api/journal")
     assert response.status_code == 200
-    assert response.json()["dates"] == []
+    assert response.json()["entries"] == []
 
 
 async def test_get_returns_markdown(authed_client, journal_dir):
-    await authed_client.post("/api/journal", json={"content": "hello", "date": "2026-06-24"})
-    response = await authed_client.get("/api/journal/2026-06-24")
+    post = await authed_client.post(
+        "/api/journal", json={"content": "hello", "date": "2026-06-24"}
+    )
+    entry_id = post.json()["id"]
+    response = await authed_client.get(f"/api/journal/{entry_id}")
     assert response.status_code == 200
     body = response.json()
+    assert body["id"] == entry_id
     assert body["date"] == "2026-06-24"
     assert "hello" in body["content"]
 
 
-async def test_get_unknown_date_returns_404(authed_client, journal_dir):
-    response = await authed_client.get("/api/journal/2099-01-01")
+async def test_get_unknown_id_returns_404(authed_client, journal_dir):
+    response = await authed_client.get("/api/journal/2099-01-01_120000")
     assert response.status_code == 404
 
 
-async def test_get_invalid_date_returns_404(authed_client, journal_dir):
+async def test_get_invalid_id_returns_404(authed_client, journal_dir):
     response = await authed_client.get("/api/journal/not-a-date")
     assert response.status_code == 404
+
+
+async def test_legacy_day_file_is_listed_and_readable(authed_client, journal_dir):
+    """A bare YYYY-MM-DD.md file from the old model stays accessible."""
+    journal_dir.mkdir(parents=True, exist_ok=True)
+    (journal_dir / "2026-06-20.md").write_text(
+        "# Journal 2026-06-20\n\nlegacy note\n", encoding="utf-8"
+    )
+    listed = await authed_client.get("/api/journal")
+    entry = next(e for e in listed.json()["entries"] if e["id"] == "2026-06-20")
+    assert entry["date"] == "2026-06-20"
+    got = await authed_client.get("/api/journal/2026-06-20")
+    assert got.status_code == 200
+    assert "legacy note" in got.json()["content"]

--- a/apps/python/tests/test_api_journal_chat.py
+++ b/apps/python/tests/test_api_journal_chat.py
@@ -212,3 +212,22 @@ async def test_journal_logs_usage_with_journal_label(
     assert len(captured) == 1
     assert captured[0]["label"] == "journal"
     assert captured[0]["usage"]["output_tokens"] == 11
+
+
+def test_gather_context_is_day_based(tmp_path, monkeypatch):
+    """`days` caps by distinct dates; multiple entries on a day all load."""
+    from web.routers.chat import _gather_journal_context
+
+    d = tmp_path / "journal"
+    d.mkdir()
+    # Two entries on the newest date, one each on the two older dates.
+    (d / "2026-06-24_090000.md").write_text("note A", encoding="utf-8")
+    (d / "2026-06-24_100000.md").write_text("note B", encoding="utf-8")
+    (d / "2026-06-23_090000.md").write_text("note C", encoding="utf-8")
+    (d / "2026-06-22_090000.md").write_text("note D", encoding="utf-8")
+    monkeypatch.setattr(journal_store, "JOURNAL_DIR", d)
+
+    # days=2 → newest two dates (06-24, 06-23): both 06-24 entries + the 06-23 one.
+    blob = _gather_journal_context(days=2)
+    assert "note A" in blob and "note B" in blob and "note C" in blob
+    assert "note D" not in blob

--- a/apps/python/web/routers/chat.py
+++ b/apps/python/web/routers/chat.py
@@ -315,7 +315,7 @@ def _gather_journal_context(days: int, max_chars: int | None = None) -> str:
         max_chars = JOURNAL_CONTEXT_MAX_CHARS
     # Walk entries newest-first, keeping every entry that belongs to one of the
     # newest ``days`` distinct dates so multiple entries per day are preserved.
-    seen_dates: list[str] = []
+    seen_dates: set[str] = set()
     sections: list[str] = []
     total = 0
     for entry_id, _ in journal_store.list_files():
@@ -323,7 +323,7 @@ def _gather_journal_context(days: int, max_chars: int | None = None) -> str:
         if date not in seen_dates:
             if len(seen_dates) >= days:
                 break
-            seen_dates.append(date)
+            seen_dates.add(date)
         content = journal_store.read_entry(entry_id)
         if not content:
             continue

--- a/apps/python/web/routers/chat.py
+++ b/apps/python/web/routers/chat.py
@@ -312,11 +312,11 @@ def _gather_journal_context(days: int, max_chars: int | None = None) -> str:
     """
     if max_chars is None:
         max_chars = JOURNAL_CONTEXT_MAX_CHARS
-    dates = journal_store.list_dates()[:days]
+    entry_ids = [entry_id for entry_id, _ in journal_store.list_files()][:days]
     sections: list[str] = []
     total = 0
-    for date in dates:
-        content = journal_store.read_entry(date)
+    for entry_id in entry_ids:
+        content = journal_store.read_entry(entry_id)
         if not content:
             continue
         section = content.strip()

--- a/apps/python/web/routers/chat.py
+++ b/apps/python/web/routers/chat.py
@@ -302,20 +302,28 @@ class JournalChatBody(BaseModel):
 
 
 def _gather_journal_context(days: int, max_chars: int | None = None) -> str:
-    """Concatenate the newest ``days`` journal files into one context blob.
+    """Concatenate journal entries from the newest ``days`` dates into a blob.
 
-    Returns "" when there are no journal entries. Entries are appended
-    newest-first and the blob is capped at ``max_chars`` (defaults to the
-    module-level ``JOURNAL_CONTEXT_MAX_CHARS``) so a long history can't blow
-    up the prompt; older entries past the budget are dropped. The whole blob
-    is wrapped as untrusted input by ``build_journal_cmd``.
+    Selection is day-based: all entries whose date falls in the most recent
+    ``days`` distinct dates are included (a single date may hold several
+    per-entry files). Entries are appended newest-first and the blob is capped
+    at ``max_chars`` (defaults to the module-level ``JOURNAL_CONTEXT_MAX_CHARS``)
+    so a long history can't blow up the prompt; entries past the budget are
+    dropped. The whole blob is wrapped as untrusted input by ``build_journal_cmd``.
     """
     if max_chars is None:
         max_chars = JOURNAL_CONTEXT_MAX_CHARS
-    entry_ids = [entry_id for entry_id, _ in journal_store.list_files()][:days]
+    # Walk entries newest-first, keeping every entry that belongs to one of the
+    # newest ``days`` distinct dates so multiple entries per day are preserved.
+    seen_dates: list[str] = []
     sections: list[str] = []
     total = 0
-    for entry_id in entry_ids:
+    for entry_id, _ in journal_store.list_files():
+        date = journal_store.date_of(entry_id)
+        if date not in seen_dates:
+            if len(seen_dates) >= days:
+                break
+            seen_dates.append(date)
         content = journal_store.read_entry(entry_id)
         if not content:
             continue

--- a/apps/python/web/routers/journal.py
+++ b/apps/python/web/routers/journal.py
@@ -1,12 +1,10 @@
-"""Journal API — accumulate and read daily Markdown notes (#271, Phase 1).
+"""Journal API — create and read per-entry Markdown notes (#271, #295).
 
-- ``POST /api/journal`` appends a timestamped note to today's file
-  (or to ``date`` when provided).
-- ``GET /api/journal`` lists available journal dates, newest first.
-- ``GET /api/journal/{date}`` returns the raw Markdown for a date.
+- ``POST /api/journal`` creates a new entry file (for today, or ``date``).
+- ``GET /api/journal`` lists available entries, newest first.
+- ``GET /api/journal/{entry_id}`` returns the raw Markdown for an entry.
 
-Notes are stored under ``output/journal/`` (gitignored). Phase 2 will feed
-this content into the chat flow for brainstorming.
+Notes are stored under ``output/journal/`` (gitignored), one file per entry.
 """
 from pydantic import BaseModel, Field
 
@@ -18,16 +16,18 @@ from web.auth import require_bearer
 router = APIRouter(dependencies=[Depends(require_bearer)])
 
 
-class JournalDate(BaseModel):
+class JournalEntry(BaseModel):
+    id: str  # entry id (file stem), e.g. 2026-06-24_153045
     date: str  # YYYY-MM-DD
     size: int  # bytes
 
 
 class JournalListResponse(BaseModel):
-    dates: list[JournalDate]
+    entries: list[JournalEntry]
 
 
 class JournalEntryResponse(BaseModel):
+    id: str
     date: str
     content: str
 
@@ -38,33 +38,40 @@ class AppendEntryRequest(BaseModel):
 
 
 class AppendEntryResponse(BaseModel):
+    id: str
     date: str
 
 
 @router.get("/journal", response_model=JournalListResponse)
 def list_journal() -> JournalListResponse:
-    """Return available journal dates, newest first."""
-    dates = [
-        JournalDate(date=date, size=path.stat().st_size)
-        for date, path in journal_store.list_files()
+    """Return available journal entries, newest first."""
+    entries = [
+        JournalEntry(
+            id=entry_id,
+            date=journal_store.date_of(entry_id),
+            size=path.stat().st_size,
+        )
+        for entry_id, path in journal_store.list_files()
     ]
-    return JournalListResponse(dates=dates)
+    return JournalListResponse(entries=entries)
 
 
 @router.post("/journal", response_model=AppendEntryResponse)
 def append_journal(req: AppendEntryRequest) -> AppendEntryResponse:
-    """Append a note to the day's journal file, creating it if absent."""
+    """Create a new journal entry file and return its id."""
     try:
-        date = journal_store.append_entry(req.content, req.date)
+        entry_id = journal_store.append_entry(req.content, req.date)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    return AppendEntryResponse(date=date)
+    return AppendEntryResponse(id=entry_id, date=journal_store.date_of(entry_id))
 
 
-@router.get("/journal/{date}", response_model=JournalEntryResponse)
-def get_journal(date: str) -> JournalEntryResponse:
-    """Return the Markdown body for a date. Unknown/invalid date returns 404."""
-    content = journal_store.read_entry(date)
+@router.get("/journal/{entry_id}", response_model=JournalEntryResponse)
+def get_journal(entry_id: str) -> JournalEntryResponse:
+    """Return the Markdown body for an entry. Unknown/invalid id returns 404."""
+    content = journal_store.read_entry(entry_id)
     if content is None:
-        raise HTTPException(status_code=404, detail=f"Journal not found: {date}")
-    return JournalEntryResponse(date=date, content=content)
+        raise HTTPException(status_code=404, detail=f"Journal not found: {entry_id}")
+    return JournalEntryResponse(
+        id=entry_id, date=journal_store.date_of(entry_id), content=content
+    )

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -18,6 +18,12 @@ const PROSE =
 const HEADER_BTN =
   "rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
 
+/** Extract HH:MM:SS from an entry id (YYYY-MM-DD_HHMMSS), or null for legacy day ids. */
+function entryTime(id: string): string | null {
+  const m = id.match(/^\d{4}-\d{2}-\d{2}_(\d{2})(\d{2})(\d{2})/)
+  return m ? `${m[1]}:${m[2]}:${m[3]}` : null
+}
+
 /** Join the `data:` lines of one raw SSE event block into text. */
 function parseSseEvent(raw: string): string {
   return raw
@@ -88,12 +94,17 @@ export function JournalScreen() {
   const loadEntry = useCallback(async (entryId: string) => {
     const seq = ++entryReqSeq.current
     setSelected(entryId)
-    const res = await fetch(`/api/journal/${entryId}`, { cache: "no-store" })
-    if (seq !== entryReqSeq.current) return
-    if (!res.ok) {
-      setContent("")
+    // Clear immediately so the previous entry's body can't render under the
+    // new header while the fetch is in flight (or if it fails).
+    setContent("")
+    let res: Response
+    try {
+      res = await fetch(`/api/journal/${entryId}`, { cache: "no-store" })
+    } catch {
       return
     }
+    if (seq !== entryReqSeq.current) return
+    if (!res.ok) return
     const data = (await res.json()) as { content: string }
     if (seq !== entryReqSeq.current) return
     setContent(data.content)
@@ -242,7 +253,12 @@ export function JournalScreen() {
                           : "hover:bg-accent/50",
                       )}
                     >
-                      <span className="tabular-nums">{e.date}</span>
+                      <span className="tabular-nums">
+                        {e.date}
+                        {entryTime(e.id) && (
+                          <span className="ml-2 text-muted-foreground">{entryTime(e.id)}</span>
+                        )}
+                      </span>
                       <span className="tabular-nums text-muted-foreground">
                         {(e.size / 1024).toFixed(1)}
                       </span>
@@ -268,7 +284,10 @@ export function JournalScreen() {
           {/* Panel header */}
           <div className="flex items-center justify-between border-b px-4 py-2">
             <div className="flex gap-3 text-xs text-muted-foreground">
-              <span>{selectedMeta?.date ?? selected}</span>
+              <span>
+                {selectedMeta?.date ?? selected}
+                {entryTime(selected) && ` ${entryTime(selected)}`}
+              </span>
               {selectedMeta && (
                 <span>{(selectedMeta.size / 1024).toFixed(1)} KB</span>
               )}

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -8,7 +8,7 @@ import { ResizeHandle } from "@/components/ResizeHandle"
 import { useResizable } from "@/lib/hooks/useResizable"
 import { cn } from "@/lib/utils"
 
-type JournalDate = { date: string; size: number }
+type JournalEntry = { id: string; date: string; size: number }
 type Turn = { question: string; answer: string }
 
 const PROSE =
@@ -48,14 +48,9 @@ async function* readSse(body: ReadableStream<Uint8Array>): AsyncGenerator<string
 }
 
 export function JournalScreen() {
-  const [dates, setDates] = useState<JournalDate[]>([])
+  const [entries, setEntries] = useState<JournalEntry[]>([])
   const [datesError, setDatesError] = useState<string | null>(null)
   const [selected, setSelected] = useState<string | null>(null)
-  // Mirror of `selected` so async callbacks read the live selection.
-  const selectedRef = useRef<string | null>(null)
-  useEffect(() => {
-    selectedRef.current = selected
-  }, [selected])
   const [content, setContent] = useState("")
   const entryReqSeq = useRef(0)
   const [entry, setEntry] = useState("")
@@ -82,18 +77,18 @@ export function JournalScreen() {
         setDatesError(`Failed to load entries (HTTP ${res.status})`)
         return
       }
-      const data = (await res.json()) as { dates: JournalDate[] }
-      setDates(data.dates)
-      return data.dates
+      const data = (await res.json()) as { entries: JournalEntry[] }
+      setEntries(data.entries)
+      return data.entries
     } catch (e) {
       setDatesError(`Failed to load entries: ${String(e)}`)
     }
   }, [])
 
-  const loadEntry = useCallback(async (date: string) => {
+  const loadEntry = useCallback(async (entryId: string) => {
     const seq = ++entryReqSeq.current
-    setSelected(date)
-    const res = await fetch(`/api/journal/${date}`, { cache: "no-store" })
+    setSelected(entryId)
+    const res = await fetch(`/api/journal/${entryId}`, { cache: "no-store" })
     if (seq !== entryReqSeq.current) return
     if (!res.ok) {
       setContent("")
@@ -126,10 +121,10 @@ export function JournalScreen() {
         setSaveError(`Save failed (HTTP ${res.status}): ${body}`)
         return
       }
-      const { date } = (await res.json()) as { date: string }
+      const { id } = (await res.json()) as { id: string }
       setEntry("")
       await loadDates()
-      await loadEntry(date)
+      await loadEntry(id)
     } catch (e) {
       setSaveError(String(e))
     } finally {
@@ -197,18 +192,18 @@ export function JournalScreen() {
         setChatError(`Auto-save failed (HTTP ${saveRes.status}): ${body}`)
         return
       }
-      const { date } = (await saveRes.json()) as { date: string }
       await loadDates()
-      if (selectedRef.current === date) await loadEntry(date)
+      // The brainstorm answer is saved as its own entry; the transcript above
+      // already shows it, so leave the current selection untouched.
     } catch (e) {
       setChatError(String(e))
     } finally {
       setBrainstorming(false)
     }
-  }, [question, brainstorming, appendToLastAnswer, loadDates, loadEntry])
+  }, [question, brainstorming, appendToLastAnswer, loadDates])
 
-  const sortedDates = [...dates].sort((a, b) => b.date.localeCompare(a.date))
-  const selectedMeta = sortedDates.find((d) => d.date === selected)
+  const sortedEntries = [...entries].sort((a, b) => b.id.localeCompare(a.id))
+  const selectedMeta = sortedEntries.find((e) => e.id === selected)
 
   return (
     <div className="flex h-full">
@@ -222,7 +217,7 @@ export function JournalScreen() {
       >
         {datesError ? (
           <p className="px-3 py-4 text-sm text-destructive">{datesError}</p>
-        ) : sortedDates.length === 0 ? (
+        ) : sortedEntries.length === 0 ? (
           <p className="px-3 py-4 text-sm text-muted-foreground">No entries yet.</p>
         ) : (
           <table className="w-full text-sm">
@@ -233,23 +228,23 @@ export function JournalScreen() {
               </tr>
             </thead>
             <tbody>
-              {sortedDates.map((d) => (
-                <tr key={d.date} className="border-b last:border-0">
+              {sortedEntries.map((e) => (
+                <tr key={e.id} className="border-b last:border-0">
                   <td colSpan={2} className="p-0">
                     <button
                       type="button"
-                      aria-pressed={selected === d.date}
-                      onClick={() => void loadEntry(d.date)}
+                      aria-pressed={selected === e.id}
+                      onClick={() => void loadEntry(e.id)}
                       className={cn(
                         "flex w-full items-center justify-between px-3 py-2 text-left text-xs transition-colors",
-                        selected === d.date
+                        selected === e.id
                           ? "bg-accent font-medium text-accent-foreground"
                           : "hover:bg-accent/50",
                       )}
                     >
-                      <span className="tabular-nums">{d.date}</span>
+                      <span className="tabular-nums">{e.date}</span>
                       <span className="tabular-nums text-muted-foreground">
-                        {(d.size / 1024).toFixed(1)}
+                        {(e.size / 1024).toFixed(1)}
                       </span>
                     </button>
                   </td>
@@ -273,7 +268,7 @@ export function JournalScreen() {
           {/* Panel header */}
           <div className="flex items-center justify-between border-b px-4 py-2">
             <div className="flex gap-3 text-xs text-muted-foreground">
-              <span>{selected}</span>
+              <span>{selectedMeta?.date ?? selected}</span>
               {selectedMeta && (
                 <span>{(selectedMeta.size / 1024).toFixed(1)} KB</span>
               )}

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -49,7 +49,7 @@ async function* readSse(body: ReadableStream<Uint8Array>): AsyncGenerator<string
 
 export function JournalScreen() {
   const [entries, setEntries] = useState<JournalEntry[]>([])
-  const [datesError, setDatesError] = useState<string | null>(null)
+  const [entriesError, setEntriesError] = useState<string | null>(null)
   const [selected, setSelected] = useState<string | null>(null)
   const [content, setContent] = useState("")
   const entryReqSeq = useRef(0)
@@ -71,17 +71,17 @@ export function JournalScreen() {
 
   const loadDates = useCallback(async () => {
     try {
-      setDatesError(null)
+      setEntriesError(null)
       const res = await fetch("/api/journal", { cache: "no-store" })
       if (!res.ok) {
-        setDatesError(`Failed to load entries (HTTP ${res.status})`)
+        setEntriesError(`Failed to load entries (HTTP ${res.status})`)
         return
       }
       const data = (await res.json()) as { entries: JournalEntry[] }
       setEntries(data.entries)
       return data.entries
     } catch (e) {
-      setDatesError(`Failed to load entries: ${String(e)}`)
+      setEntriesError(`Failed to load entries: ${String(e)}`)
     }
   }, [])
 
@@ -215,8 +215,8 @@ export function JournalScreen() {
           selected ? "border-r" : "flex-1",
         )}
       >
-        {datesError ? (
-          <p className="px-3 py-4 text-sm text-destructive">{datesError}</p>
+        {entriesError ? (
+          <p className="px-3 py-4 text-sm text-destructive">{entriesError}</p>
         ) : sortedEntries.length === 0 ? (
           <p className="px-3 py-4 text-sm text-muted-foreground">No entries yet.</p>
         ) : (

--- a/apps/web/tests/briefing-dashboard.test.tsx
+++ b/apps/web/tests/briefing-dashboard.test.tsx
@@ -274,12 +274,16 @@ describe("BriefingDashboard", () => {
     const user = userEvent.setup()
     await user.type(screen.getByTestId("briefing-search-input"), "content")
 
-    // search narrows the list to the two server matches
-    await waitFor(() =>
-      expect(screen.queryByTestId("briefing-row-briefing_2026-06-19.md")).not.toBeInTheDocument(),
-    )
-    expect(screen.getByTestId("briefing-row-briefing_2026-06-20.md")).toBeInTheDocument()
-    expect(screen.getByTestId("briefing-row-local_2026-06-18.md")).toBeInTheDocument()
+    // search narrows the list to the two server matches. Assert the full final
+    // state in one waitFor: the unmatched row gone AND both matches present.
+    // This only holds once results arrive, so it can't race the debounced
+    // fetch's transient empty state nor match the initial pre-search list
+    // (which also contains 2026-06-20).
+    await waitFor(() => {
+      expect(screen.queryByTestId("briefing-row-briefing_2026-06-19.md")).not.toBeInTheDocument()
+      expect(screen.getByTestId("briefing-row-briefing_2026-06-20.md")).toBeInTheDocument()
+      expect(screen.getByTestId("briefing-row-local_2026-06-18.md")).toBeInTheDocument()
+    })
     const searchUrl = fetchMock.mock.calls.map((c) => c[0]).find((u: string) => u.includes("/search"))
     expect(searchUrl).toContain("q=content")
 


### PR DESCRIPTION
## Summary
- Each journal entry is now its own `YYYY-MM-DD_HHMMSS.md` file (id = file stem), so one date can hold multiple independent entries
- API: `GET /journal` → `entries[{id,date,size}]`; `POST` → `{id,date}`; `GET /journal/{id}` → `{id,date,content}`
- Brainstorm auto-save creates a separate entry instead of appending to the day file
- Frontend keys list rows and selection on entry id
- **Migration:** legacy `YYYY-MM-DD.md` day files stay listable and readable (resolved at read time); no one-shot migration needed

## Test plan
- [ ] `apps/python/tests/test_api_journal.py` passes (incl. legacy day-file compat)
- [ ] Full `pytest` green (649 passed)
- [ ] Two POSTs with the same date produce two separate entries
- [ ] `tsc --noEmit` + vitest (163) pass on web

Closes #295

## Summary by Sourcery

Move journal storage and API from one-file-per-day to one-file-per-entry, while keeping legacy day files readable and listable.

New Features:
- Expose journal entry identifiers in the API and frontend so multiple entries can coexist per date and be addressed individually.
- Support listing and fetching per-entry journal files, including multiple entries on the same day, in both the backend and web UI.

Enhancements:
- Update journal context gathering for chat to be based on distinct dates while including all entries for those days.
- Adjust web journal screen to key selection and display on entry id and to treat brainstorm auto-save outputs as separate entries without changing selection.

Tests:
- Extend API and chat tests to cover the new per-entry storage model and verify backward compatibility with legacy day-based journal files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Journal entries are now saved and viewed as individual notes, each with its own entry ID.
  * The journal list now shows separate entries with dates and sizes, and supports multiple entries on the same day.

* **Bug Fixes**
  * Viewing and saving journal items now works consistently with the new entry-based format.
  * Chat context now includes all entries from the most recent days, instead of only one note per day.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->