### PR TITLE
feat(journal): soft-delete entries via trash directory

### DIFF
--- a/apps/python/src/journal_store.py
+++ b/apps/python/src/journal_store.py
@@ -117,3 +117,58 @@ def read_entry(entry_id: str) -> str | None:
     if not path.exists() or not path.is_file():
         return None
     return path.read_text(encoding="utf-8")
+
+
+def _deleted_dir() -> Path:
+    """Return the trash directory for soft-deleted entries."""
+    return JOURNAL_DIR / "deleted"
+
+
+def soft_delete(entry_id: str) -> bool:
+    """Move an active entry into the trash directory.
+
+    Returns True if the entry was found and moved, False if it does not exist.
+    Because ``list_files`` only globs the top-level directory, a moved entry is
+    automatically excluded from listings without any per-query filtering.
+    """
+    if not _ENTRY_RE.match(entry_id):
+        return False
+    src = JOURNAL_DIR / f"{entry_id}.md"
+    if not src.exists() or not src.is_file():
+        return False
+    trash = _deleted_dir()
+    trash.mkdir(parents=True, exist_ok=True)
+    src.replace(trash / f"{entry_id}.md")
+    return True
+
+
+def restore(entry_id: str) -> bool:
+    """Move a soft-deleted entry back into the active directory.
+
+    Returns True if a trashed entry was found and restored, False otherwise.
+    Restoring over an existing active entry is refused (returns False).
+    """
+    if not _ENTRY_RE.match(entry_id):
+        return False
+    src = _deleted_dir() / f"{entry_id}.md"
+    if not src.exists() or not src.is_file():
+        return False
+    dst = JOURNAL_DIR / f"{entry_id}.md"
+    if dst.exists():
+        return False
+    src.replace(dst)
+    return True
+
+
+def purge(entry_id: str) -> bool:
+    """Permanently delete a soft-deleted entry from the trash directory.
+
+    Returns True if a trashed entry was found and removed, False otherwise.
+    """
+    if not _ENTRY_RE.match(entry_id):
+        return False
+    path = _deleted_dir() / f"{entry_id}.md"
+    if not path.exists() or not path.is_file():
+        return False
+    path.unlink()
+    return True

--- a/apps/python/tests/test_api_journal.py
+++ b/apps/python/tests/test_api_journal.py
@@ -207,3 +207,16 @@ async def test_purge_permanently_deletes_from_trash(authed_client, journal_dir):
 async def test_delete_requires_auth(async_client, journal_dir):
     resp = await async_client.delete("/api/journal/2026-06-24_120000")
     assert resp.status_code == 401
+
+
+async def test_purge_param_requires_literal_true(authed_client, journal_dir):
+    """A non-'true' purge value soft-deletes (no accidental permanent delete)."""
+    post = await authed_client.post(
+        "/api/journal", json={"content": "keep recoverable", "date": "2026-06-24"}
+    )
+    entry_id = post.json()["id"]
+
+    resp = await authed_client.delete(f"/api/journal/{entry_id}?purge=1")
+    assert resp.status_code == 204
+    # Soft-deleted, not purged: still recoverable in trash.
+    assert (journal_dir / "deleted" / f"{entry_id}.md").exists()

--- a/apps/python/tests/test_api_journal.py
+++ b/apps/python/tests/test_api_journal.py
@@ -150,3 +150,60 @@ async def test_append_nonexistent_calendar_date_rejected(authed_client, journal_
         "/api/journal", json={"content": "x", "date": "2026-99-99"}
     )
     assert response.status_code == 400
+
+
+async def test_soft_delete_moves_to_trash_and_excludes_from_list(authed_client, journal_dir):
+    post = await authed_client.post(
+        "/api/journal", json={"content": "to delete", "date": "2026-06-24"}
+    )
+    entry_id = post.json()["id"]
+
+    resp = await authed_client.delete(f"/api/journal/{entry_id}")
+    assert resp.status_code == 204
+    # File moved under deleted/, gone from the active dir.
+    assert not (journal_dir / f"{entry_id}.md").exists()
+    assert (journal_dir / "deleted" / f"{entry_id}.md").exists()
+    # No longer listed.
+    listed = await authed_client.get("/api/journal")
+    assert all(e["id"] != entry_id for e in listed.json()["entries"])
+
+
+async def test_soft_delete_unknown_returns_404(authed_client, journal_dir):
+    resp = await authed_client.delete("/api/journal/2099-01-01_120000")
+    assert resp.status_code == 404
+
+
+async def test_restore_returns_entry_to_active_list(authed_client, journal_dir):
+    post = await authed_client.post(
+        "/api/journal", json={"content": "restore me", "date": "2026-06-24"}
+    )
+    entry_id = post.json()["id"]
+    await authed_client.delete(f"/api/journal/{entry_id}")
+
+    resp = await authed_client.post(f"/api/journal/{entry_id}/restore")
+    assert resp.status_code == 204
+    assert (journal_dir / f"{entry_id}.md").exists()
+    listed = await authed_client.get("/api/journal")
+    assert any(e["id"] == entry_id for e in listed.json()["entries"])
+
+
+async def test_restore_unknown_returns_404(authed_client, journal_dir):
+    resp = await authed_client.post("/api/journal/2099-01-01_120000/restore")
+    assert resp.status_code == 404
+
+
+async def test_purge_permanently_deletes_from_trash(authed_client, journal_dir):
+    post = await authed_client.post(
+        "/api/journal", json={"content": "purge me", "date": "2026-06-24"}
+    )
+    entry_id = post.json()["id"]
+    await authed_client.delete(f"/api/journal/{entry_id}")
+
+    resp = await authed_client.delete(f"/api/journal/{entry_id}?purge=true")
+    assert resp.status_code == 204
+    assert not (journal_dir / "deleted" / f"{entry_id}.md").exists()
+
+
+async def test_delete_requires_auth(async_client, journal_dir):
+    resp = await async_client.delete("/api/journal/2026-06-24_120000")
+    assert resp.status_code == 401

--- a/apps/python/web/routers/journal.py
+++ b/apps/python/web/routers/journal.py
@@ -75,3 +75,18 @@ def get_journal(entry_id: str) -> JournalEntryResponse:
     return JournalEntryResponse(
         id=entry_id, date=journal_store.date_of(entry_id), content=content
     )
+
+
+@router.delete("/journal/{entry_id}", status_code=204)
+def delete_journal(entry_id: str, purge: bool = False) -> None:
+    """Soft-delete an entry (move to trash), or permanently delete with ?purge=true."""
+    ok = journal_store.purge(entry_id) if purge else journal_store.soft_delete(entry_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail=f"Journal not found: {entry_id}")
+
+
+@router.post("/journal/{entry_id}/restore", status_code=204)
+def restore_journal(entry_id: str) -> None:
+    """Restore a soft-deleted entry back into the active list."""
+    if not journal_store.restore(entry_id):
+        raise HTTPException(status_code=404, detail=f"Trashed journal not found: {entry_id}")

--- a/apps/python/web/routers/journal.py
+++ b/apps/python/web/routers/journal.py
@@ -78,9 +78,16 @@ def get_journal(entry_id: str) -> JournalEntryResponse:
 
 
 @router.delete("/journal/{entry_id}", status_code=204)
-def delete_journal(entry_id: str, purge: bool = False) -> None:
-    """Soft-delete an entry (move to trash), or permanently delete with ?purge=true."""
-    ok = journal_store.purge(entry_id) if purge else journal_store.soft_delete(entry_id)
+def delete_journal(entry_id: str, purge: str | None = None) -> None:
+    """Soft-delete an entry (move to trash), or permanently delete it.
+
+    Only a literal ``?purge=true`` performs a permanent delete; any other value
+    (``?purge=1``, ``?purge=yes``, ``?purge=false``, or omission) soft-deletes.
+    The strict match guards against accidental permanent deletes from FastAPI's
+    lenient bool coercion.
+    """
+    should_purge = purge == "true"
+    ok = journal_store.purge(entry_id) if should_purge else journal_store.soft_delete(entry_id)
     if not ok:
         raise HTTPException(status_code=404, detail=f"Journal not found: {entry_id}")
 

--- a/apps/web/components/briefing/icons.tsx
+++ b/apps/web/components/briefing/icons.tsx
@@ -50,6 +50,17 @@ export function CloseIcon(props: IconProps) {
   )
 }
 
+export function TrashIcon({ size = 14 }: IconProps) {
+  return (
+    <Svg size={size}>
+      <polyline points="3 6 5 6 21 6" />
+      <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+      <line x1="10" y1="11" x2="10" y2="17" />
+      <line x1="14" y1="11" x2="14" y2="17" />
+    </Svg>
+  )
+}
+
 export function ExternalLinkIcon({ size = 12 }: IconProps) {
   return (
     <Svg size={size}>

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -287,7 +287,7 @@ export function JournalScreen() {
                         type="button"
                         onClick={() => void deleteEntry(e.id)}
                         aria-label={`Delete entry ${e.id}`}
-                        className="absolute right-2 rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-destructive focus:opacity-100 group-hover:opacity-100"
+                        className="absolute right-2 rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-destructive focus:bg-accent focus:text-destructive focus:opacity-100 group-hover:opacity-100"
                       >
                         <TrashIcon />
                       </button>

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 
-import { CloseIcon } from "@/components/briefing/icons"
+import { CloseIcon, TrashIcon } from "@/components/briefing/icons"
 import { ResizeHandle } from "@/components/ResizeHandle"
 import { useResizable } from "@/lib/hooks/useResizable"
 import { cn } from "@/lib/utils"
@@ -115,6 +115,25 @@ export function JournalScreen() {
   }, [loadDates])
 
   const closePanel = () => setSelected(null)
+
+  const deleteEntry = useCallback(
+    async (entryId: string) => {
+      if (!window.confirm("Move this entry to trash?")) return
+      try {
+        const res = await fetch(`/api/journal/${entryId}`, { method: "DELETE" })
+        if (!res.ok) {
+          setEntriesError(`Delete failed (HTTP ${res.status})`)
+          return
+        }
+        // Collapse the panel if the open entry was the one removed.
+        setSelected((cur) => (cur === entryId ? null : cur))
+        await loadDates()
+      } catch (e) {
+        setEntriesError(`Delete failed: ${String(e)}`)
+      }
+    },
+    [loadDates],
+  )
 
   const save = useCallback(async () => {
     const text = entry.trim()
@@ -242,27 +261,37 @@ export function JournalScreen() {
               {sortedEntries.map((e) => (
                 <tr key={e.id} className="border-b last:border-0">
                   <td colSpan={2} className="p-0">
-                    <button
-                      type="button"
-                      aria-pressed={selected === e.id}
-                      onClick={() => void loadEntry(e.id)}
-                      className={cn(
-                        "flex w-full items-center justify-between px-3 py-2 text-left text-xs transition-colors",
-                        selected === e.id
-                          ? "bg-accent font-medium text-accent-foreground"
-                          : "hover:bg-accent/50",
-                      )}
-                    >
-                      <span className="tabular-nums">
-                        {e.date}
-                        {entryTime(e.id) && (
-                          <span className="ml-2 text-muted-foreground">{entryTime(e.id)}</span>
+                    <div className="group relative flex items-center">
+                      <button
+                        type="button"
+                        aria-pressed={selected === e.id}
+                        onClick={() => void loadEntry(e.id)}
+                        className={cn(
+                          "flex w-full items-center justify-between px-3 py-2 text-left text-xs transition-colors",
+                          selected === e.id
+                            ? "bg-accent font-medium text-accent-foreground"
+                            : "hover:bg-accent/50",
                         )}
-                      </span>
-                      <span className="tabular-nums text-muted-foreground">
-                        {(e.size / 1024).toFixed(1)}
-                      </span>
-                    </button>
+                      >
+                        <span className="tabular-nums">
+                          {e.date}
+                          {entryTime(e.id) && (
+                            <span className="ml-2 text-muted-foreground">{entryTime(e.id)}</span>
+                          )}
+                        </span>
+                        <span className="pr-6 tabular-nums text-muted-foreground">
+                          {(e.size / 1024).toFixed(1)}
+                        </span>
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void deleteEntry(e.id)}
+                        aria-label={`Delete entry ${e.id}`}
+                        className="absolute right-2 rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-destructive focus:opacity-100 group-hover:opacity-100"
+                      >
+                        <TrashIcon />
+                      </button>
+                    </div>
                   </td>
                 </tr>
               ))}


### PR DESCRIPTION
## Summary
- `journal_store`: `soft_delete`/`restore`/`purge` move files in/out of a `deleted/` trash dir; `list_files` excludes it automatically (no flag filtering)
- API: `DELETE /journal/{id}` (soft; `?purge=true` for permanent), `POST /journal/{id}/restore`
- Frontend: per-row trash icon (shown on hover) with confirm; the row drops on success and the panel collapses if the open entry was deleted

## Test plan
- [ ] `pytest` green (657): soft-delete, listing exclusion, restore, purge, auth
- [ ] `DELETE /journal/{id}` → 204, file moved under `deleted/`, gone from list
- [ ] `POST /journal/{id}/restore` → 204, entry back in list
- [ ] tsc + vitest (163) pass on web

Closes #296

## Summary by Sourcery

Introduce soft-delete, restore, and purge flows for journal entries across backend and frontend.

New Features:
- Add backend support for soft-deleting journal entries to a trash directory, restoring them, and permanently purging them.
- Expose DELETE /api/journal/{id} with optional ?purge=true and POST /api/journal/{id}/restore endpoints for managing journal entry lifecycle.
- Add a trash icon and delete interaction to the journal entries list, including confirmation and auto-collapsing of the currently open entry on delete.

Tests:
- Add API tests covering soft delete behavior, listing exclusion, restore, purge semantics, purge query parameter handling, and auth requirements for journal deletion.