### PR TITLE
feat(web): add Journal trash view to restore or purge deleted entries

### DIFF
--- a/apps/python/src/journal_store.py
+++ b/apps/python/src/journal_store.py
@@ -92,21 +92,31 @@ def append_entry(content: str, date: str | None = None) -> str:
             n += 1
 
 
-def list_files() -> list[tuple[str, Path]]:
-    """Return (entry_id, path) for available entries, newest first.
+def _list_entry_files(directory: Path) -> list[tuple[str, Path]]:
+    """Return (entry_id, path) for entry files in a directory, newest first.
 
     Entry ids start with the date and embed the time, so a reverse
     lexicographic sort yields newest-first ordering.
     """
-    if not JOURNAL_DIR.exists():
+    if not directory.exists():
         return []
     files = [
         (path.stem, path)
-        for path in JOURNAL_DIR.glob("*.md")
+        for path in directory.glob("*.md")
         if path.is_file() and _ENTRY_RE.match(path.stem)
     ]
     files.sort(key=lambda f: f[0], reverse=True)
     return files
+
+
+def list_files() -> list[tuple[str, Path]]:
+    """Return (entry_id, path) for available entries, newest first."""
+    return _list_entry_files(JOURNAL_DIR)
+
+
+def list_trashed() -> list[tuple[str, Path]]:
+    """Return (entry_id, path) for soft-deleted entries, newest first."""
+    return _list_entry_files(_deleted_dir())
 
 
 def read_entry(entry_id: str) -> str | None:

--- a/apps/python/tests/test_api_journal.py
+++ b/apps/python/tests/test_api_journal.py
@@ -220,3 +220,33 @@ async def test_purge_param_requires_literal_true(authed_client, journal_dir):
     assert resp.status_code == 204
     # Soft-deleted, not purged: still recoverable in trash.
     assert (journal_dir / "deleted" / f"{entry_id}.md").exists()
+
+
+async def test_trash_lists_soft_deleted_entries(authed_client, journal_dir):
+    post = await authed_client.post(
+        "/api/journal", json={"content": "trash me", "date": "2026-06-24"}
+    )
+    entry_id = post.json()["id"]
+    await authed_client.delete(f"/api/journal/{entry_id}")
+
+    resp = await authed_client.get("/api/journal/trash")
+    assert resp.status_code == 200
+    trashed = resp.json()["entries"]
+    assert any(e["id"] == entry_id for e in trashed)
+    row = next(e for e in trashed if e["id"] == entry_id)
+    assert row["date"] == "2026-06-24"
+    assert row["size"] > 0
+    # Active list does not include the trashed entry.
+    active = await authed_client.get("/api/journal")
+    assert all(e["id"] != entry_id for e in active.json()["entries"])
+
+
+async def test_trash_empty_when_nothing_deleted(authed_client, journal_dir):
+    resp = await authed_client.get("/api/journal/trash")
+    assert resp.status_code == 200
+    assert resp.json()["entries"] == []
+
+
+async def test_trash_requires_auth(async_client, journal_dir):
+    resp = await async_client.get("/api/journal/trash")
+    assert resp.status_code == 401

--- a/apps/python/web/routers/journal.py
+++ b/apps/python/web/routers/journal.py
@@ -6,6 +6,8 @@
 
 Notes are stored under ``output/journal/`` (gitignored), one file per entry.
 """
+from pathlib import Path
+
 from pydantic import BaseModel, Field
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -42,18 +44,27 @@ class AppendEntryResponse(BaseModel):
     date: str
 
 
-@router.get("/journal", response_model=JournalListResponse)
-def list_journal() -> JournalListResponse:
-    """Return available journal entries, newest first."""
-    entries = [
+def _to_entries(files: list[tuple[str, Path]]) -> list[JournalEntry]:
+    return [
         JournalEntry(
             id=entry_id,
             date=journal_store.date_of(entry_id),
             size=path.stat().st_size,
         )
-        for entry_id, path in journal_store.list_files()
+        for entry_id, path in files
     ]
-    return JournalListResponse(entries=entries)
+
+
+@router.get("/journal", response_model=JournalListResponse)
+def list_journal() -> JournalListResponse:
+    """Return available journal entries, newest first."""
+    return JournalListResponse(entries=_to_entries(journal_store.list_files()))
+
+
+@router.get("/journal/trash", response_model=JournalListResponse)
+def list_trash() -> JournalListResponse:
+    """Return soft-deleted journal entries, newest first."""
+    return JournalListResponse(entries=_to_entries(journal_store.list_trashed()))
 
 
 @router.post("/journal", response_model=AppendEntryResponse)

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -56,6 +56,8 @@ async function* readSse(body: ReadableStream<Uint8Array>): AsyncGenerator<string
 export function JournalScreen() {
   const [entries, setEntries] = useState<JournalEntry[]>([])
   const [entriesError, setEntriesError] = useState<string | null>(null)
+  const [trash, setTrash] = useState<JournalEntry[]>([])
+  const [showTrash, setShowTrash] = useState(false)
   const [selected, setSelected] = useState<string | null>(null)
   const [composing, setComposing] = useState(false)
   const composeRef = useRef<HTMLTextAreaElement>(null)
@@ -136,6 +138,20 @@ export function JournalScreen() {
     if (composing) composeRef.current?.focus()
   }, [composing])
 
+  const loadTrash = useCallback(async () => {
+    try {
+      const res = await fetch("/api/journal/trash", { cache: "no-store" })
+      if (!res.ok) {
+        setEntriesError(`Failed to load trash (HTTP ${res.status})`)
+        return
+      }
+      const data = (await res.json()) as { entries: JournalEntry[] }
+      setTrash(data.entries)
+    } catch (e) {
+      setEntriesError(`Failed to load trash: ${String(e)}`)
+    }
+  }, [])
+
   const deleteEntry = useCallback(
     async (entryId: string) => {
       if (!window.confirm("Move this entry to trash?")) return
@@ -154,6 +170,48 @@ export function JournalScreen() {
     },
     [loadDates],
   )
+
+  const restoreEntry = useCallback(
+    async (entryId: string) => {
+      try {
+        const res = await fetch(`/api/journal/${entryId}/restore`, { method: "POST" })
+        if (!res.ok) {
+          setEntriesError(`Restore failed (HTTP ${res.status})`)
+          return
+        }
+        await Promise.all([loadDates(), loadTrash()])
+      } catch (e) {
+        setEntriesError(`Restore failed: ${String(e)}`)
+      }
+    },
+    [loadDates, loadTrash],
+  )
+
+  const purgeEntry = useCallback(
+    async (entryId: string) => {
+      if (!window.confirm("Permanently delete this entry? This cannot be undone.")) return
+      try {
+        const res = await fetch(`/api/journal/${entryId}?purge=true`, { method: "DELETE" })
+        if (!res.ok) {
+          setEntriesError(`Permanent delete failed (HTTP ${res.status})`)
+          return
+        }
+        await loadTrash()
+      } catch (e) {
+        setEntriesError(`Permanent delete failed: ${String(e)}`)
+      }
+    },
+    [loadTrash],
+  )
+
+  // Toggle the trash view, loading its contents when opening.
+  const toggleTrash = () => {
+    setShowTrash((cur) => {
+      const next = !cur
+      if (next) void loadTrash()
+      return next
+    })
+  }
 
   const save = useCallback(async () => {
     const text = entry.trim()
@@ -266,19 +324,79 @@ export function JournalScreen() {
           panelOpen ? "border-r" : "flex-1",
         )}
       >
-        {/* New entry — explicit create path, always available */}
-        <div className="border-b p-2">
+        {/* Top bar: New entry create path + Trash toggle */}
+        <div className="flex items-center gap-2 border-b p-2">
           <button
             type="button"
             onClick={startCompose}
-            className="flex w-full items-center justify-center gap-1 rounded-md border border-dashed px-3 py-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+            className="flex flex-1 items-center justify-center gap-1 rounded-md border border-dashed px-3 py-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
           >
             <span className="text-base leading-none">+</span> New entry
           </button>
+          <button
+            type="button"
+            onClick={toggleTrash}
+            aria-pressed={showTrash}
+            className={cn(
+              "flex items-center gap-1 rounded-md border px-3 py-2 text-xs font-medium transition-colors",
+              showTrash
+                ? "bg-accent text-accent-foreground"
+                : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+            )}
+          >
+            <TrashIcon /> Trash
+          </button>
         </div>
 
-        {entriesError ? (
+        {entriesError && (
           <p className="px-3 py-4 text-sm text-destructive">{entriesError}</p>
+        )}
+
+        {showTrash ? (
+          trash.length === 0 ? (
+            <p className="px-3 py-4 text-sm text-muted-foreground">Trash is empty.</p>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b bg-muted/50 text-xs text-muted-foreground">
+                  <th className="px-3 py-2 text-left">Deleted</th>
+                  <th className="px-3 py-2 text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {[...trash]
+                  .sort((a, b) => b.id.localeCompare(a.id))
+                  .map((e) => (
+                    <tr key={e.id} className="border-b last:border-0">
+                      <td className="px-3 py-2 text-xs tabular-nums">
+                        {e.date}
+                        {entryTime(e.id) && (
+                          <span className="ml-2 text-muted-foreground">{entryTime(e.id)}</span>
+                        )}
+                      </td>
+                      <td className="px-3 py-2">
+                        <div className="flex items-center justify-end gap-2">
+                          <button
+                            type="button"
+                            onClick={() => void restoreEntry(e.id)}
+                            className="rounded-md border px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+                          >
+                            Restore
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => void purgeEntry(e.id)}
+                            className="rounded-md border px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-destructive"
+                          >
+                            Delete
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+              </tbody>
+            </table>
+          )
         ) : sortedEntries.length === 0 ? (
           <p className="px-3 py-4 text-sm text-muted-foreground">No entries yet.</p>
         ) : (

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -140,6 +140,7 @@ export function JournalScreen() {
 
   const loadTrash = useCallback(async () => {
     try {
+      setEntriesError(null)
       const res = await fetch("/api/journal/trash", { cache: "no-store" })
       if (!res.ok) {
         setEntriesError(`Failed to load trash (HTTP ${res.status})`)
@@ -204,14 +205,13 @@ export function JournalScreen() {
     [loadTrash],
   )
 
-  // Toggle the trash view, loading its contents when opening.
-  const toggleTrash = () => {
-    setShowTrash((cur) => {
-      const next = !cur
-      if (next) void loadTrash()
-      return next
-    })
-  }
+  // Toggle the trash view, loading its contents when opening. Side effects stay
+  // out of the state updater: compute `next`, set it, then conditionally load.
+  const toggleTrash = useCallback(() => {
+    const next = !showTrash
+    setShowTrash(next)
+    if (next) void loadTrash()
+  }, [showTrash, loadTrash])
 
   const save = useCallback(async () => {
     const text = entry.trim()
@@ -360,6 +360,7 @@ export function JournalScreen() {
               <thead>
                 <tr className="border-b bg-muted/50 text-xs text-muted-foreground">
                   <th className="px-3 py-2 text-left">Deleted</th>
+                  <th className="px-3 py-2 text-right">Size (KB)</th>
                   <th className="px-3 py-2 text-right">Actions</th>
                 </tr>
               </thead>
@@ -373,6 +374,9 @@ export function JournalScreen() {
                         {entryTime(e.id) && (
                           <span className="ml-2 text-muted-foreground">{entryTime(e.id)}</span>
                         )}
+                      </td>
+                      <td className="px-3 py-2 text-right text-xs tabular-nums text-muted-foreground">
+                        {(e.size / 1024).toFixed(1)}
                       </td>
                       <td className="px-3 py-2">
                         <div className="flex items-center justify-end gap-2">


### PR DESCRIPTION
## Summary
- `journal_store.list_trashed()` lists soft-deleted entries (shares glob helper with `list_files`)
- API: `GET /journal/trash` (declared before `/journal/{id}` so the static path isn't shadowed)
- Frontend: a Trash toggle in the list top bar; trashed rows offer Restore (`POST /restore`) and Delete permanently (`DELETE ?purge=true`, with confirm)

## Test plan
- [x] `GET /journal/trash` returns soft-deleted entries with id/date/size; excluded from active list
- [ ] Restore returns an entry to the active list; purge removes it for good (after confirm)
- [ ] pytest 661 + vitest 163 pass

Closes #301

## Summary by Sourcery

Add support for viewing and managing soft-deleted journal entries via a dedicated trash listing in the API and web UI.

New Features:
- Expose a /api/journal/trash endpoint that lists soft-deleted journal entries with id, date, and size.
- Add a trash toggle to the Journal screen that shows trashed entries and allows restoring or permanently deleting them.

Enhancements:
- Refactor journal entry listing logic into a shared helper used for both active and trashed entries.

Tests:
- Add API tests covering trash listing behavior, empty trash responses, and authentication requirements for accessing trash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Trash view for journal entries, letting you browse soft-deleted items separately from active entries.
  * Added actions to restore entries or permanently delete them from the Trash.
* **Bug Fixes**
  * Journal entry lists now load consistently for both active and deleted items, with newest entries shown first.
  * The Trash view correctly handles empty states and requires sign-in before access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->