### PR TITLE
feat(web): save weekly recap locally for the Briefing viewer

### DIFF
--- a/apps/python/src/weekly_handler.py
+++ b/apps/python/src/weekly_handler.py
@@ -33,12 +33,17 @@ def weekly_handler(event=None, context=None):
     # Persist locally so the recap shows up in the Briefing viewer alongside
     # daily briefings. Type prefix "weekly-summary" matches the briefing API's
     # filename convention, so listing/search/tabs work with no API change.
-    local_path = write_md_file(
-        BRIEFING_OUTPUT_DIR,
-        f"weekly-summary_{date.today().strftime('%Y-%m-%d')}.md",
-        summary,
-    )
-    logger.info("local weekly MD: %s", local_path)
+    # Best-effort: a local write failure must not block the Notion post.
+    try:
+        local_path = write_md_file(
+            BRIEFING_OUTPUT_DIR,
+            f"weekly-summary_{date.today().strftime('%Y-%m-%d')}.md",
+            summary,
+        )
+    except OSError:
+        logger.exception("failed to persist local weekly MD")
+    else:
+        logger.info("local weekly MD: %s", local_path)
 
     logger.info("creating Notion page...")
     page_url = send_to_notion(

--- a/apps/python/src/weekly_handler.py
+++ b/apps/python/src/weekly_handler.py
@@ -1,6 +1,10 @@
 """Handler that creates the weekly briefing recap page in Notion."""
+from datetime import date
+
 from src.config import CONFIG
+from src.constants import BRIEFING_OUTPUT_DIR
 from src.generator.weekly_summary import generate_weekly_summary, week_label
+from src.notifier.local_md import write_md_file
 from src.notifier.notion import fetch_weekly_pages, send_to_notion
 from src.logger import get_logger
 
@@ -25,6 +29,16 @@ def weekly_handler(event=None, context=None):
     logger.info("generating weekly summary (%d pages)...", len(pages))
     summary = generate_weekly_summary(pages)
     title = f"週次振り返り — {week_label()}"
+
+    # Persist locally so the recap shows up in the Briefing viewer alongside
+    # daily briefings. Type prefix "weekly-summary" matches the briefing API's
+    # filename convention, so listing/search/tabs work with no API change.
+    local_path = write_md_file(
+        BRIEFING_OUTPUT_DIR,
+        f"weekly-summary_{date.today().strftime('%Y-%m-%d')}.md",
+        summary,
+    )
+    logger.info("local weekly MD: %s", local_path)
 
     logger.info("creating Notion page...")
     page_url = send_to_notion(

--- a/apps/python/tests/test_weekly_handler.py
+++ b/apps/python/tests/test_weekly_handler.py
@@ -1,5 +1,5 @@
 """週次ハンドラと Notion ページ取得のテスト。"""
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from unittest.mock import MagicMock, patch, call
 
 import pytest
@@ -306,8 +306,10 @@ class TestWeeklyHandler:
         ):
             weekly_handler()
 
+        expected = f"weekly-summary_{date.today().strftime('%Y-%m-%d')}.md"
         written = list(self._out_dir.glob("weekly-summary_*.md"))
         assert len(written) == 1
+        assert written[0].name == expected
         assert written[0].read_text(encoding="utf-8") == "サマリー本文"
 
     def test_notion_post_includes_weekly_tag(self):

--- a/apps/python/tests/test_weekly_handler.py
+++ b/apps/python/tests/test_weekly_handler.py
@@ -255,6 +255,13 @@ class TestFetchWeeklyPages:
 # ---------------------------------------------------------------------------
 
 class TestWeeklyHandler:
+    @pytest.fixture(autouse=True)
+    def _isolate_output_dir(self, tmp_path):
+        """Redirect local MD writes to tmp_path so tests never touch the repo's output dir."""
+        with patch("src.weekly_handler.BRIEFING_OUTPUT_DIR", tmp_path):
+            self._out_dir = tmp_path
+            yield
+
     def test_success_returns_200(self):
         pages = [{"date": "2026-04-25", "title": "T", "text": "content"}]
         with (
@@ -288,6 +295,20 @@ class TestWeeklyHandler:
         ):
             result = weekly_handler()
         assert result["statusCode"] == 500
+
+    def test_saves_local_weekly_md(self):
+        """The recap is written locally as weekly-summary_<date>.md for the Briefing viewer."""
+        pages = [{"date": "2026-04-25", "title": "T", "text": "content"}]
+        with (
+            patch("src.weekly_handler.fetch_weekly_pages", return_value=pages),
+            patch("src.weekly_handler.generate_weekly_summary", return_value="サマリー本文"),
+            patch("src.weekly_handler.send_to_notion", return_value="https://notion.so/w"),
+        ):
+            weekly_handler()
+
+        written = list(self._out_dir.glob("weekly-summary_*.md"))
+        assert len(written) == 1
+        assert written[0].read_text(encoding="utf-8") == "サマリー本文"
 
     def test_notion_post_includes_weekly_tag(self):
         pages = [{"date": "2026-04-25", "title": "T", "text": "content"}]

--- a/apps/web/lib/briefing-types.ts
+++ b/apps/web/lib/briefing-types.ts
@@ -17,6 +17,7 @@ export type BriefingFileResponse = {
 const KNOWN_TYPE_LABELS: Record<string, string> = {
   briefing: "Briefing",
   local: "Local",
+  "weekly-summary": "Weekly",
 }
 
 /** Map a type prefix to a display label: known → mapped, unknown → capitalized. */

--- a/apps/web/tests/briefing-tabs.test.tsx
+++ b/apps/web/tests/briefing-tabs.test.tsx
@@ -22,6 +22,7 @@ describe("briefingTypeLabel", () => {
   it("maps known types and capitalizes unknown ones", () => {
     expect(briefingTypeLabel("briefing")).toBe("Briefing")
     expect(briefingTypeLabel("local")).toBe("Local")
+    expect(briefingTypeLabel("weekly-summary")).toBe("Weekly")
     expect(briefingTypeLabel("market")).toBe("Market")
   })
 })


### PR DESCRIPTION
## Summary
- `weekly_handler` writes the recap as `weekly-summary_{date}.md` into the briefing output dir (Notion post unchanged)
- The `weekly-summary` type appears in the Briefing viewer; added a `Weekly` tab label

## Test plan
- [ ] `pytest tests/test_weekly_handler.py` passes (local MD written)
- [ ] `vitest briefing-tabs` passes (Weekly label)
- [ ] Briefing page shows a Weekly tab rendering the recap

Closes #305

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Weekly summaries are now saved locally as date-stamped Markdown files before being published.
  - The web app now recognizes weekly summaries as a “Weekly” briefing type.

- **Tests**
  - Added a test to verify the local weekly summary file’s name and contents match the generated output.
  - Expanded briefing type label mapping tests to include the weekly summary label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->