### PR TITLE
fix(web): darken border token on Soft background in Light theme

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -80,6 +80,15 @@
       );
   }
 
+  /* On Soft background the default light-theme border (91.4% lightness) is
+     nearly invisible against the gradient. Drop it to 78% so dividers,
+     dashed outlines, and table headers stay legible. Dark theme is unaffected
+     because .dark already sets --border to 17.5% lightness. */
+  html[data-bg="soft"]:not(.dark) {
+    --border: 214.3 31.8% 78%;
+    --input: 214.3 31.8% 78%;
+  }
+
 }
 
 /* Dark mode prose body text — override Tailwind Typography's default gray-300


### PR DESCRIPTION
## Summary

- Override `--border` / `--input` to `78%` lightness (from `91.4%`) when `html[data-bg="soft"]` and not dark mode
- Fixes invisible row dividers, dashed "New entry" outline, and header borders on Light + Soft background
- Dark theme and Default background preset are unaffected

## Test plan

- [ ] Light + Soft: Journal table row dividers visible
- [ ] Light + Soft: "New entry" dashed border visible
- [ ] Light + Soft: "Size (KB)" header divider visible
- [ ] Dark theme borders unchanged
- [ ] Default background preset unaffected

Closes #304

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contrast for the soft background theme in light mode by adjusting border and input styling only when that background is active.
  * Better visual clarity against the soft gradient background, without changing other theme settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->