### PR TITLE
feat(web): open briefing content links in a new tab

### DIFF
--- a/apps/web/components/briefing/BriefingPanel.tsx
+++ b/apps/web/components/briefing/BriefingPanel.tsx
@@ -17,6 +17,17 @@ const PROSE_CLASS =
 const HEADER_BTN =
   "rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
 
+// Open links rendered inside briefing content in a new tab. `rel` guards
+// against reverse-tabnabbing on the opened page. In-app navigation lives in the
+// sidebar/routes (not markdown), so it is unaffected.
+const MARKDOWN_COMPONENTS = {
+  a: ({ children, ...props }: React.ComponentPropsWithoutRef<"a">) => (
+    <a {...props} target="_blank" rel="noopener noreferrer">
+      {children}
+    </a>
+  ),
+}
+
 // Track the heading currently scrolled into view within `containerRef`.
 // `content` is the trigger: when it changes the rendered headings change, so the
 // observer is rebuilt against the new DOM nodes.
@@ -139,6 +150,7 @@ export function BriefingPanel({
               <ReactMarkdown
                 remarkPlugins={[remarkGfm]}
                 rehypePlugins={[rehypeHeadingIds, [rehypeSanitize, sanitizeSchema]]}
+                components={MARKDOWN_COMPONENTS}
               >
                 {content}
               </ReactMarkdown>

--- a/apps/web/tests/briefing-panel.test.tsx
+++ b/apps/web/tests/briefing-panel.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { BriefingPanel } from "@/components/briefing/BriefingPanel"
+import { BriefingFile } from "@/lib/briefing-types"
+
+const FILE: BriefingFile = {
+  name: "market_2026-06-21.md",
+  type: "market",
+  date: "2026-06-21",
+  size: 1024,
+}
+
+function renderPanel(content: string | null) {
+  return render(
+    <BriefingPanel
+      file={FILE}
+      content={content}
+      loading={false}
+      error={null}
+      fullSize={false}
+      onToggleFullSize={() => {}}
+      onClose={() => {}}
+    />,
+  )
+}
+
+describe("BriefingPanel links", () => {
+  it("opens content links in a new tab with rel=noopener noreferrer", () => {
+    renderPanel("[example](https://example.com)")
+    const link = screen.getByRole("link", { name: "example" })
+    expect(link).toHaveAttribute("target", "_blank")
+    expect(link).toHaveAttribute("rel", "noopener noreferrer")
+  })
+})


### PR DESCRIPTION
## Summary
- Render briefing markdown anchors with `target="_blank"` and `rel="noopener noreferrer"` so outbound content links open in a new tab. Sidebar/route navigation is unaffected (not markdown).

## Test plan
- [x] `vitest` BriefingPanel link test (new)
- [x] tsc + eslint clean

Closes #281