### PR TITLE
feat(journal): remove Record today, add Item column with auto-title

### DIFF
--- a/apps/python/src/journal_store.py
+++ b/apps/python/src/journal_store.py
@@ -63,6 +63,8 @@ def save_item(entry_id: str, item: str) -> None:
     """Persist a short item label (≤20 chars) alongside the entry markdown."""
     import json
 
+    if not _ENTRY_RE.match(entry_id):
+        raise ValueError(f"Invalid journal entry id: {entry_id!r}")
     _item_path(entry_id).write_text(
         json.dumps({"item": item[:20]}, ensure_ascii=False), encoding="utf-8"
     )
@@ -72,6 +74,8 @@ def get_item(entry_id: str) -> str:
     """Return the stored item label for an entry, or empty string if absent."""
     import json
 
+    if not _ENTRY_RE.match(entry_id):
+        return ""
     p = _item_path(entry_id)
     if not p.exists():
         return ""

--- a/apps/python/src/journal_store.py
+++ b/apps/python/src/journal_store.py
@@ -55,6 +55,32 @@ def _path_for(entry_id: str) -> Path:
     return JOURNAL_DIR / f"{entry_id}.md"
 
 
+def _item_path(entry_id: str) -> Path:
+    return JOURNAL_DIR / f"{entry_id}.json"
+
+
+def save_item(entry_id: str, item: str) -> None:
+    """Persist a short item label (≤20 chars) alongside the entry markdown."""
+    import json
+
+    _item_path(entry_id).write_text(
+        json.dumps({"item": item[:20]}, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+def get_item(entry_id: str) -> str:
+    """Return the stored item label for an entry, or empty string if absent."""
+    import json
+
+    p = _item_path(entry_id)
+    if not p.exists():
+        return ""
+    try:
+        return json.loads(p.read_text(encoding="utf-8")).get("item", "")
+    except Exception:
+        return ""
+
+
 def append_entry(content: str, date: str | None = None) -> str:
     """Create a new entry file for the given date and return its entry id.
 
@@ -149,6 +175,9 @@ def soft_delete(entry_id: str) -> bool:
     trash = _deleted_dir()
     trash.mkdir(parents=True, exist_ok=True)
     src.replace(trash / f"{entry_id}.md")
+    item_src = _item_path(entry_id)
+    if item_src.exists():
+        item_src.replace(trash / f"{entry_id}.json")
     return True
 
 
@@ -167,6 +196,9 @@ def restore(entry_id: str) -> bool:
     if dst.exists():
         return False
     src.replace(dst)
+    item_src = _deleted_dir() / f"{entry_id}.json"
+    if item_src.exists():
+        item_src.replace(_item_path(entry_id))
     return True
 
 
@@ -181,4 +213,7 @@ def purge(entry_id: str) -> bool:
     if not path.exists() or not path.is_file():
         return False
     path.unlink()
+    item = _deleted_dir() / f"{entry_id}.json"
+    if item.exists():
+        item.unlink()
     return True

--- a/apps/python/src/journal_store.py
+++ b/apps/python/src/journal_store.py
@@ -71,12 +71,27 @@ def save_item(entry_id: str, item: str) -> None:
 
 
 def get_item(entry_id: str) -> str:
-    """Return the stored item label for an entry, or empty string if absent."""
+    """Return the stored item label for an active entry, or empty string if absent."""
     import json
 
     if not _ENTRY_RE.match(entry_id):
         return ""
     p = _item_path(entry_id)
+    if not p.exists():
+        return ""
+    try:
+        return json.loads(p.read_text(encoding="utf-8")).get("item", "")
+    except Exception:
+        return ""
+
+
+def get_trashed_item(entry_id: str) -> str:
+    """Return the stored item label for a soft-deleted entry, or empty string."""
+    import json
+
+    if not _ENTRY_RE.match(entry_id):
+        return ""
+    p = _deleted_dir() / f"{entry_id}.json"
     if not p.exists():
         return ""
     try:

--- a/apps/python/web/routers/journal.py
+++ b/apps/python/web/routers/journal.py
@@ -67,7 +67,17 @@ def list_journal() -> JournalListResponse:
 @router.get("/journal/trash", response_model=JournalListResponse)
 def list_trash() -> JournalListResponse:
     """Return soft-deleted journal entries, newest first."""
-    return JournalListResponse(entries=_to_entries(journal_store.list_trashed()))
+    files = journal_store.list_trashed()
+    entries = [
+        JournalEntry(
+            id=entry_id,
+            date=journal_store.date_of(entry_id),
+            size=path.stat().st_size,
+            item=journal_store.get_trashed_item(entry_id),
+        )
+        for entry_id, path in files
+    ]
+    return JournalListResponse(entries=entries)
 
 
 @router.post("/journal", response_model=AppendEntryResponse)

--- a/apps/python/web/routers/journal.py
+++ b/apps/python/web/routers/journal.py
@@ -22,6 +22,7 @@ class JournalEntry(BaseModel):
     id: str  # entry id (file stem), e.g. 2026-06-24_153045
     date: str  # YYYY-MM-DD
     size: int  # bytes
+    item: str  # short label ≤20 chars, empty for legacy entries
 
 
 class JournalListResponse(BaseModel):
@@ -37,6 +38,7 @@ class JournalEntryResponse(BaseModel):
 class AppendEntryRequest(BaseModel):
     content: str = Field(min_length=1)
     date: str | None = None  # defaults to today when omitted
+    item: str | None = None  # optional short label (≤20 chars)
 
 
 class AppendEntryResponse(BaseModel):
@@ -50,6 +52,7 @@ def _to_entries(files: list[tuple[str, Path]]) -> list[JournalEntry]:
             id=entry_id,
             date=journal_store.date_of(entry_id),
             size=path.stat().st_size,
+            item=journal_store.get_item(entry_id),
         )
         for entry_id, path in files
     ]
@@ -74,6 +77,8 @@ def append_journal(req: AppendEntryRequest) -> AppendEntryResponse:
         entry_id = journal_store.append_entry(req.content, req.date)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if req.item:
+        journal_store.save_item(entry_id, req.item)
     return AppendEntryResponse(id=entry_id, date=journal_store.date_of(entry_id))
 
 

--- a/apps/python/web/routers/journal.py
+++ b/apps/python/web/routers/journal.py
@@ -78,7 +78,10 @@ def append_journal(req: AppendEntryRequest) -> AppendEntryResponse:
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     if req.item:
-        journal_store.save_item(entry_id, req.item)
+        try:
+            journal_store.save_item(entry_id, req.item)
+        except Exception:
+            pass  # item label is best-effort; entry is already committed
     return AppendEntryResponse(id=entry_id, date=journal_store.date_of(entry_id))
 
 

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -332,6 +332,7 @@ export function JournalScreen() {
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b bg-muted/50 text-xs text-muted-foreground">
+                  <th className="px-3 py-2 text-left">Item</th>
                   <th className="px-3 py-2 text-left">Deleted</th>
                   <th className="px-3 py-2 text-right">Size (KB)</th>
                   <th className="px-3 py-2 text-right">Actions</th>
@@ -342,6 +343,9 @@ export function JournalScreen() {
                   .sort((a, b) => b.id.localeCompare(a.id))
                   .map((e) => (
                     <tr key={e.id} className="border-b last:border-0">
+                      <td className="w-[7rem] max-w-[7rem] truncate px-3 py-2 text-xs">
+                        {e.item || "—"}
+                      </td>
                       <td className="px-3 py-2 text-xs tabular-nums">
                         {e.date}
                         {entryTime(e.id) && (

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -391,42 +391,35 @@ export function JournalScreen() {
             </thead>
             <tbody>
               {sortedEntries.map((e) => (
-                <tr key={e.id} className="border-b last:border-0">
-                  <td colSpan={3} className="p-0">
-                    <div className="group relative flex items-center">
-                      <button
-                        type="button"
-                        aria-pressed={selected === e.id}
-                        onClick={() => void loadEntry(e.id)}
-                        className={cn(
-                          "flex w-full items-center gap-2 px-3 py-2 text-left text-xs transition-colors",
-                          selected === e.id
-                            ? "bg-accent font-medium text-accent-foreground"
-                            : "hover:bg-accent/50",
-                        )}
-                      >
-                        <span className="w-[7rem] flex-shrink-0 truncate">
-                          {e.item || "—"}
-                        </span>
-                        <span className="w-[5rem] flex-shrink-0 truncate tabular-nums text-muted-foreground">
-                          {e.date}
-                          {entryTime(e.id) && (
-                            <span className="ml-1">{entryTime(e.id)}</span>
-                          )}
-                        </span>
-                        <span className="flex-1 whitespace-nowrap pr-6 text-right tabular-nums text-muted-foreground">
-                          {(e.size / 1024).toFixed(1)}
-                        </span>
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => void deleteEntry(e.id)}
-                        aria-label={`Delete entry ${e.id}`}
-                        className="absolute right-2 rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-destructive focus:bg-accent focus:text-destructive focus:opacity-100 group-hover:opacity-100"
-                      >
-                        <TrashIcon />
-                      </button>
-                    </div>
+                <tr
+                  key={e.id}
+                  onClick={() => void loadEntry(e.id)}
+                  className={cn(
+                    "group cursor-pointer border-b last:border-0 text-xs transition-colors",
+                    selected === e.id
+                      ? "bg-accent font-medium text-accent-foreground"
+                      : "hover:bg-accent/50",
+                  )}
+                >
+                  <td className="max-w-[7rem] truncate px-3 py-2">
+                    {e.item || "—"}
+                  </td>
+                  <td className="truncate px-3 py-2 tabular-nums text-muted-foreground">
+                    {e.date}
+                    {entryTime(e.id) && (
+                      <span className="ml-1">{entryTime(e.id)}</span>
+                    )}
+                  </td>
+                  <td className="relative px-3 py-2 text-right tabular-nums text-muted-foreground">
+                    {(e.size / 1024).toFixed(1)}
+                    <button
+                      type="button"
+                      onClick={(ev) => { ev.stopPropagation(); void deleteEntry(e.id) }}
+                      aria-label={`Delete entry ${e.id}`}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-destructive focus:bg-accent focus:text-destructive focus:opacity-100 group-hover:opacity-100"
+                    >
+                      <TrashIcon />
+                    </button>
                   </td>
                 </tr>
               ))}

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -11,7 +11,7 @@ import { useResizable } from "@/lib/hooks/useResizable"
 import type { ImageAttachment } from "@/lib/types/image"
 import { cn } from "@/lib/utils"
 
-type JournalEntry = { id: string; date: string; size: number }
+type JournalEntry = { id: string; date: string; size: number; item: string }
 type Turn = { question: string; answer: string }
 
 const PROSE =
@@ -62,16 +62,11 @@ export function JournalScreen() {
   const [trash, setTrash] = useState<JournalEntry[]>([])
   const [showTrash, setShowTrash] = useState(false)
   const [selected, setSelected] = useState<string | null>(null)
-  const [composing, setComposing] = useState(false)
-  const composeRef = useRef<HTMLTextAreaElement>(null)
   const brainstormRef = useRef<HTMLTextAreaElement>(null)
   const [brainstormImage, setBrainstormImage] = useState<ImageAttachment | null>(null)
   const { isDragging: isBrainstormDragging } = useImageDrop(brainstormRef, setBrainstormImage)
   const [content, setContent] = useState("")
   const entryReqSeq = useRef(0)
-  const [entry, setEntry] = useState("")
-  const [saving, setSaving] = useState(false)
-  const [saveError, setSaveError] = useState<string | null>(null)
 
   const [question, setQuestion] = useState("")
   const [turns, setTurns] = useState<Turn[]>([])
@@ -104,7 +99,6 @@ export function JournalScreen() {
   const loadEntry = useCallback(async (entryId: string) => {
     const seq = ++entryReqSeq.current
     setSelected(entryId)
-    setComposing(false)
     // Clear immediately so the previous entry's body can't render under the
     // new header while the fetch is in flight (or if it fails).
     setContent("")
@@ -127,22 +121,7 @@ export function JournalScreen() {
 
   const closePanel = () => {
     setSelected(null)
-    setComposing(false)
   }
-
-  // Open a blank compose panel and focus the textarea.
-  const startCompose = () => {
-    setSelected(null)
-    setContent("")
-    setEntry("")
-    setSaveError(null)
-    setComposing(true)
-  }
-
-  // Focus the compose textarea once the panel has opened.
-  useEffect(() => {
-    if (composing) composeRef.current?.focus()
-  }, [composing])
 
   const loadTrash = useCallback(async () => {
     try {
@@ -219,33 +198,6 @@ export function JournalScreen() {
     if (next) void loadTrash()
   }, [showTrash, loadTrash])
 
-  const save = useCallback(async () => {
-    const text = entry.trim()
-    if (!text || saving) return
-    setSaving(true)
-    setSaveError(null)
-    try {
-      const res = await fetch("/api/journal", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ content: text }),
-      })
-      if (!res.ok) {
-        const body = await res.text()
-        setSaveError(`Save failed (HTTP ${res.status}): ${body}`)
-        return
-      }
-      const { id } = (await res.json()) as { id: string }
-      setEntry("")
-      await loadDates()
-      await loadEntry(id)
-    } catch (e) {
-      setSaveError(String(e))
-    } finally {
-      setSaving(false)
-    }
-  }, [entry, saving, loadDates, loadEntry])
-
   const appendToLastAnswer = useCallback((chunk: string) => {
     setTurns((prev) => {
       if (prev.length === 0) return prev
@@ -302,7 +254,10 @@ export function JournalScreen() {
       const saveRes = await fetch("/api/journal", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ content: `### Brainstorm\n\n**Q:** ${q}\n\n${answer}` }),
+        body: JSON.stringify({
+          content: `### Brainstorm\n\n**Q:** ${q}\n\n${answer}`,
+          item: q.slice(0, 20),
+        }),
       })
       if (!saveRes.ok) {
         const body = await saveRes.text()
@@ -322,7 +277,7 @@ export function JournalScreen() {
 
   const sortedEntries = [...entries].sort((a, b) => b.id.localeCompare(a.id))
   const selectedMeta = sortedEntries.find((e) => e.id === selected)
-  const panelOpen = selected !== null || composing
+  const panelOpen = selected !== null
 
   return (
     <div className="flex h-full">
@@ -334,15 +289,8 @@ export function JournalScreen() {
           panelOpen ? "border-r" : "flex-1",
         )}
       >
-        {/* Top bar: New entry create path + Trash toggle */}
+        {/* Top bar: Trash toggle */}
         <div className="flex items-center gap-2 border-b p-2">
-          <button
-            type="button"
-            onClick={startCompose}
-            className="flex flex-1 items-center justify-center gap-1 rounded-md border border-dashed px-3 py-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
-          >
-            <span className="text-base leading-none">+</span> New entry
-          </button>
           <button
             type="button"
             onClick={toggleTrash}
@@ -417,6 +365,7 @@ export function JournalScreen() {
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b bg-muted/50 text-xs text-muted-foreground">
+                <th className="px-3 py-2 text-left">Item</th>
                 <th className="px-3 py-2 text-left">Date</th>
                 <th className="px-3 py-2 text-right">Size (KB)</th>
               </tr>
@@ -424,26 +373,29 @@ export function JournalScreen() {
             <tbody>
               {sortedEntries.map((e) => (
                 <tr key={e.id} className="border-b last:border-0">
-                  <td colSpan={2} className="p-0">
+                  <td colSpan={3} className="p-0">
                     <div className="group relative flex items-center">
                       <button
                         type="button"
                         aria-pressed={selected === e.id}
                         onClick={() => void loadEntry(e.id)}
                         className={cn(
-                          "flex w-full items-center justify-between px-3 py-2 text-left text-xs transition-colors",
+                          "flex w-full items-center gap-2 px-3 py-2 text-left text-xs transition-colors",
                           selected === e.id
                             ? "bg-accent font-medium text-accent-foreground"
                             : "hover:bg-accent/50",
                         )}
                       >
-                        <span className="tabular-nums">
+                        <span className="w-[7rem] flex-shrink-0 truncate">
+                          {e.item || "—"}
+                        </span>
+                        <span className="w-[5rem] flex-shrink-0 whitespace-nowrap tabular-nums text-muted-foreground">
                           {e.date}
                           {entryTime(e.id) && (
-                            <span className="ml-2 text-muted-foreground">{entryTime(e.id)}</span>
+                            <span className="ml-1">{entryTime(e.id)}</span>
                           )}
                         </span>
-                        <span className="pr-6 tabular-nums text-muted-foreground">
+                        <span className="flex-1 whitespace-nowrap pr-6 text-right tabular-nums text-muted-foreground">
                           {(e.size / 1024).toFixed(1)}
                         </span>
                       </button>
@@ -477,18 +429,12 @@ export function JournalScreen() {
           {/* Panel header */}
           <div className="flex items-center justify-between border-b px-4 py-2">
             <div className="flex gap-3 text-xs text-muted-foreground">
-              {composing ? (
-                <span className="font-medium">New entry</span>
-              ) : (
-                <>
-                  <span>
-                    {selectedMeta?.date ?? selected}
-                    {selected && entryTime(selected) && ` ${entryTime(selected)}`}
-                  </span>
-                  {selectedMeta && (
-                    <span>{(selectedMeta.size / 1024).toFixed(1)} KB</span>
-                  )}
-                </>
+              <span>
+                {selectedMeta?.date ?? selected}
+                {selected && entryTime(selected) && ` ${entryTime(selected)}`}
+              </span>
+              {selectedMeta && (
+                <span>{(selectedMeta.size / 1024).toFixed(1)} KB</span>
               )}
             </div>
             <button
@@ -510,32 +456,7 @@ export function JournalScreen() {
                 </div>
               )}
 
-              {/* Record today */}
-              <section className="flex flex-col gap-2 rounded-lg border bg-card p-4">
-                <h3 className="text-sm font-semibold">Record today</h3>
-                <textarea
-                  ref={composeRef}
-                  value={entry}
-                  onChange={(e) => setEntry(e.target.value)}
-                  placeholder="What happened today? What are you thinking about?"
-                  rows={5}
-                  className="w-full resize-y rounded-md border bg-background p-3 text-sm"
-                />
-                <div className="flex items-center gap-3">
-                  <button
-                    type="button"
-                    onClick={() => void save()}
-                    disabled={saving || entry.trim() === ""}
-                    className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
-                  >
-                    {saving ? "Saving…" : "Save entry"}
-                  </button>
-                  {saveError && <span className="text-sm text-destructive">{saveError}</span>}
-                </div>
-              </section>
-
-              {/* Brainstorm (hidden while composing a new blank entry) */}
-              {selected && (
+              {/* Brainstorm with Claude */}
               <section className="flex flex-col gap-3 rounded-lg border bg-card p-4">
                 <div>
                   <h3 className="text-sm font-semibold">Brainstorm with Claude</h3>
@@ -598,7 +519,6 @@ export function JournalScreen() {
                   </div>
                 </div>
               </section>
-              )}
             </div>
           </div>
         </div>

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -404,7 +404,7 @@ export function JournalScreen() {
                         <span className="w-[7rem] flex-shrink-0 truncate">
                           {e.item || "—"}
                         </span>
-                        <span className="w-[5rem] flex-shrink-0 whitespace-nowrap tabular-nums text-muted-foreground">
+                        <span className="w-[5rem] flex-shrink-0 truncate tabular-nums text-muted-foreground">
                           {e.date}
                           {entryTime(e.id) && (
                             <span className="ml-1">{entryTime(e.id)}</span>

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -62,6 +62,7 @@ export function JournalScreen() {
   const [trash, setTrash] = useState<JournalEntry[]>([])
   const [showTrash, setShowTrash] = useState(false)
   const [selected, setSelected] = useState<string | null>(null)
+  const [composing, setComposing] = useState(false)
   const brainstormRef = useRef<HTMLTextAreaElement>(null)
   const [brainstormImage, setBrainstormImage] = useState<ImageAttachment | null>(null)
   const { isDragging: isBrainstormDragging } = useImageDrop(brainstormRef, setBrainstormImage)
@@ -99,6 +100,7 @@ export function JournalScreen() {
   const loadEntry = useCallback(async (entryId: string) => {
     const seq = ++entryReqSeq.current
     setSelected(entryId)
+    setComposing(false)
     // Clear immediately so the previous entry's body can't render under the
     // new header while the fetch is in flight (or if it fails).
     setContent("")
@@ -121,6 +123,12 @@ export function JournalScreen() {
 
   const closePanel = () => {
     setSelected(null)
+    setComposing(false)
+  }
+
+  const startCompose = () => {
+    setSelected(null)
+    setComposing(true)
   }
 
   const loadTrash = useCallback(async () => {
@@ -277,7 +285,7 @@ export function JournalScreen() {
 
   const sortedEntries = [...entries].sort((a, b) => b.id.localeCompare(a.id))
   const selectedMeta = sortedEntries.find((e) => e.id === selected)
-  const panelOpen = selected !== null
+  const panelOpen = selected !== null || composing
 
   return (
     <div className="flex h-full">
@@ -289,8 +297,15 @@ export function JournalScreen() {
           panelOpen ? "border-r" : "flex-1",
         )}
       >
-        {/* Top bar: Trash toggle */}
+        {/* Top bar: New entry + Trash toggle */}
         <div className="flex items-center gap-2 border-b p-2">
+          <button
+            type="button"
+            onClick={startCompose}
+            className="flex flex-1 items-center justify-center gap-1 rounded-md border border-dashed px-3 py-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+          >
+            <span className="text-base leading-none">+</span> New
+          </button>
           <button
             type="button"
             onClick={toggleTrash}
@@ -429,12 +444,18 @@ export function JournalScreen() {
           {/* Panel header */}
           <div className="flex items-center justify-between border-b px-4 py-2">
             <div className="flex gap-3 text-xs text-muted-foreground">
-              <span>
-                {selectedMeta?.date ?? selected}
-                {selected && entryTime(selected) && ` ${entryTime(selected)}`}
-              </span>
-              {selectedMeta && (
-                <span>{(selectedMeta.size / 1024).toFixed(1)} KB</span>
+              {composing && !selected ? (
+                <span className="font-medium">New entry</span>
+              ) : (
+                <>
+                  <span>
+                    {selectedMeta?.date ?? selected}
+                    {selected && entryTime(selected) && ` ${entryTime(selected)}`}
+                  </span>
+                  {selectedMeta && (
+                    <span>{(selectedMeta.size / 1024).toFixed(1)} KB</span>
+                  )}
+                </>
               )}
             </div>
             <button

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -148,7 +148,6 @@ export function JournalScreen() {
 
   const deleteEntry = useCallback(
     async (entryId: string) => {
-      if (!window.confirm("Move this entry to trash?")) return
       try {
         const res = await fetch(`/api/journal/${entryId}`, { method: "DELETE" })
         if (!res.ok) {
@@ -183,7 +182,6 @@ export function JournalScreen() {
 
   const purgeEntry = useCallback(
     async (entryId: string) => {
-      if (!window.confirm("Permanently delete this entry? This cannot be undone.")) return
       try {
         const res = await fetch(`/api/journal/${entryId}?purge=true`, { method: "DELETE" })
         if (!res.ok) {


### PR DESCRIPTION
## Summary
- Remove "Record today" section; Brainstorm with Claude becomes the sole entry path
- Add `item` sidecar JSON per entry (≤20 chars); Brainstorm auto-sets item from the question
- Extend `/api/journal` response with `item` field; table reordered to Item / Date / Size with no-wrap truncation

## Test plan
- [ ] `pytest tests/test_api_journal.py` — all 26 tests pass
- [ ] `tsc --noEmit` — no type errors
- [ ] "Record today" section is absent from the Journal view
- [ ] Brainstorm Q&A creates entry with auto-generated item (≤20 chars)
- [ ] Table shows Item / Date / Size columns; no text wrapping in rows
- [ ] Existing legacy entries display without errors (item shows "—")

Closes #318

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Journal entries can now include a short label, shown in journal lists and trash views.
  * Creating an entry now supports saving an optional label alongside the content.
  * Brainstorm auto-saves now include a label excerpt to improve identification.

* **Bug Fixes**
  * Labels are now kept in sync with the entry lifecycle: they move to trash, restore correctly, and are removed on permanent deletion.

* **UI Changes**
  * The manual compose/recording editor flow was removed; brainstorm streaming still auto-saves and refreshes the list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->