### PR TITLE
fix(web): stabilise usage detail height to prevent layout jitter

### DIFF
--- a/apps/web/components/screens/UsageDashboard.tsx
+++ b/apps/web/components/screens/UsageDashboard.tsx
@@ -186,27 +186,27 @@ export function UsageDashboard() {
         </section>
       )}
 
-      {activeRecord ? (
-        <dl
-          data-testid="usage-detail"
-          role="status"
-          aria-live="polite"
-          className="grid grid-cols-2 gap-x-4 gap-y-1 rounded-md border p-3 text-sm sm:grid-cols-3"
-        >
-          {USAGE_FIELD_ORDER.map((key) => (
-            <div key={key} className="flex justify-between gap-2">
-              <dt className="text-muted-foreground">{USAGE_FIELD_LABELS[key]}</dt>
-              <dd className="font-medium">
-                {formatUsageField(key, activeRecord[key])}
-              </dd>
-            </div>
-          ))}
-        </dl>
-      ) : (
-        <p data-testid="usage-detail-hint" className="text-sm text-muted-foreground">
-          Hover or focus a bar to see its details.
-        </p>
-      )}
+      <div className="min-h-[7rem]" aria-live="polite" role="status">
+        {activeRecord ? (
+          <dl
+            data-testid="usage-detail"
+            className="grid grid-cols-2 gap-x-4 gap-y-1 rounded-md border p-3 text-sm sm:grid-cols-3"
+          >
+            {USAGE_FIELD_ORDER.map((key) => (
+              <div key={key} className="flex justify-between gap-2">
+                <dt className="text-muted-foreground">{USAGE_FIELD_LABELS[key]}</dt>
+                <dd className="font-medium">
+                  {formatUsageField(key, activeRecord[key])}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        ) : (
+          <p data-testid="usage-detail-hint" className="text-sm text-muted-foreground">
+            Hover or focus a bar to see its details.
+          </p>
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Wrap the detail panel (`<dl>` / hint `<p>`) in a `min-h-[7rem]` container
- Prevents layout shift when focus/hover toggles the active bar

## Test plan
- [x] All 10 existing usage-dashboard tests pass

Closes #317