### PR TITLE
fix(web): append subsequent brainstorm turns to same journal entry

### DIFF
--- a/apps/python/src/journal_store.py
+++ b/apps/python/src/journal_store.py
@@ -144,13 +144,16 @@ def append_to_entry(entry_id: str, content: str) -> bool:
     Used when a brainstorm session continues: subsequent turns are appended to
     the same file rather than creating a new one.
     """
+    text = content.strip()
+    if not text:
+        return False
     if not _ENTRY_RE.match(entry_id):
         return False
     path = JOURNAL_DIR / f"{entry_id}.md"
     if not path.exists() or not path.is_file():
         return False
     with path.open("a", encoding="utf-8") as fh:
-        fh.write(f"\n\n---\n\n{content.strip()}\n")
+        fh.write(f"\n\n---\n\n{text}\n")
     return True
 
 

--- a/apps/python/src/journal_store.py
+++ b/apps/python/src/journal_store.py
@@ -137,6 +137,23 @@ def append_entry(content: str, date: str | None = None) -> str:
             n += 1
 
 
+def append_to_entry(entry_id: str, content: str) -> bool:
+    """Append additional content to an existing entry file.
+
+    Returns True if the entry was found and updated, False if it does not exist.
+    Used when a brainstorm session continues: subsequent turns are appended to
+    the same file rather than creating a new one.
+    """
+    if not _ENTRY_RE.match(entry_id):
+        return False
+    path = JOURNAL_DIR / f"{entry_id}.md"
+    if not path.exists() or not path.is_file():
+        return False
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(f"\n\n---\n\n{content.strip()}\n")
+    return True
+
+
 def _list_entry_files(directory: Path) -> list[tuple[str, Path]]:
     """Return (entry_id, path) for entry files in a directory, newest first.
 

--- a/apps/python/tests/test_api_export.py
+++ b/apps/python/tests/test_api_export.py
@@ -60,6 +60,7 @@ async def test_zip_excludes_noise(authed_client, output_dir):
 
 async def test_empty_output_returns_empty_zip(authed_client, tmp_path, monkeypatch):
     monkeypatch.setattr(export_router, "OUTPUT_DIR", tmp_path / "nonexistent")
+    monkeypatch.setattr(export_router, "INPUT_DIR", tmp_path / "nonexistent_input")
     response = await authed_client.get("/api/export")
     assert response.status_code == 200
     zf = zipfile.ZipFile(io.BytesIO(response.content))

--- a/apps/python/web/routers/journal.py
+++ b/apps/python/web/routers/journal.py
@@ -41,6 +41,10 @@ class AppendEntryRequest(BaseModel):
     item: str | None = None  # optional short label (≤20 chars)
 
 
+class PatchEntryRequest(BaseModel):
+    content: str = Field(min_length=1)
+
+
 class AppendEntryResponse(BaseModel):
     id: str
     date: str
@@ -93,6 +97,18 @@ def append_journal(req: AppendEntryRequest) -> AppendEntryResponse:
         except Exception:
             pass  # item label is best-effort; entry is already committed
     return AppendEntryResponse(id=entry_id, date=journal_store.date_of(entry_id))
+
+
+@router.patch("/journal/{entry_id}", status_code=204)
+def patch_journal(entry_id: str, req: PatchEntryRequest) -> None:
+    """Append additional content to an existing journal entry.
+
+    Used when a brainstorm session continues: subsequent turns are appended to
+    the same file rather than creating a new one.
+    """
+    ok = journal_store.append_to_entry(entry_id, req.content)
+    if not ok:
+        raise HTTPException(status_code=404, detail=f"Journal not found: {entry_id}")
 
 
 @router.get("/journal/{entry_id}", response_model=JournalEntryResponse)

--- a/apps/python/web/routers/journal.py
+++ b/apps/python/web/routers/journal.py
@@ -106,6 +106,8 @@ def patch_journal(entry_id: str, req: PatchEntryRequest) -> None:
     Used when a brainstorm session continues: subsequent turns are appended to
     the same file rather than creating a new one.
     """
+    if not req.content.strip():
+        raise HTTPException(status_code=400, detail="content must not be blank")
     ok = journal_store.append_to_entry(entry_id, req.content)
     if not ok:
         raise HTTPException(status_code=404, detail=f"Journal not found: {entry_id}")

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -127,6 +127,7 @@ export function JournalScreen() {
   const closePanel = () => {
     setSelected(null)
     setComposing(false)
+    brainstormEntryId.current = null
   }
 
   const startCompose = () => {
@@ -282,6 +283,8 @@ export function JournalScreen() {
         }
       }
       if (!saveRes.ok) {
+        // 404 means the entry was deleted — reset so the next turn creates fresh.
+        if (saveRes.status === 404) brainstormEntryId.current = null
         const body = await saveRes.text()
         setChatError(`Auto-save failed (HTTP ${saveRes.status}): ${body}`)
         return

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -73,6 +73,9 @@ export function JournalScreen() {
   const [turns, setTurns] = useState<Turn[]>([])
   const [brainstorming, setBrainstorming] = useState(false)
   const [chatError, setChatError] = useState<string | null>(null)
+  // Tracks the journal entry id for the current brainstorm session so that
+  // subsequent turns append to the same entry instead of creating new ones.
+  const brainstormEntryId = useRef<string | null>(null)
 
   const { width: listWidth, startResize } = useResizable({
     storageKey: "ai-agent:journal-list-width:v1",
@@ -257,14 +260,27 @@ export function JournalScreen() {
         dropPendingTurn()
         return
       }
-      const saveRes = await fetch("/api/journal", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          content: `### Brainstorm\n\n**Q:** ${q}\n\n${answer}`,
-          item: q.slice(0, 20),
-        }),
-      })
+      const qaBlock = `### Brainstorm\n\n**Q:** ${q}\n\n${answer}`
+      let saveRes: Response
+      if (brainstormEntryId.current) {
+        // Append to the existing entry for this brainstorm session.
+        saveRes = await fetch(`/api/journal/${brainstormEntryId.current}`, {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ content: qaBlock }),
+        })
+      } else {
+        // First turn: create a new entry and remember its id.
+        saveRes = await fetch("/api/journal", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ content: qaBlock, item: q.slice(0, 20) }),
+        })
+        if (saveRes.ok) {
+          const saved = (await saveRes.json()) as { id: string }
+          brainstormEntryId.current = saved.id
+        }
+      }
       if (!saveRes.ok) {
         const body = await saveRes.text()
         setChatError(`Auto-save failed (HTTP ${saveRes.status}): ${body}`)


### PR DESCRIPTION
## Summary

- Second and later messages in the journal brainstorm chat were creating a new journal entry each time instead of appending to the same page
- Add `append_to_entry()` to `journal_store` for in-place file append
- Add `PATCH /api/journal/{entry_id}` endpoint
- Track `brainstormEntryId` ref in `JournalScreen`; first turn POSTs a new entry, subsequent turns PATCH the same entry
- Fix `test_empty_output_returns_empty_zip`: also patch `INPUT_DIR` so real image files don't leak into the assertion

## Test plan

- [x] All 665 tests pass (`pytest`)
- [x] First brainstorm turn creates a new journal entry
- [x] Second (and later) turns append to the same entry — no new page created
- [x] Page reload starts a fresh session (new entry on next brainstorm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7ag4dxUN1GjbastP3injd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now continue an existing journal entry instead of creating a new one each time.
  * Brainstorm session updates are now saved into the same journal entry, keeping related notes together.

* **Bug Fixes**
  * Exporting from an empty or unavailable source now still produces a valid empty zip file.
  * Attempts to update a missing journal entry now return a clear “not found” response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->