### PR TITLE
feat(web): add time-range pulldown to usage daily trend chart

### DIFF
--- a/apps/web/components/screens/UsageDashboard.tsx
+++ b/apps/web/components/screens/UsageDashboard.tsx
@@ -3,7 +3,9 @@ import { useCallback, useEffect, useRef, useState } from "react"
 
 import { UsageBarChart } from "@/components/UsageBarChart"
 import { UsageTrendChart } from "@/components/UsageTrendChart"
+import { formatLocalDate } from "@/lib/utils"
 import {
+  filterSummaryByRange,
   formatUsageField,
   UsageChartMetric,
   UsageDailySummary,
@@ -12,6 +14,8 @@ import {
   USAGE_CHART_METRIC_LABELS,
   USAGE_FIELD_LABELS,
   USAGE_FIELD_ORDER,
+  UsageRange,
+  USAGE_RANGE_LABELS,
   UsageRecord,
   UsageSummaryResponse,
 } from "@/lib/usage-types"
@@ -32,6 +36,7 @@ export function UsageDashboard() {
   const [selectedDate, setSelectedDate] = useState<string | null>(null)
   const [records, setRecords] = useState<UsageRecord[]>([])
   const [metric, setMetric] = useState<UsageChartMetric>("cost_usd")
+  const [range, setRange] = useState<UsageRange>("7d")
   const [summary, setSummary] = useState<UsageDailySummary[]>([])
   const [activeIndex, setActiveIndex] = useState<number | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -122,6 +127,7 @@ export function UsageDashboard() {
     )
   }
 
+  const visibleSummary = filterSummaryByRange(summary, range, formatLocalDate())
   const activeRecord = activeIndex !== null ? records[activeIndex] : null
 
   return (
@@ -138,6 +144,21 @@ export function UsageDashboard() {
             {dates.map((d) => (
               <option key={d} value={d}>
                 {d}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          Range
+          <select
+            data-testid="usage-range-select"
+            value={range}
+            onChange={(e) => setRange(e.target.value as UsageRange)}
+            className="rounded-md border bg-background px-2 py-1 text-sm"
+          >
+            {(Object.keys(USAGE_RANGE_LABELS) as UsageRange[]).map((r) => (
+              <option key={r} value={r}>
+                {USAGE_RANGE_LABELS[r]}
               </option>
             ))}
           </select>
@@ -177,12 +198,12 @@ export function UsageDashboard() {
         )}
       </section>
 
-      {summary.length > 0 && metric !== "all" && (
+      {visibleSummary.length > 0 && metric !== "all" && (
         <section className="space-y-1">
           <h3 className="text-sm font-medium text-muted-foreground">
-            Daily trend — {USAGE_CHART_METRIC_LABELS[metric]}
+            Daily trend ({USAGE_RANGE_LABELS[range]}) — {USAGE_CHART_METRIC_LABELS[metric]}
           </h3>
-          <UsageTrendChart summary={summary} metric={metric} />
+          <UsageTrendChart summary={visibleSummary} metric={metric} />
         </section>
       )}
 

--- a/apps/web/components/screens/UsageDashboard.tsx
+++ b/apps/web/components/screens/UsageDashboard.tsx
@@ -149,21 +149,6 @@ export function UsageDashboard() {
           </select>
         </label>
         <label className="flex items-center gap-2 text-sm">
-          Range
-          <select
-            data-testid="usage-range-select"
-            value={range}
-            onChange={(e) => setRange(e.target.value as UsageRange)}
-            className="rounded-md border bg-background px-2 py-1 text-sm"
-          >
-            {(Object.keys(USAGE_RANGE_LABELS) as UsageRange[]).map((r) => (
-              <option key={r} value={r}>
-                {USAGE_RANGE_LABELS[r]}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="flex items-center gap-2 text-sm">
           Metric
           <select
             data-testid="usage-metric-select"
@@ -174,6 +159,21 @@ export function UsageDashboard() {
             {METRICS.map((m) => (
               <option key={m} value={m}>
                 {USAGE_CHART_METRIC_LABELS[m]}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          Range
+          <select
+            data-testid="usage-range-select"
+            value={range}
+            onChange={(e) => setRange(e.target.value as UsageRange)}
+            className="rounded-md border bg-background px-2 py-1 text-sm"
+          >
+            {(Object.keys(USAGE_RANGE_LABELS) as UsageRange[]).map((r) => (
+              <option key={r} value={r}>
+                {USAGE_RANGE_LABELS[r]}
               </option>
             ))}
           </select>

--- a/apps/web/lib/usage-types.ts
+++ b/apps/web/lib/usage-types.ts
@@ -53,7 +53,8 @@ export const USAGE_RANGE_DAYS: Record<UsageRange, number | null> = {
 // Keep only summary rows within `range` calendar days of `today` (ISO
 // YYYY-MM-DD). Comparison is lexicographic on ISO date strings, which is
 // correct for fixed-width YYYY-MM-DD. The cutoff is `today - (days - 1)` so a
-// 7-day window includes today plus the previous six days.
+// 7-day window includes today plus the previous six days; rows dated after
+// `today` are excluded so the window stays bounded on both ends.
 export function filterSummaryByRange(
   summary: UsageDailySummary[],
   range: UsageRange,
@@ -64,7 +65,7 @@ export function filterSummaryByRange(
   const base = new Date(`${today}T00:00:00`)
   base.setDate(base.getDate() - (days - 1))
   const cutoff = formatLocalDate(base)
-  return summary.filter((d) => d.date >= cutoff)
+  return summary.filter((d) => d.date >= cutoff && d.date <= today)
 }
 
 // Numeric fields a user can chart on the y-axis.

--- a/apps/web/lib/usage-types.ts
+++ b/apps/web/lib/usage-types.ts
@@ -1,3 +1,5 @@
+import { formatLocalDate } from "@/lib/utils"
+
 export type UsageRecord = {
   timestamp: string
   label: string
@@ -61,7 +63,7 @@ export function filterSummaryByRange(
   if (days === null) return summary
   const base = new Date(`${today}T00:00:00`)
   base.setDate(base.getDate() - (days - 1))
-  const cutoff = `${base.getFullYear()}-${String(base.getMonth() + 1).padStart(2, "0")}-${String(base.getDate()).padStart(2, "0")}`
+  const cutoff = formatLocalDate(base)
   return summary.filter((d) => d.date >= cutoff)
 }
 

--- a/apps/web/lib/usage-types.ts
+++ b/apps/web/lib/usage-types.ts
@@ -32,6 +32,39 @@ export type UsageSummaryResponse = {
   summary: UsageDailySummary[]
 }
 
+// Time-range options for filtering the daily trend chart.
+export type UsageRange = "7d" | "30d" | "all"
+
+export const USAGE_RANGE_LABELS: Record<UsageRange, string> = {
+  "7d": "Last 7 days",
+  "30d": "Last 30 days",
+  all: "All time",
+}
+
+// Number of calendar days to keep (inclusive of today); null = no limit.
+export const USAGE_RANGE_DAYS: Record<UsageRange, number | null> = {
+  "7d": 7,
+  "30d": 30,
+  all: null,
+}
+
+// Keep only summary rows within `range` calendar days of `today` (ISO
+// YYYY-MM-DD). Comparison is lexicographic on ISO date strings, which is
+// correct for fixed-width YYYY-MM-DD. The cutoff is `today - (days - 1)` so a
+// 7-day window includes today plus the previous six days.
+export function filterSummaryByRange(
+  summary: UsageDailySummary[],
+  range: UsageRange,
+  today: string,
+): UsageDailySummary[] {
+  const days = USAGE_RANGE_DAYS[range]
+  if (days === null) return summary
+  const base = new Date(`${today}T00:00:00`)
+  base.setDate(base.getDate() - (days - 1))
+  const cutoff = `${base.getFullYear()}-${String(base.getMonth() + 1).padStart(2, "0")}-${String(base.getDate()).padStart(2, "0")}`
+  return summary.filter((d) => d.date >= cutoff)
+}
+
 // Numeric fields a user can chart on the y-axis.
 export type UsageMetric =
   | "cost_usd"

--- a/apps/web/tests/usage-dashboard.test.tsx
+++ b/apps/web/tests/usage-dashboard.test.tsx
@@ -108,21 +108,29 @@ describe("UsageDashboard", () => {
   })
 
   it("renders the daily trend chart from the summary endpoint", async () => {
-    fetchMock.mockImplementation((url: string) => {
-      if (url.includes("/api/usage/summary")) return Promise.resolve(jsonResponse(SUMMARY))
-      if (url.includes("/api/usage/dates")) return Promise.resolve(jsonResponse(DATES))
-      return Promise.resolve(jsonResponse(DAY_20620))
-    })
+    // Pin the clock so 2026-06-23/24 (SUMMARY fixture dates) always fall within
+    // the default 7-day window, regardless of when the test actually runs.
+    vi.useFakeTimers({ toFake: ["Date"] })
+    vi.setSystemTime(new Date(2026, 5, 25)) // 2026-06-25 local
+    try {
+      fetchMock.mockImplementation((url: string) => {
+        if (url.includes("/api/usage/summary")) return Promise.resolve(jsonResponse(SUMMARY))
+        if (url.includes("/api/usage/dates")) return Promise.resolve(jsonResponse(DATES))
+        return Promise.resolve(jsonResponse(DAY_20620))
+      })
 
-    render(<UsageDashboard />)
+      render(<UsageDashboard />)
 
-    await waitFor(() => {
-      expect(screen.getByTestId("usage-trend-chart")).toBeInTheDocument()
-    })
-    // One point per summary day; line drawn for >1 point.
-    expect(screen.getByTestId("usage-trend-point-0")).toBeInTheDocument()
-    expect(screen.getByTestId("usage-trend-point-1")).toBeInTheDocument()
-    expect(screen.getByTestId("usage-trend-line")).toBeInTheDocument()
+      await waitFor(() => {
+        expect(screen.getByTestId("usage-trend-chart")).toBeInTheDocument()
+      })
+      // One point per summary day; line drawn for >1 point.
+      expect(screen.getByTestId("usage-trend-point-0")).toBeInTheDocument()
+      expect(screen.getByTestId("usage-trend-point-1")).toBeInTheDocument()
+      expect(screen.getByTestId("usage-trend-line")).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("shows formatted key/value detail when a bar is hovered", async () => {
@@ -206,6 +214,11 @@ describe("UsageDashboard", () => {
   })
 
   it("renders stacked segments and legend when metric is 'all'; restores trend on switch back", async () => {
+    // Pin the clock so 2026-06-23/24 (SUMMARY fixture dates) always fall within
+    // the default 7-day window, regardless of when the test actually runs.
+    vi.useFakeTimers({ toFake: ["Date"] })
+    vi.setSystemTime(new Date(2026, 5, 25)) // 2026-06-25 local
+    try {
     fetchMock.mockImplementation((url: string) => {
       if (url.includes("/api/usage/summary")) return Promise.resolve(jsonResponse(SUMMARY))
       if (url.includes("/api/usage/dates")) return Promise.resolve(jsonResponse(DATES))
@@ -235,6 +248,9 @@ describe("UsageDashboard", () => {
     await waitFor(() => {
       expect(screen.getByTestId("usage-trend-chart")).toBeInTheDocument()
     })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("defaults to a 7-day range and drops out-of-window trend points", async () => {

--- a/apps/web/tests/usage-dashboard.test.tsx
+++ b/apps/web/tests/usage-dashboard.test.tsx
@@ -34,7 +34,7 @@ const DAY_20620 = {
 const SUMMARY = {
   summary: [
     {
-      date: "2026-06-19",
+      date: "2026-06-23",
       calls: 3,
       input_tokens: 100,
       output_tokens: 2000,
@@ -43,7 +43,7 @@ const SUMMARY = {
       cost_usd: 0.5,
     },
     {
-      date: "2026-06-20",
+      date: "2026-06-24",
       calls: 2,
       input_tokens: 200,
       output_tokens: 10607,
@@ -235,6 +235,36 @@ describe("UsageDashboard", () => {
     await waitFor(() => {
       expect(screen.getByTestId("usage-trend-chart")).toBeInTheDocument()
     })
+  })
+
+  it("defaults to a 7-day range and drops out-of-window trend points", async () => {
+    // Fix 'today' far past the SUMMARY dates so the 7-day default hides them.
+    vi.useFakeTimers({ toFake: ["Date"] })
+    vi.setSystemTime(new Date(2026, 6, 15)) // 2026-07-15 local
+    try {
+      fetchMock.mockImplementation((url: string) => {
+        if (url.startsWith("/api/usage/dates")) return Promise.resolve(jsonResponse(DATES))
+        if (url.startsWith("/api/usage/summary")) return Promise.resolve(jsonResponse(SUMMARY))
+        return Promise.resolve(jsonResponse(DAY_20620))
+      })
+      render(<UsageDashboard />)
+
+      const rangeSelect = await screen.findByTestId("usage-range-select")
+      expect((rangeSelect as HTMLSelectElement).value).toBe("7d")
+
+      // 2026-06-19/20 are >7 days before 2026-07-15, so no trend points render.
+      await waitFor(() => {
+        expect(screen.queryByTestId("usage-trend-point-0")).toBeNull()
+      })
+
+      // Switching to All time brings the points back.
+      await userEvent.selectOptions(rangeSelect, "all")
+      await waitFor(() => {
+        expect(screen.getByTestId("usage-trend-point-0")).toBeInTheDocument()
+      })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("ignores a stale slow response when the date changed", async () => {

--- a/apps/web/tests/usage-dashboard.test.tsx
+++ b/apps/web/tests/usage-dashboard.test.tsx
@@ -268,7 +268,7 @@ describe("UsageDashboard", () => {
       const rangeSelect = await screen.findByTestId("usage-range-select")
       expect((rangeSelect as HTMLSelectElement).value).toBe("7d")
 
-      // 2026-06-19/20 are >7 days before 2026-07-15, so no trend points render.
+      // 2026-06-23/24 are >7 days before 2026-07-15, so no trend points render.
       await waitFor(() => {
         expect(screen.queryByTestId("usage-trend-point-0")).toBeNull()
       })

--- a/apps/web/tests/usage-types.test.ts
+++ b/apps/web/tests/usage-types.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest"
 
-import { niceScale } from "@/lib/usage-types"
+import {
+  filterSummaryByRange,
+  niceScale,
+  UsageDailySummary,
+} from "@/lib/usage-types"
 
 describe("niceScale", () => {
   it("rounds a max of 14 to a step of 2", () => {
@@ -33,5 +37,46 @@ describe("niceScale", () => {
 
   it("falls back to a 0..1 scale for non-positive input", () => {
     expect(niceScale(0)).toEqual({ niceMax: 1, step: 1, ticks: [0, 1] })
+  })
+})
+
+function day(date: string): UsageDailySummary {
+  return {
+    date,
+    calls: 1,
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_read_tokens: 0,
+    cache_creation_tokens: 0,
+    cost_usd: 0,
+  }
+}
+
+describe("filterSummaryByRange", () => {
+  // today = 2026-06-29; 7d window keeps 2026-06-23..2026-06-29 inclusive.
+  const summary = [
+    day("2026-06-22"), // out (8 days back)
+    day("2026-06-23"), // boundary in (6 days back)
+    day("2026-06-29"), // today, in
+  ]
+
+  it("keeps the boundary day and drops the day before it for 7d", () => {
+    const result = filterSummaryByRange(summary, "7d", "2026-06-29")
+    expect(result.map((d) => d.date)).toEqual(["2026-06-23", "2026-06-29"])
+  })
+
+  it("returns all rows for the 'all' range", () => {
+    const result = filterSummaryByRange(summary, "all", "2026-06-29")
+    expect(result).toHaveLength(3)
+  })
+
+  it("keeps a 30-day window", () => {
+    const result = filterSummaryByRange(summary, "30d", "2026-06-29")
+    // 2026-06-22 is 7 days back, well within 30 days.
+    expect(result).toHaveLength(3)
+  })
+
+  it("handles an empty summary", () => {
+    expect(filterSummaryByRange([], "7d", "2026-06-29")).toEqual([])
   })
 })

--- a/apps/web/tests/usage-types.test.ts
+++ b/apps/web/tests/usage-types.test.ts
@@ -65,6 +65,12 @@ describe("filterSummaryByRange", () => {
     expect(result.map((d) => d.date)).toEqual(["2026-06-23", "2026-06-29"])
   })
 
+  it("drops future-dated rows past today for bounded ranges", () => {
+    const withFuture = [...summary, day("2026-07-01")]
+    const result = filterSummaryByRange(withFuture, "7d", "2026-06-29")
+    expect(result.map((d) => d.date)).toEqual(["2026-06-23", "2026-06-29"])
+  })
+
   it("returns all rows for the 'all' range", () => {
     const result = filterSummaryByRange(summary, "all", "2026-06-29")
     expect(result).toHaveLength(3)

--- a/docs/superpowers/plans/2026-06-29-usage-range-pulldown.md
+++ b/docs/superpowers/plans/2026-06-29-usage-range-pulldown.md
@@ -1,0 +1,277 @@
+# Usage 期間レンジプルダウン Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Usage ダッシュボードの日別トレンドチャートに、表示範囲を「Last 7 days / Last 30 days / All time」で切替える期間レンジプルダウンを追加する。
+
+**Architecture:** バックエンド変更なし。`/api/usage/summary` が返す全日分の `summary` を、純関数 `filterSummaryByRange` で暦日ベースに絞り込み、`UsageTrendChart` に渡す。期間選択 state を `UsageDashboard` に持たせる。
+
+**Tech Stack:** Next.js 14 (App Router) / React / TypeScript / Vitest + Testing Library。
+
+## Global Constraints
+
+- コード内コメント・docstring は **英語** で書く（チャット応答は日本語）。
+- UI 表示文言は既存に合わせ **英語**（`Last 7 days` 等）。
+- 既存の Date / Metric プルダウン・Per run 棒グラフの挙動は変更しない。
+- テストランナーは `apps/web` で `npm run test`（vitest run）。lint は `npm run lint`。
+- ファイルパスはすべて `apps/web/` 配下。
+
+---
+
+### Task 1: `filterSummaryByRange` 純関数とレンジ定数
+
+**Files:**
+- Modify: `apps/web/lib/usage-types.ts`
+- Test: `apps/web/tests/usage-types.test.ts`
+
+**Interfaces:**
+- Consumes: 既存 `UsageDailySummary` 型（`{ date: string; ... }`、`date` は ISO `YYYY-MM-DD`）。
+- Produces:
+  - `type UsageRange = "7d" | "30d" | "all"`
+  - `const USAGE_RANGE_LABELS: Record<UsageRange, string>`
+  - `const USAGE_RANGE_DAYS: Record<UsageRange, number | null>`
+  - `function filterSummaryByRange(summary: UsageDailySummary[], range: UsageRange, today: string): UsageDailySummary[]`
+
+- [ ] **Step 1: Write the failing tests**
+
+`apps/web/tests/usage-types.test.ts` の import 行に `filterSummaryByRange`, `USAGE_RANGE_DAYS`, `type UsageRange` を追加し、末尾に以下の describe を追加する。
+
+```ts
+import {
+  filterSummaryByRange,
+  niceScale,
+  UsageDailySummary,
+} from "@/lib/usage-types"
+
+function day(date: string): UsageDailySummary {
+  return {
+    date,
+    calls: 1,
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_read_tokens: 0,
+    cache_creation_tokens: 0,
+    cost_usd: 0,
+  }
+}
+
+describe("filterSummaryByRange", () => {
+  // today = 2026-06-29; 7d window keeps 2026-06-23..2026-06-29 inclusive.
+  const summary = [
+    day("2026-06-22"), // out (8 days back)
+    day("2026-06-23"), // boundary in (6 days back)
+    day("2026-06-29"), // today, in
+  ]
+
+  it("keeps the boundary day and drops the day before it for 7d", () => {
+    const result = filterSummaryByRange(summary, "7d", "2026-06-29")
+    expect(result.map((d) => d.date)).toEqual(["2026-06-23", "2026-06-29"])
+  })
+
+  it("returns all rows for the 'all' range", () => {
+    const result = filterSummaryByRange(summary, "all", "2026-06-29")
+    expect(result).toHaveLength(3)
+  })
+
+  it("keeps a 30-day window", () => {
+    const result = filterSummaryByRange(summary, "30d", "2026-06-29")
+    // 2026-06-22 is 7 days back, well within 30 days.
+    expect(result).toHaveLength(3)
+  })
+
+  it("handles an empty summary", () => {
+    expect(filterSummaryByRange([], "7d", "2026-06-29")).toEqual([])
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd apps/web && npm run test -- usage-types`
+Expected: FAIL — `filterSummaryByRange is not a function` / export なし。
+
+- [ ] **Step 3: Implement the function and constants**
+
+`apps/web/lib/usage-types.ts` の `UsageSummaryResponse` 型定義の直後（35 行目付近）に追記する。
+
+```ts
+// Time-range options for filtering the daily trend chart.
+export type UsageRange = "7d" | "30d" | "all"
+
+export const USAGE_RANGE_LABELS: Record<UsageRange, string> = {
+  "7d": "Last 7 days",
+  "30d": "Last 30 days",
+  all: "All time",
+}
+
+// Number of calendar days to keep (inclusive of today); null = no limit.
+export const USAGE_RANGE_DAYS: Record<UsageRange, number | null> = {
+  "7d": 7,
+  "30d": 30,
+  all: null,
+}
+
+// Keep only summary rows within `range` calendar days of `today` (ISO
+// YYYY-MM-DD). Comparison is lexicographic on ISO date strings, which is
+// correct for fixed-width YYYY-MM-DD. The cutoff is `today - (days - 1)` so a
+// 7-day window includes today plus the previous six days.
+export function filterSummaryByRange(
+  summary: UsageDailySummary[],
+  range: UsageRange,
+  today: string,
+): UsageDailySummary[] {
+  const days = USAGE_RANGE_DAYS[range]
+  if (days === null) return summary
+  const base = new Date(`${today}T00:00:00`)
+  base.setDate(base.getDate() - (days - 1))
+  const cutoff = `${base.getFullYear()}-${String(base.getMonth() + 1).padStart(2, "0")}-${String(base.getDate()).padStart(2, "0")}`
+  return summary.filter((d) => d.date >= cutoff)
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd apps/web && npm run test -- usage-types`
+Expected: PASS（既存 `niceScale` テスト含め green）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/lib/usage-types.ts apps/web/tests/usage-types.test.ts
+git commit -m "feat(web): add filterSummaryByRange and usage range constants"
+```
+
+---
+
+### Task 2: Range プルダウンを UsageDashboard に統合
+
+**Files:**
+- Modify: `apps/web/components/screens/UsageDashboard.tsx`
+- Test: `apps/web/tests/usage-dashboard.test.tsx`
+
+**Interfaces:**
+- Consumes: Task 1 の `UsageRange`, `USAGE_RANGE_LABELS`, `filterSummaryByRange`、既存 `formatLocalDate`（`@/lib/utils`）。
+- Produces: `data-testid="usage-range-select"` の `<select>`（UI 契約）。
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/web/tests/usage-dashboard.test.tsx` に以下のテストを追加する。既存 `SUMMARY` は `2026-06-19` と `2026-06-20` の 2 日分。`formatLocalDate` 経由で today を決めるため、`vi.useFakeTimers` で時刻を固定する。ファイル冒頭付近の既存 describe 内に追加する（`fetchMock` のセットアップは既存ヘルパに従う。`/api/usage/dates`→DATES、`/api/usage/summary`→SUMMARY、`/api/usage?date=`→DAY を返すルーティングは既存テストのパターンを踏襲すること）。
+
+```ts
+it("defaults to a 7-day range and drops out-of-window trend points", async () => {
+  // Fix 'today' far past the SUMMARY dates so the 7-day default hides them.
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date(2026, 6, 15)) // 2026-07-15 local
+  try {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.startsWith("/api/usage/dates")) return Promise.resolve(jsonResponse(DATES))
+      if (url.startsWith("/api/usage/summary")) return Promise.resolve(jsonResponse(SUMMARY))
+      return Promise.resolve(jsonResponse(DAY_20620))
+    })
+    render(<UsageDashboard />)
+
+    const rangeSelect = await screen.findByTestId("usage-range-select")
+    expect((rangeSelect as HTMLSelectElement).value).toBe("7d")
+
+    // 2026-06-19/20 are >7 days before 2026-07-15, so no trend points render.
+    await waitFor(() => {
+      expect(screen.queryByTestId("usage-trend-point-0")).toBeNull()
+    })
+
+    // Switching to All time brings the points back.
+    await userEvent.selectOptions(rangeSelect, "all")
+    await waitFor(() => {
+      expect(screen.getByTestId("usage-trend-point-0")).toBeInTheDocument()
+    })
+  } finally {
+    vi.useRealTimers()
+  }
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/web && npm run test -- usage-dashboard`
+Expected: FAIL — `usage-range-select` が見つからない。
+
+- [ ] **Step 3: Implement the Range pulldown**
+
+`apps/web/components/screens/UsageDashboard.tsx` を編集する。
+
+(a) import に追記:
+
+```ts
+import { formatLocalDate } from "@/lib/utils"
+```
+
+`@/lib/usage-types` の import 群に `filterSummaryByRange`, `UsageRange`, `USAGE_RANGE_LABELS` を追加する。
+
+(b) `metric` state の直後に range state を追加:
+
+```ts
+  const [range, setRange] = useState<UsageRange>("7d")
+```
+
+(c) `activeRecord` を算出している箇所（`const activeRecord = ...` の手前）に追加:
+
+```ts
+  const visibleSummary = filterSummaryByRange(summary, range, formatLocalDate())
+```
+
+(d) Metric の `<label>` ブロックの直後に Range プルダウンを追加:
+
+```tsx
+        <label className="flex items-center gap-2 text-sm">
+          Range
+          <select
+            data-testid="usage-range-select"
+            value={range}
+            onChange={(e) => setRange(e.target.value as UsageRange)}
+            className="rounded-md border bg-background px-2 py-1 text-sm"
+          >
+            {(Object.keys(USAGE_RANGE_LABELS) as UsageRange[]).map((r) => (
+              <option key={r} value={r}>
+                {USAGE_RANGE_LABELS[r]}
+              </option>
+            ))}
+          </select>
+        </label>
+```
+
+(e) トレンドセクションを `summary` から `visibleSummary` に差し替え、見出しにレンジを反映:
+
+```tsx
+      {visibleSummary.length > 0 && metric !== "all" && (
+        <section className="space-y-1">
+          <h3 className="text-sm font-medium text-muted-foreground">
+            Daily trend ({USAGE_RANGE_LABELS[range]}) — {USAGE_CHART_METRIC_LABELS[metric]}
+          </h3>
+          <UsageTrendChart summary={visibleSummary} metric={metric} />
+        </section>
+      )}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/web && npm run test -- usage-dashboard`
+Expected: PASS（既存 UsageDashboard テストも green のまま）。
+
+- [ ] **Step 5: Lint and full test sweep**
+
+Run: `cd apps/web && npm run lint && npm run test`
+Expected: lint クリーン、全 vitest スイート green。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/components/screens/UsageDashboard.tsx apps/web/tests/usage-dashboard.test.tsx
+git commit -m "feat(web): add time-range pulldown to usage daily trend chart"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** 期間レンジプルダウン追加（Task 2）/ 初期値 7d（Task 2 step1,3）/ 暦日ベースフィルタ（Task 1）/ 選択肢 7d・30d・all（Task 1 定数）/ Per run・Date 無変更（変更箇所限定）/ バックエンド無変更（該当タスクなし、意図どおり）。全カバー。
+- **Placeholder scan:** プレースホルダなし。各ステップに実コード・実コマンド記載。
+- **Type consistency:** `filterSummaryByRange(summary, range, today)` のシグネチャは Task 1 定義と Task 2 呼び出しで一致。`UsageRange` / `USAGE_RANGE_LABELS` 名称一致。`formatLocalDate()` は既存 `@/lib/utils` のシグネチャ（引数省略可）に一致。

--- a/docs/superpowers/plans/2026-06-29-usage-range-pulldown.md
+++ b/docs/superpowers/plans/2026-06-29-usage-range-pulldown.md
@@ -124,10 +124,15 @@ export function filterSummaryByRange(
   if (days === null) return summary
   const base = new Date(`${today}T00:00:00`)
   base.setDate(base.getDate() - (days - 1))
-  const cutoff = `${base.getFullYear()}-${String(base.getMonth() + 1).padStart(2, "0")}-${String(base.getDate()).padStart(2, "0")}`
-  return summary.filter((d) => d.date >= cutoff)
+  // Reuse the shared local-ISO formatter so cutoff/today use one source of truth.
+  const cutoff = formatLocalDate(base)
+  return summary.filter((d) => d.date >= cutoff && d.date <= today)
 }
 ```
+
+> 実装メモ: `formatLocalDate` は `@/lib/utils` から import する（手書きの YYYY-MM-DD
+> 組み立てを避け一元化）。フィルタは下限 `cutoff` に加え上限 `today` も課し、未来日の
+> 行が窓に残らないようにする。
 
 - [ ] **Step 4: Run the tests to verify they pass**
 

--- a/docs/superpowers/specs/2026-06-29-usage-range-pulldown-design.md
+++ b/docs/superpowers/specs/2026-06-29-usage-range-pulldown-design.md
@@ -1,0 +1,108 @@
+# Usage 期間レンジプルダウン 設計書
+
+- 日付: 2026-06-29
+- 対象 Issue: Usage の一週間分を表示する項目を pulldown で追加。一週間の間に日毎でどれだけトークン消費したかなど分析したい。
+
+## 背景
+
+Config > Usage ダッシュボード (`apps/web/components/screens/UsageDashboard.tsx`) は既に
+以下を備えている。
+
+- **Date プルダウン** (`/api/usage/dates`) — 単日を選び、その日の run 単位の棒グラフ
+  (`UsageBarChart`) を表示
+- **Metric プルダウン** — cost / input / output / cache / duration / all を切替
+- **Daily trend チャート** (`/api/usage/summary` → `UsageTrendChart`) — 日別合算を
+  **全期間** ISO 日付昇順で折れ線表示
+
+日毎のトークン消費トレンド自体は既に可視化されているが、常に全期間表示のため
+「直近1週間の消費を分析する」には不便。本対応では **表示範囲を絞り込む期間レンジ
+プルダウン** を追加する。
+
+## ゴール / 非ゴール
+
+### ゴール
+- 日別トレンドチャートの表示範囲を「Last 7 days / Last 30 days / All time」で切替える
+  プルダウンを追加する。初期値は **Last 7 days**。
+- 絞り込みは **暦日ベース**（今日から N-1 日前の日付以降を残す）で行う。
+
+### 非ゴール
+- Per run 棒グラフ・Date プルダウンの挙動は変更しない（単日詳細用として維持）。
+- バックエンド (`/api/usage/*`) の変更はしない。
+- 集計値（合計・日平均など）の新規サマリ表示は追加しない（YAGNI）。
+
+## 設計方針: クライアント側フィルタ（バックエンド変更なし）
+
+`/api/usage/summary` は既に全日分を ISO 日付昇順で返している。新規 API は不要で、
+`UsageDashboard` が取得済みの `summary` をレンジで絞り込んだ `visibleSummary` を
+`UsageTrendChart` に渡すだけで完結する。
+
+### 暦日フィルタの定義
+
+- レンジ `7d` → 「今日を含む直近 7 暦日」。すなわち `date >= today - 6 days`。
+- レンジ `30d` → `date >= today - 29 days`。
+- レンジ `all` → フィルタなし。
+
+ログは毎日連続して存在するとは限らないため、件数 slice ではなく日付比較で残す。
+比較は ISO 日付文字列 (`YYYY-MM-DD`) の辞書順比較で正しく行える。今日の基準は
+ローカルタイムの `new Date()` から `YYYY-MM-DD` を生成する。
+
+## 変更点
+
+### 1. `apps/web/lib/usage-types.ts`
+- 型・定数を追加:
+  ```ts
+  export type UsageRange = "7d" | "30d" | "all"
+
+  export const USAGE_RANGE_LABELS: Record<UsageRange, string> = {
+    "7d": "Last 7 days",
+    "30d": "Last 30 days",
+    all: "All time",
+  }
+
+  // Number of calendar days to keep; null = no limit.
+  export const USAGE_RANGE_DAYS: Record<UsageRange, number | null> = {
+    "7d": 7,
+    "30d": 30,
+    all: null,
+  }
+  ```
+- 純関数 `filterSummaryByRange(summary, range, today)` を追加してフィルタロジックを
+  テスト可能にする:
+  ```ts
+  export function filterSummaryByRange(
+    summary: UsageDailySummary[],
+    range: UsageRange,
+    today: string, // ISO YYYY-MM-DD (local)
+  ): UsageDailySummary[]
+  ```
+  `USAGE_RANGE_DAYS[range]` が `null` ならそのまま返す。そうでなければ
+  `today` から `days - 1` 日引いた下限 ISO を計算し `date >= cutoff` を残す。
+
+### 2. `apps/web/components/screens/UsageDashboard.tsx`
+- `range` state を追加（初期値 `"7d"`）。
+- Metric プルダウンの隣に「Range」プルダウンを追加（`data-testid="usage-range-select"`、
+  選択肢は `USAGE_RANGE_LABELS`）。
+- `visibleSummary = filterSummaryByRange(summary, range, todayISO)` を算出し
+  `UsageTrendChart` に渡す。
+- トレンド見出しを `Daily trend ({USAGE_RANGE_LABELS[range]}) — {metric}` に変更。
+- トレンドセクションの表示条件は `visibleSummary.length > 0 && metric !== "all"`。
+
+### 3. テスト
+- `apps/web/lib/usage-types.test.ts`（または既存テストファイル）に
+  `filterSummaryByRange` の単体テストを追加:
+  - `7d` で境界日 (`today-6`) は残り `today-7` は除外される
+  - `all` は全件返す
+  - 空配列・単一要素のエッジケース
+- `UsageDashboard` のテストに Range プルダウンの存在と、`7d` 既定で範囲外の点が
+  描画されないことを確認するケースを追加。
+
+## エラーハンドリング
+- `summary` 取得失敗時の挙動は現状維持（非致命、棒グラフは動作）。
+- `filterSummaryByRange` は純関数で副作用なし。不正 `today` は呼び出し側で生成するため
+  考慮不要。
+
+## テスト計画
+- [ ] `filterSummaryByRange` 単体テスト green
+- [ ] `UsageDashboard` の Range プルダウンテスト green
+- [ ] `apps/web` の lint / typecheck パス
+- [ ] 手動: Usage 画面で Range 切替えにより折れ線の点数が変わることを確認


### PR DESCRIPTION
## Summary
- Usage ダッシュボードの日別トレンドチャートに期間レンジプルダウン（Last 7 days / Last 30 days / All time、初期値 7 days）を追加
- 直近1週間など任意の期間に絞って日毎のトークン消費を分析できるようにした
- バックエンド変更なし: 既存 `/api/usage/summary` の全日分を純関数 `filterSummaryByRange` で暦日ベース（today から N-1 日前以降）に絞り込むクライアント側フィルタ
- Per-run 棒グラフ・Date/Metric プルダウンの挙動は不変

## Changes
- `apps/web/lib/usage-types.ts`: `UsageRange` 型・`USAGE_RANGE_LABELS`・`USAGE_RANGE_DAYS`・`filterSummaryByRange` を追加
- `apps/web/components/screens/UsageDashboard.tsx`: Range プルダウン（Date → Metric → Range 順）と `visibleSummary` を追加
- テスト: `filterSummaryByRange` の単体テスト、デフォルト 7d 挙動テスト、既存トレンドテストの clock pinning

## Test plan
- [x] `npm run test`（apps/web）: 215/215 passed
- [x] `npm run lint`: 既存の無関係な警告のみ
- [ ] 手動: Usage 画面で Range 切替により折れ線の点数が変わることを確認

設計書: `docs/superpowers/specs/2026-06-29-usage-range-pulldown-design.md`
実装計画: `docs/superpowers/plans/2026-06-29-usage-range-pulldown.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Range” selector to the Usage dashboard’s daily trend chart (Last 7 days, Last 30 days, All time).
  * The trend chart displays only data within the selected range and reflects the chosen range in its header.

* **Bug Fixes**
  * Improved default behavior so the trend focuses on recent activity, excluding out-of-window points until a wider range is selected.

* **Tests**
  * Updated and added dashboard and filtering tests, including deterministic date handling and boundary checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->