### PR TITLE
feat(charts): add stock price comparison chart generation (#14)

### DIFF
--- a/apps/python/bin/chart.sh
+++ b/apps/python/bin/chart.sh
@@ -4,5 +4,11 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
-source "$PROJECT_ROOT/.venv/bin/activate"
+VENV_ACTIVATE="$PROJECT_ROOT/.venv/bin/activate"
+if [ ! -f "$VENV_ACTIVATE" ]; then
+    echo "error: venv not found at $VENV_ACTIVATE" >&2
+    echo "create it first: cd $PROJECT_ROOT && uv venv .venv && uv pip sync requirements.txt" >&2
+    exit 1
+fi
+source "$VENV_ACTIVATE"
 PYTHONPATH="$PROJECT_ROOT" exec python -m src.charts "$@"

--- a/apps/python/bin/chart.sh
+++ b/apps/python/bin/chart.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+source "$PROJECT_ROOT/.venv/bin/activate"
+PYTHONPATH="$PROJECT_ROOT" exec python -m src.charts "$@"

--- a/apps/python/requirements.in
+++ b/apps/python/requirements.in
@@ -1,5 +1,6 @@
 requests
 yfinance
+matplotlib
 python-dotenv
 notion-client
 pytest

--- a/apps/python/requirements.txt
+++ b/apps/python/requirements.txt
@@ -52,12 +52,16 @@ chromadb==1.5.9
     # via -r requirements.in
 click==8.4.1
     # via uvicorn
+contourpy==1.3.3
+    # via matplotlib
 courlan==1.4.0
     # via trafilatura
 coverage==7.13.5
     # via pytest-cov
 curl-cffi==0.15.0
     # via yfinance
+cycler==0.12.1
+    # via matplotlib
 dateparser==1.4.0
     # via htmldate
 distro==1.9.0
@@ -72,6 +76,8 @@ filelock==3.29.1
     # via huggingface-hub
 flatbuffers==25.12.19
     # via onnxruntime
+fonttools==4.63.0
+    # via matplotlib
 frozendict==2.4.7
     # via yfinance
 frozenlist==1.8.0
@@ -134,6 +140,8 @@ justext==3.0.2
     # via trafilatura
 keyring==25.7.0
     # via -r requirements.in
+kiwisolver==1.5.0
+    # via matplotlib
 kubernetes==36.0.2
     # via chromadb
 lxml==6.1.1
@@ -146,6 +154,8 @@ lxml-html-clean==0.4.5
     # via lxml
 markdown-it-py==4.0.0
     # via rich
+matplotlib==3.11.0
+    # via -r requirements.in
 mdurl==0.1.2
     # via markdown-it-py
 mmh3==5.2.1
@@ -165,6 +175,8 @@ notion-client==3.0.0
 numpy==2.4.4
     # via
     #   chromadb
+    #   contourpy
+    #   matplotlib
     #   onnxruntime
     #   pandas
     #   yfinance
@@ -205,12 +217,15 @@ packaging==26.1
     # via
     #   build
     #   huggingface-hub
+    #   matplotlib
     #   onnxruntime
     #   pytest
 pandas==3.0.2
     # via yfinance
 peewee==4.0.4
     # via yfinance
+pillow==12.2.0
+    # via matplotlib
 platformdirs==4.9.6
     # via yfinance
 pluggy==1.6.0
@@ -247,6 +262,8 @@ pygments==2.20.0
     # via
     #   pytest
     #   rich
+pyparsing==3.3.2
+    # via matplotlib
 pypika==0.51.1
     # via chromadb
 pyproject-hooks==1.2.0
@@ -265,6 +282,7 @@ python-dateutil==2.9.0.post0
     #   dateparser
     #   htmldate
     #   kubernetes
+    #   matplotlib
     #   pandas
 python-dotenv==1.2.2
     # via

--- a/apps/python/src/charts/__main__.py
+++ b/apps/python/src/charts/__main__.py
@@ -1,0 +1,62 @@
+"""CLI entrypoint for chart generation (#14).
+
+Usage:
+    python -m src.charts price [--tickers PLTR NVDA] [--output-dir DIR] [--period 3mo]
+
+When ``--tickers`` is omitted, the portfolio tickers from the briefing config
+are used.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from src.charts.price_comparison import generate_price_comparison
+
+# Default output directory: apps/python/output/charts (output/ is git-ignored).
+_DEFAULT_OUTPUT_DIR = Path(__file__).parents[2] / "output" / "charts"
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="python -m src.charts")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    price = sub.add_parser("price", help="multi-ticker price comparison chart")
+    price.add_argument(
+        "--tickers",
+        nargs="+",
+        default=None,
+        help="ticker symbols (default: portfolio tickers from config)",
+    )
+    price.add_argument(
+        "--output-dir",
+        type=Path,
+        default=_DEFAULT_OUTPUT_DIR,
+        help=f"output directory (default: {_DEFAULT_OUTPUT_DIR})",
+    )
+    price.add_argument(
+        "--period",
+        default="3mo",
+        help="lookback window passed to yfinance (default: 3mo)",
+    )
+
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit:
+        return 2
+
+    if args.cmd == "price":
+        tickers = args.tickers
+        if not tickers:
+            # Lazy import so the config file is only read when actually needed.
+            from src.config import CONFIG
+
+            tickers = list(CONFIG.portfolio.tickers)
+        out_path = generate_price_comparison(tickers, args.output_dir, args.period)
+        print(f"saved: {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/apps/python/src/charts/__main__.py
+++ b/apps/python/src/charts/__main__.py
@@ -43,8 +43,9 @@ def main(argv: list[str]) -> int:
 
     try:
         args = parser.parse_args(argv)
-    except SystemExit:
-        return 2
+    except SystemExit as e:
+        # Preserve argparse's real exit status (0 for --help, 2 for parse errors).
+        return int(e.code) if e.code is not None else 0
 
     if args.cmd == "price":
         tickers = args.tickers
@@ -53,7 +54,15 @@ def main(argv: list[str]) -> int:
             from src.config import CONFIG
 
             tickers = list(CONFIG.portfolio.tickers)
-        out_path = generate_price_comparison(tickers, args.output_dir, args.period)
+        try:
+            out_path = generate_price_comparison(tickers, args.output_dir, args.period)
+        except ValueError as exc:
+            tickers_str = ", ".join(tickers)
+            print(
+                f"error: {exc} (tickers={tickers_str}, period={args.period})",
+                file=sys.stderr,
+            )
+            return 3
         print(f"saved: {out_path}")
     return 0
 

--- a/apps/python/src/charts/price_comparison.py
+++ b/apps/python/src/charts/price_comparison.py
@@ -52,7 +52,12 @@ def render_price_comparison(close_df: pd.DataFrame, out_path: Path) -> Path:
 def _extract_close(raw: pd.DataFrame, tickers: list[str]) -> pd.DataFrame:
     """Pull the Close frame out of a yfinance.download() result and keep
     only the requested tickers that are actually present, as columns."""
-    close = raw["Close"]
+    try:
+        close = raw["Close"]
+    except KeyError:
+        # Empty / invalid-ticker downloads may lack a "Close" column entirely;
+        # normalize to an empty frame so the caller's ValueError contract holds.
+        return pd.DataFrame(index=raw.index)
     if isinstance(close, pd.Series):
         # Single-ticker download returns a flat Series; name the column after
         # the ticker so the downstream present-filter can find it.

--- a/apps/python/src/charts/price_comparison.py
+++ b/apps/python/src/charts/price_comparison.py
@@ -1,0 +1,47 @@
+"""Generate a normalized multi-ticker price comparison chart (#14 MVP)."""
+from datetime import datetime
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless backend; must precede pyplot import
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pandas as pd  # noqa: E402
+import yfinance as yf  # noqa: E402
+
+from src.logger import get_logger  # noqa: E402
+
+logger = get_logger(__name__)
+
+
+def normalize_to_index(close_df: pd.DataFrame) -> pd.DataFrame:
+    """Rebase each column to 100 at the first row so differently-priced
+    tickers share one comparable axis. Columns whose first value is NaN or
+    zero cannot be rebased and are dropped."""
+    out = {}
+    for col in close_df.columns:
+        first = close_df[col].iloc[0]
+        if pd.isna(first) or first == 0:
+            continue
+        out[col] = close_df[col] / first * 100
+    return pd.DataFrame(out, index=close_df.index)
+
+
+def render_price_comparison(close_df: pd.DataFrame, out_path: Path) -> Path:
+    """Normalize the raw Close DataFrame (index = dates, columns = tickers),
+    render a multi-line comparison chart, and save it as PNG to out_path.
+    Creates the parent directory if needed. Returns out_path."""
+    normalized = normalize_to_index(close_df)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig, ax = plt.subplots(figsize=(10, 6))
+    for col in normalized.columns:
+        ax.plot(normalized.index, normalized[col], label=col)
+    ax.set_title("Price comparison (normalized to 100)")
+    ax.set_xlabel("Date")
+    ax.set_ylabel("Indexed price (start = 100)")
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+    fig.savefig(out_path, dpi=120, bbox_inches="tight")
+    plt.close(fig)
+    return out_path

--- a/apps/python/src/charts/price_comparison.py
+++ b/apps/python/src/charts/price_comparison.py
@@ -45,3 +45,29 @@ def render_price_comparison(close_df: pd.DataFrame, out_path: Path) -> Path:
     fig.savefig(out_path, dpi=120, bbox_inches="tight")
     plt.close(fig)
     return out_path
+
+
+def _extract_close(raw: pd.DataFrame, tickers: list[str]) -> pd.DataFrame:
+    """Pull the Close frame out of a yfinance.download() result and keep
+    only the requested tickers that are actually present, as columns."""
+    close = raw["Close"]
+    if isinstance(close, pd.Series):
+        close = close.to_frame()
+    present = [t for t in tickers if t in close.columns]
+    return close.reindex(columns=present)
+
+
+def generate_price_comparison(
+    tickers: list[str],
+    output_dir: Path,
+    period: str = "3mo",
+) -> Path:
+    """Fetch Close prices via yfinance, render a normalized comparison chart,
+    and save it to output_dir/price-comparison-YYYYMMDD.png. Returns the saved
+    path. Raises ValueError if no usable ticker data was fetched."""
+    raw = yf.download(tickers, period=period, progress=False)
+    close = _extract_close(raw, tickers)
+    if normalize_to_index(close).columns.empty:
+        raise ValueError("no usable ticker data for chart")
+    out_path = output_dir / f"price-comparison-{datetime.now():%Y%m%d}.png"
+    return render_price_comparison(close, out_path)

--- a/apps/python/src/charts/price_comparison.py
+++ b/apps/python/src/charts/price_comparison.py
@@ -35,15 +35,17 @@ def render_price_comparison(close_df: pd.DataFrame, out_path: Path) -> Path:
     normalized = normalize_to_index(close_df)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     fig, ax = plt.subplots(figsize=(10, 6))
-    for col in normalized.columns:
-        ax.plot(normalized.index, normalized[col], label=col)
-    ax.set_title("Price comparison (normalized to 100)")
-    ax.set_xlabel("Date")
-    ax.set_ylabel("Indexed price (start = 100)")
-    ax.legend()
-    ax.grid(True, alpha=0.3)
-    fig.savefig(out_path, dpi=120, bbox_inches="tight")
-    plt.close(fig)
+    try:
+        for col in normalized.columns:
+            ax.plot(normalized.index, normalized[col], label=col)
+        ax.set_title("Price comparison (normalized to 100)")
+        ax.set_xlabel("Date")
+        ax.set_ylabel("Indexed price (start = 100)")
+        ax.legend()
+        ax.grid(True, alpha=0.3)
+        fig.savefig(out_path, dpi=120, bbox_inches="tight")
+    finally:
+        plt.close(fig)
     return out_path
 
 
@@ -52,7 +54,9 @@ def _extract_close(raw: pd.DataFrame, tickers: list[str]) -> pd.DataFrame:
     only the requested tickers that are actually present, as columns."""
     close = raw["Close"]
     if isinstance(close, pd.Series):
-        close = close.to_frame()
+        # Single-ticker download returns a flat Series; name the column after
+        # the ticker so the downstream present-filter can find it.
+        close = close.to_frame(name=tickers[0])
     present = [t for t in tickers if t in close.columns]
     return close.reindex(columns=present)
 
@@ -65,9 +69,14 @@ def generate_price_comparison(
     """Fetch Close prices via yfinance, render a normalized comparison chart,
     and save it to output_dir/price-comparison-YYYYMMDD.png. Returns the saved
     path. Raises ValueError if no usable ticker data was fetched."""
-    raw = yf.download(tickers, period=period, progress=False)
+    try:
+        raw = yf.download(tickers, period=period, progress=False)
+    except Exception as e:
+        logger.warning("price fetch failed for %s: %s", tickers, e)
+        raise ValueError("no usable ticker data for chart") from e
     close = _extract_close(raw, tickers)
     if normalize_to_index(close).columns.empty:
+        logger.warning("no usable close data for tickers %s", tickers)
         raise ValueError("no usable ticker data for chart")
     out_path = output_dir / f"price-comparison-{datetime.now():%Y%m%d}.png"
     return render_price_comparison(close, out_path)

--- a/apps/python/tests/test_charts_cli.py
+++ b/apps/python/tests/test_charts_cli.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+from src.charts import __main__ as cli
+
+
+def test_price_passes_explicit_args(tmp_path, monkeypatch, capsys):
+    captured = {}
+
+    def fake_generate(tickers, output_dir, period):
+        captured["tickers"] = tickers
+        captured["output_dir"] = output_dir
+        captured["period"] = period
+        return output_dir / "price-comparison-20260629.png"
+
+    monkeypatch.setattr(cli, "generate_price_comparison", fake_generate)
+
+    rc = cli.main(
+        ["price", "--tickers", "PLTR", "NVDA", "--output-dir", str(tmp_path), "--period", "1mo"]
+    )
+
+    assert rc == 0
+    assert captured["tickers"] == ["PLTR", "NVDA"]
+    assert captured["output_dir"] == tmp_path
+    assert captured["period"] == "1mo"
+    assert "saved:" in capsys.readouterr().out
+
+
+def test_price_defaults_to_config_tickers(tmp_path, monkeypatch):
+    captured = {}
+
+    def fake_generate(tickers, output_dir, period):
+        captured["tickers"] = tickers
+        return Path("x.png")
+
+    monkeypatch.setattr(cli, "generate_price_comparison", fake_generate)
+
+    # Stub the lazily-imported config so the test stays config-file-independent.
+    import types
+
+    fake_config = types.SimpleNamespace(
+        portfolio=types.SimpleNamespace(tickers=["AAA", "BBB"])
+    )
+    monkeypatch.setitem(
+        __import__("sys").modules, "src.config", types.SimpleNamespace(CONFIG=fake_config)
+    )
+
+    rc = cli.main(["price", "--output-dir", str(tmp_path)])
+
+    assert rc == 0
+    assert captured["tickers"] == ["AAA", "BBB"]

--- a/apps/python/tests/test_charts_cli.py
+++ b/apps/python/tests/test_charts_cli.py
@@ -48,3 +48,27 @@ def test_price_defaults_to_config_tickers(tmp_path, monkeypatch):
 
     assert rc == 0
     assert captured["tickers"] == ["AAA", "BBB"]
+
+
+def test_help_exits_zero():
+    # argparse raises SystemExit(0) for --help; main must preserve that.
+    assert cli.main(["--help"]) == 0
+    assert cli.main(["price", "--help"]) == 0
+
+
+def test_parse_error_returns_two():
+    # Unknown subcommand is a parse error → argparse SystemExit(2).
+    assert cli.main(["bogus"]) == 2
+
+
+def test_price_reports_value_error_and_returns_three(tmp_path, monkeypatch, capsys):
+    def fake_generate(tickers, output_dir, period):
+        raise ValueError("no usable ticker data for chart")
+
+    monkeypatch.setattr(cli, "generate_price_comparison", fake_generate)
+
+    rc = cli.main(["price", "--tickers", "ZZZ", "--output-dir", str(tmp_path)])
+
+    assert rc == 3
+    err = capsys.readouterr().err
+    assert "error:" in err and "ZZZ" in err

--- a/apps/python/tests/test_charts_price_comparison.py
+++ b/apps/python/tests/test_charts_price_comparison.py
@@ -1,10 +1,12 @@
-import math
+from datetime import datetime
 from pathlib import Path
 
 import pandas as pd
 import pytest
 
+from src.charts import price_comparison as pc_module
 from src.charts.price_comparison import (
+    generate_price_comparison,
     normalize_to_index,
     render_price_comparison,
 )
@@ -45,3 +47,43 @@ def test_render_writes_a_nonempty_png(tmp_path: Path):
     assert result == out_path
     assert out_path.exists()
     assert out_path.stat().st_size > 0
+
+
+def _yf_multiindex(tickers, with_data=True):
+    """Mimic yfinance.download() output: columns are a MultiIndex
+    (field, ticker) including a top-level 'Close'."""
+    idx = pd.to_datetime(["2026-01-01", "2026-01-02", "2026-01-03"])
+    cols = pd.MultiIndex.from_product([["Close", "Open"], tickers])
+    if with_data:
+        data = {
+            ("Close", tickers[0]): [10.0, 11.0, 12.0],
+            ("Close", tickers[1]): [100.0, 90.0, 110.0],
+            ("Open", tickers[0]): [9.0, 10.0, 11.0],
+            ("Open", tickers[1]): [99.0, 89.0, 109.0],
+        }
+    else:
+        nan = [float("nan")] * 3
+        data = {(f, t): nan for f in ["Close", "Open"] for t in tickers}
+    return pd.DataFrame(data, index=idx, columns=cols)
+
+
+def test_generate_writes_dated_png(tmp_path, monkeypatch):
+    tickers = ["PLTR", "NVDA"]
+    monkeypatch.setattr(
+        pc_module.yf, "download",
+        lambda *a, **k: _yf_multiindex(tickers),
+    )
+    out = generate_price_comparison(tickers, tmp_path)
+    expected = tmp_path / f"price-comparison-{datetime.now():%Y%m%d}.png"
+    assert out == expected
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_generate_raises_when_no_usable_data(tmp_path, monkeypatch):
+    tickers = ["PLTR", "NVDA"]
+    monkeypatch.setattr(
+        pc_module.yf, "download",
+        lambda *a, **k: _yf_multiindex(tickers, with_data=False),
+    )
+    with pytest.raises(ValueError):
+        generate_price_comparison(tickers, tmp_path)

--- a/apps/python/tests/test_charts_price_comparison.py
+++ b/apps/python/tests/test_charts_price_comparison.py
@@ -79,6 +79,30 @@ def test_generate_writes_dated_png(tmp_path, monkeypatch):
     assert out.exists() and out.stat().st_size > 0
 
 
+def _yf_single_ticker_flat(ticker: str) -> pd.DataFrame:
+    """Mimic yfinance.download() for a single ticker: flat DataFrame with plain
+    column names (e.g. 'Close', 'Open') — NOT a MultiIndex."""
+    idx = pd.to_datetime(["2026-01-01", "2026-01-02", "2026-01-03"])
+    return pd.DataFrame(
+        {"Close": [10.0, 11.0, 12.0], "Open": [9.0, 10.0, 11.0]},
+        index=idx,
+    )
+
+
+def test_generate_single_ticker_writes_dated_png(tmp_path, monkeypatch):
+    """Single-ticker download returns a flat frame; _extract_close must name
+    the column after the ticker so the present-filter keeps it."""
+    ticker = "PLTR"
+    monkeypatch.setattr(
+        pc_module.yf, "download",
+        lambda *a, **k: _yf_single_ticker_flat(ticker),
+    )
+    out = generate_price_comparison([ticker], tmp_path)
+    expected = tmp_path / f"price-comparison-{datetime.now():%Y%m%d}.png"
+    assert out == expected
+    assert out.exists() and out.stat().st_size > 0
+
+
 def test_generate_raises_when_no_usable_data(tmp_path, monkeypatch):
     tickers = ["PLTR", "NVDA"]
     monkeypatch.setattr(

--- a/apps/python/tests/test_charts_price_comparison.py
+++ b/apps/python/tests/test_charts_price_comparison.py
@@ -67,14 +67,24 @@ def _yf_multiindex(tickers, with_data=True):
     return pd.DataFrame(data, index=idx, columns=cols)
 
 
+class _FixedDateTime:
+    """Stub for pc_module.datetime so the filename date is deterministic
+    (avoids midnight-boundary flakiness between the call and the assertion)."""
+
+    @classmethod
+    def now(cls):
+        return datetime(2026, 6, 29)
+
+
 def test_generate_writes_dated_png(tmp_path, monkeypatch):
     tickers = ["PLTR", "NVDA"]
+    monkeypatch.setattr(pc_module, "datetime", _FixedDateTime)
     monkeypatch.setattr(
         pc_module.yf, "download",
         lambda *a, **k: _yf_multiindex(tickers),
     )
     out = generate_price_comparison(tickers, tmp_path)
-    expected = tmp_path / f"price-comparison-{datetime.now():%Y%m%d}.png"
+    expected = tmp_path / "price-comparison-20260629.png"
     assert out == expected
     assert out.exists() and out.stat().st_size > 0
 
@@ -93,12 +103,13 @@ def test_generate_single_ticker_writes_dated_png(tmp_path, monkeypatch):
     """Single-ticker download returns a flat frame; _extract_close must name
     the column after the ticker so the present-filter keeps it."""
     ticker = "PLTR"
+    monkeypatch.setattr(pc_module, "datetime", _FixedDateTime)
     monkeypatch.setattr(
         pc_module.yf, "download",
         lambda *a, **k: _yf_single_ticker_flat(ticker),
     )
     out = generate_price_comparison([ticker], tmp_path)
-    expected = tmp_path / f"price-comparison-{datetime.now():%Y%m%d}.png"
+    expected = tmp_path / "price-comparison-20260629.png"
     assert out == expected
     assert out.exists() and out.stat().st_size > 0
 
@@ -109,5 +120,16 @@ def test_generate_raises_when_no_usable_data(tmp_path, monkeypatch):
         pc_module.yf, "download",
         lambda *a, **k: _yf_multiindex(tickers, with_data=False),
     )
+    with pytest.raises(ValueError):
+        generate_price_comparison(tickers, tmp_path)
+
+
+def test_generate_raises_valueerror_when_close_column_absent(tmp_path, monkeypatch):
+    """An empty / invalid-ticker download lacking a 'Close' column must surface
+    as the documented ValueError, not a raw KeyError."""
+    tickers = ["PLTR", "NVDA"]
+    idx = pd.to_datetime(["2026-01-01", "2026-01-02"])
+    no_close = pd.DataFrame({"Open": [1.0, 2.0]}, index=idx)
+    monkeypatch.setattr(pc_module.yf, "download", lambda *a, **k: no_close)
     with pytest.raises(ValueError):
         generate_price_comparison(tickers, tmp_path)

--- a/apps/python/tests/test_charts_price_comparison.py
+++ b/apps/python/tests/test_charts_price_comparison.py
@@ -1,0 +1,47 @@
+import math
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from src.charts.price_comparison import (
+    normalize_to_index,
+    render_price_comparison,
+)
+
+
+def _close_df() -> pd.DataFrame:
+    # index = dates, columns = tickers
+    idx = pd.to_datetime(["2026-01-01", "2026-01-02", "2026-01-03"])
+    return pd.DataFrame(
+        {"PLTR": [10.0, 11.0, 12.0], "NVDA": [100.0, 90.0, 110.0]},
+        index=idx,
+    )
+
+
+def test_normalize_rebases_each_column_to_100():
+    out = normalize_to_index(_close_df())
+    # First row is exactly 100 for every column.
+    assert out.iloc[0]["PLTR"] == pytest.approx(100.0)
+    assert out.iloc[0]["NVDA"] == pytest.approx(100.0)
+    # Later rows are value / first * 100.
+    assert out.iloc[1]["PLTR"] == pytest.approx(110.0)  # 11/10*100
+    assert out.iloc[2]["NVDA"] == pytest.approx(110.0)  # 110/100*100
+
+
+def test_normalize_drops_columns_with_unusable_first_value():
+    idx = pd.to_datetime(["2026-01-01", "2026-01-02"])
+    df = pd.DataFrame(
+        {"OK": [5.0, 6.0], "ZERO": [0.0, 1.0], "NAN": [float("nan"), 2.0]},
+        index=idx,
+    )
+    out = normalize_to_index(df)
+    assert list(out.columns) == ["OK"]
+
+
+def test_render_writes_a_nonempty_png(tmp_path: Path):
+    out_path = tmp_path / "chart.png"
+    result = render_price_comparison(_close_df(), out_path)
+    assert result == out_path
+    assert out_path.exists()
+    assert out_path.stat().st_size > 0

--- a/bin/chart.sh
+++ b/bin/chart.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+ENV_FILE="$PROJECT_ROOT/.env"
+if [ -f "$ENV_FILE" ]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "$ENV_FILE"
+    set +a
+fi
+
+exec "$PROJECT_ROOT/apps/python/bin/chart.sh" "$@"

--- a/docs/superpowers/plans/2026-06-29-stock-price-chart.md
+++ b/docs/superpowers/plans/2026-06-29-stock-price-chart.md
@@ -268,9 +268,14 @@ Expected: FAIL — `ImportError: cannot import name 'generate_price_comparison'`
 def _extract_close(raw: pd.DataFrame, tickers: list[str]) -> pd.DataFrame:
     """Pull the Close frame out of a yfinance.download() result and keep
     only the requested tickers that are actually present, as columns."""
-    close = raw["Close"]
+    try:
+        close = raw["Close"]
+    except KeyError:
+        return pd.DataFrame(index=raw.index)
     if isinstance(close, pd.Series):
-        close = close.to_frame()
+        # Single-ticker download returns a flat Series; name the column after
+        # the ticker so the downstream present-filter can find it.
+        close = close.to_frame(name=tickers[0])
     present = [t for t in tickers if t in close.columns]
     return close.reindex(columns=present)
 
@@ -283,9 +288,14 @@ def generate_price_comparison(
     """Fetch Close prices via yfinance, render a normalized comparison chart,
     and save it to output_dir/price-comparison-YYYYMMDD.png. Returns the saved
     path. Raises ValueError if no usable ticker data was fetched."""
-    raw = yf.download(tickers, period=period, progress=False)
+    try:
+        raw = yf.download(tickers, period=period, progress=False)
+    except Exception as e:
+        logger.warning("price fetch failed for %s: %s", tickers, e)
+        raise ValueError("no usable ticker data for chart") from e
     close = _extract_close(raw, tickers)
     if normalize_to_index(close).columns.empty:
+        logger.warning("no usable close data for tickers %s", tickers)
         raise ValueError("no usable ticker data for chart")
     out_path = output_dir / f"price-comparison-{datetime.now():%Y%m%d}.png"
     return render_price_comparison(close, out_path)

--- a/docs/superpowers/plans/2026-06-29-stock-price-chart.md
+++ b/docs/superpowers/plans/2026-06-29-stock-price-chart.md
@@ -1,0 +1,326 @@
+# 株価比較チャート生成 Implementation Plan (#14 MVP)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 複数銘柄の3ヶ月終値を始点=100 に正規化した比較チャート (PNG) を生成し `apps/python/output/charts/` に保存する関数群を提供する。
+
+**Architecture:** 新パッケージ `apps/python/src/charts/`。yfinance 依存のオーケストレーション層 (`generate_price_comparison`) と、ネットワーク非依存の純関数/描画層 (`normalize_to_index`, `render_price_comparison`) を分離。matplotlib は Agg バックエンドで使用。
+
+**Tech Stack:** Python / matplotlib (Agg) / pandas / yfinance / pytest。
+
+## Global Constraints
+
+- コード内コメント・docstring は **英語** で統一（チャット応答は日本語）。
+- `apps/python/requirements.txt` は自動生成。**`requirements.in` のみ編集**し
+  `uv pip compile requirements.in -o requirements.txt` で再生成する。
+- すべてのコマンドは `apps/python/` から実行。テストランナーは `.venv/bin/pytest`。
+- テストは **ネットワーク非依存**（yfinance は monkeypatch でスタブ）。
+- matplotlib は `pyplot` を import する前に `matplotlib.use("Agg")` を呼ぶ。
+- テストは既存パターンに合わせ `from src.charts.price_comparison import ...` でインポート。
+
+---
+
+### Task 1: 依存追加 + 純関数/描画層
+
+**Files:**
+- Modify: `apps/python/requirements.in`
+- Regenerate: `apps/python/requirements.txt`
+- Create: `apps/python/src/charts/__init__.py`
+- Create: `apps/python/src/charts/price_comparison.py`
+- Test: `apps/python/tests/test_charts_price_comparison.py`
+
+**Interfaces:**
+- Produces:
+  - `normalize_to_index(close_df: pd.DataFrame) -> pd.DataFrame` — 各列を先頭行=100 に
+    リベース。先頭値が NaN / 0 の列は除外。
+  - `render_price_comparison(close_df: pd.DataFrame, out_path: Path) -> Path` — 正規化済み
+    でない生の Close DataFrame を受け取り、内部で `normalize_to_index` を適用して
+    折れ線 PNG を `out_path` に保存。親ディレクトリを作成。`out_path` を返す。
+
+- [ ] **Step 1: Add matplotlib to requirements.in and recompile**
+
+`apps/python/requirements.in` の `yfinance` 行の直後に `matplotlib` を追加する。
+編集後の先頭付近:
+
+```
+requests
+yfinance
+matplotlib
+python-dotenv
+```
+
+その後、依存を再コンパイルして同期する:
+
+```bash
+cd apps/python
+uv pip compile requirements.in -o requirements.txt
+uv pip sync requirements.txt
+```
+
+確認: `.venv/bin/python -c "import matplotlib; print(matplotlib.__version__)"` がバージョンを表示する。
+
+- [ ] **Step 2: Write the failing tests (pure + render layer)**
+
+`apps/python/tests/test_charts_price_comparison.py` を新規作成:
+
+```python
+import math
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from src.charts.price_comparison import (
+    normalize_to_index,
+    render_price_comparison,
+)
+
+
+def _close_df() -> pd.DataFrame:
+    # index = dates, columns = tickers
+    idx = pd.to_datetime(["2026-01-01", "2026-01-02", "2026-01-03"])
+    return pd.DataFrame(
+        {"PLTR": [10.0, 11.0, 12.0], "NVDA": [100.0, 90.0, 110.0]},
+        index=idx,
+    )
+
+
+def test_normalize_rebases_each_column_to_100():
+    out = normalize_to_index(_close_df())
+    # First row is exactly 100 for every column.
+    assert out.iloc[0]["PLTR"] == pytest.approx(100.0)
+    assert out.iloc[0]["NVDA"] == pytest.approx(100.0)
+    # Later rows are value / first * 100.
+    assert out.iloc[1]["PLTR"] == pytest.approx(110.0)  # 11/10*100
+    assert out.iloc[2]["NVDA"] == pytest.approx(110.0)  # 110/100*100
+
+
+def test_normalize_drops_columns_with_unusable_first_value():
+    idx = pd.to_datetime(["2026-01-01", "2026-01-02"])
+    df = pd.DataFrame(
+        {"OK": [5.0, 6.0], "ZERO": [0.0, 1.0], "NAN": [float("nan"), 2.0]},
+        index=idx,
+    )
+    out = normalize_to_index(df)
+    assert list(out.columns) == ["OK"]
+
+
+def test_render_writes_a_nonempty_png(tmp_path: Path):
+    out_path = tmp_path / "chart.png"
+    result = render_price_comparison(_close_df(), out_path)
+    assert result == out_path
+    assert out_path.exists()
+    assert out_path.stat().st_size > 0
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `cd apps/python && .venv/bin/pytest tests/test_charts_price_comparison.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'src.charts'` (import error collecting the file).
+
+- [ ] **Step 4: Create the package and implement the pure/render layer**
+
+`apps/python/src/charts/__init__.py` を空ファイルで作成。
+
+`apps/python/src/charts/price_comparison.py`:
+
+```python
+"""Generate a normalized multi-ticker price comparison chart (#14 MVP)."""
+from datetime import datetime
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless backend; must precede pyplot import
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pandas as pd  # noqa: E402
+import yfinance as yf  # noqa: E402
+
+from src.logger import get_logger  # noqa: E402
+
+logger = get_logger(__name__)
+
+
+def normalize_to_index(close_df: pd.DataFrame) -> pd.DataFrame:
+    """Rebase each column to 100 at the first row so differently-priced
+    tickers share one comparable axis. Columns whose first value is NaN or
+    zero cannot be rebased and are dropped."""
+    out = {}
+    for col in close_df.columns:
+        first = close_df[col].iloc[0]
+        if pd.isna(first) or first == 0:
+            continue
+        out[col] = close_df[col] / first * 100
+    return pd.DataFrame(out, index=close_df.index)
+
+
+def render_price_comparison(close_df: pd.DataFrame, out_path: Path) -> Path:
+    """Normalize the raw Close DataFrame (index = dates, columns = tickers),
+    render a multi-line comparison chart, and save it as PNG to out_path.
+    Creates the parent directory if needed. Returns out_path."""
+    normalized = normalize_to_index(close_df)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig, ax = plt.subplots(figsize=(10, 6))
+    for col in normalized.columns:
+        ax.plot(normalized.index, normalized[col], label=col)
+    ax.set_title("Price comparison (normalized to 100)")
+    ax.set_xlabel("Date")
+    ax.set_ylabel("Indexed price (start = 100)")
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+    fig.savefig(out_path, dpi=120, bbox_inches="tight")
+    plt.close(fig)
+    return out_path
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd apps/python && .venv/bin/pytest tests/test_charts_price_comparison.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/nakagawakazusa/work/ai-agent
+git add apps/python/requirements.in apps/python/requirements.txt apps/python/src/charts/__init__.py apps/python/src/charts/price_comparison.py apps/python/tests/test_charts_price_comparison.py
+git commit -m "feat(charts): add price normalization and chart rendering (#14)"
+```
+
+---
+
+### Task 2: yfinance オーケストレーション層
+
+**Files:**
+- Modify: `apps/python/src/charts/price_comparison.py`
+- Test: `apps/python/tests/test_charts_price_comparison.py`
+
+**Interfaces:**
+- Consumes: `render_price_comparison(close_df, out_path) -> Path` (Task 1)。
+- Produces:
+  - `generate_price_comparison(tickers: list[str], output_dir: Path, period: str = "3mo") -> Path`
+    — yfinance で Close を取得し、`output_dir/price-comparison-YYYYMMDD.png` に保存して
+    Path を返す。使用可能なデータが無ければ `ValueError` を送出。
+
+- [ ] **Step 1: Write the failing tests (orchestration)**
+
+`apps/python/tests/test_charts_price_comparison.py` の import に
+`generate_price_comparison` を追加し、末尾に以下を追記する。yfinance の
+multi-ticker 出力を模した MultiIndex 列 DataFrame をスタブで返す。
+
+```python
+from datetime import datetime
+
+from src.charts import price_comparison as pc_module
+from src.charts.price_comparison import generate_price_comparison
+
+
+def _yf_multiindex(tickers, with_data=True):
+    """Mimic yfinance.download() output: columns are a MultiIndex
+    (field, ticker) including a top-level 'Close'."""
+    idx = pd.to_datetime(["2026-01-01", "2026-01-02", "2026-01-03"])
+    cols = pd.MultiIndex.from_product([["Close", "Open"], tickers])
+    if with_data:
+        data = {
+            ("Close", tickers[0]): [10.0, 11.0, 12.0],
+            ("Close", tickers[1]): [100.0, 90.0, 110.0],
+            ("Open", tickers[0]): [9.0, 10.0, 11.0],
+            ("Open", tickers[1]): [99.0, 89.0, 109.0],
+        }
+    else:
+        nan = [float("nan")] * 3
+        data = {(f, t): nan for f in ["Close", "Open"] for t in tickers}
+    return pd.DataFrame(data, index=idx, columns=cols)
+
+
+def test_generate_writes_dated_png(tmp_path, monkeypatch):
+    tickers = ["PLTR", "NVDA"]
+    monkeypatch.setattr(
+        pc_module.yf, "download",
+        lambda *a, **k: _yf_multiindex(tickers),
+    )
+    out = generate_price_comparison(tickers, tmp_path)
+    expected = tmp_path / f"price-comparison-{datetime.now():%Y%m%d}.png"
+    assert out == expected
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_generate_raises_when_no_usable_data(tmp_path, monkeypatch):
+    tickers = ["PLTR", "NVDA"]
+    monkeypatch.setattr(
+        pc_module.yf, "download",
+        lambda *a, **k: _yf_multiindex(tickers, with_data=False),
+    )
+    with pytest.raises(ValueError):
+        generate_price_comparison(tickers, tmp_path)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd apps/python && .venv/bin/pytest tests/test_charts_price_comparison.py -k generate -v`
+Expected: FAIL — `ImportError: cannot import name 'generate_price_comparison'`.
+
+- [ ] **Step 3: Implement generate_price_comparison**
+
+`apps/python/src/charts/price_comparison.py` の `render_price_comparison` の後に追記:
+
+```python
+def _extract_close(raw: pd.DataFrame, tickers: list[str]) -> pd.DataFrame:
+    """Pull the Close frame out of a yfinance.download() result and keep
+    only the requested tickers that are actually present, as columns."""
+    close = raw["Close"]
+    if isinstance(close, pd.Series):
+        close = close.to_frame()
+    present = [t for t in tickers if t in close.columns]
+    return close.reindex(columns=present)
+
+
+def generate_price_comparison(
+    tickers: list[str],
+    output_dir: Path,
+    period: str = "3mo",
+) -> Path:
+    """Fetch Close prices via yfinance, render a normalized comparison chart,
+    and save it to output_dir/price-comparison-YYYYMMDD.png. Returns the saved
+    path. Raises ValueError if no usable ticker data was fetched."""
+    raw = yf.download(tickers, period=period, progress=False)
+    close = _extract_close(raw, tickers)
+    if normalize_to_index(close).columns.empty:
+        raise ValueError("no usable ticker data for chart")
+    out_path = output_dir / f"price-comparison-{datetime.now():%Y%m%d}.png"
+    return render_price_comparison(close, out_path)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd apps/python && .venv/bin/pytest tests/test_charts_price_comparison.py -v`
+Expected: PASS (5 tests total).
+
+- [ ] **Step 5: Run the full Python suite (no regressions)**
+
+Run: `cd apps/python && .venv/bin/pytest -q`
+Expected: all tests pass (no collection errors from the new package/import).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/nakagawakazusa/work/ai-agent
+git add apps/python/src/charts/price_comparison.py apps/python/tests/test_charts_price_comparison.py
+git commit -m "feat(charts): add yfinance-backed generate_price_comparison (#14)"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** パッケージ `src/charts/`（Task 1）/ matplotlib 追加+再コンパイル
+  （Task 1 Step1）/ Agg バックエンド（Task 1 実装）/ `normalize_to_index`（Task 1）/
+  `render_price_comparison`（Task 1）/ `generate_price_comparison`（Task 2）/ 始点=100
+  正規化・先頭 NaN/0 除外（Task 1 テスト）/ 単一→複数銘柄の列正規化 `_extract_close`
+  （Task 2）/ 日付ファイル名（Task 2）/ ValueError（Task 2 テスト）/ ネットワーク非依存
+  （全テスト monkeypatch/スタブ）。全カバー。
+- **Placeholder scan:** プレースホルダなし。各ステップに実コード・実コマンド記載。
+- **Type consistency:** `normalize_to_index(df)->df`、`render_price_comparison(df, Path)->Path`、
+  `generate_price_comparison(list, Path, str)->Path`、`_extract_close(df, list)->df` は
+  Task 1/2 の定義と呼び出しで一致。`pc_module.yf.download` の monkeypatch 先は実装の
+  `yf` import と一致。

--- a/docs/superpowers/specs/2026-06-29-stock-price-chart-design.md
+++ b/docs/superpowers/specs/2026-06-29-stock-price-chart-design.md
@@ -111,7 +111,7 @@ def generate_price_comparison(
 
 - 1 本/銘柄の折れ線。凡例に ticker 名。
 - Y 軸: 正規化指数（始点=100）。X 軸: 日付。
-- タイトル: `Price comparison (normalized, last {period})`。
+- タイトル: `Price comparison (normalized to 100)`。
 - グリッド表示。`fig.savefig(out_path, dpi=120, bbox_inches="tight")` 後に
   `plt.close(fig)` で確実に解放（メモリリーク防止）。
 

--- a/docs/superpowers/specs/2026-06-29-stock-price-chart-design.md
+++ b/docs/superpowers/specs/2026-06-29-stock-price-chart-design.md
@@ -1,0 +1,147 @@
+# 株価比較チャート生成 設計書 (MVP)
+
+- 日付: 2026-06-29
+- 対象 Issue: #14 feat: add chart generation for stock and metrics visualization
+
+## 背景
+
+エージェント出力を視覚的に補強するため、Python の可視化ライブラリでチャートを生成
+する。Issue は複数チャート（価格比較・EPS・リターン比較・相関ヒートマップ・メトリクス
+トレンド）と投稿連携（Discord / Notion）を挙げているが、本 PR は Issue が MVP と明記
+する **複数銘柄の価格比較チャートを生成しローカル保存するところまで** に絞る。
+
+## ゴール / 非ゴール
+
+### ゴール
+- 対象銘柄の3ヶ月終値推移を1枚の比較チャート（PNG）として生成し
+  `apps/python/output/charts/` に保存する。
+- 価格スケールの異なる銘柄を同一軸で比較できるよう、始点を 100 に正規化する。
+- yfinance への依存を描画層から分離し、ネットワーク不要で単体テストできる構造にする。
+
+### 非ゴール
+- Discord / Notion への投稿連携（別 PR）。
+- EPS・リターン比較・相関ヒートマップ・メトリクストレンドの各チャート（別 PR）。
+- 既存ブリーフィングパイプラインへの組み込み（本 PR は生成関数の提供まで）。
+
+## アーキテクチャ
+
+新パッケージ `apps/python/src/charts/`:
+
+- `apps/python/src/charts/__init__.py`
+- `apps/python/src/charts/price_comparison.py` — チャート生成のメイン
+
+依存追加: `matplotlib` を `apps/python/requirements.in` に追加し
+`requirements.txt` を再コンパイル（CLAUDE.md のルール: `.in` のみ編集 →
+`uv pip compile`）。
+
+matplotlib は **Agg バックエンド** を使用する（GUI 非依存・ヘッドレス / CI 安全）。
+`price_comparison.py` の import 時に `matplotlib.use("Agg")` を `pyplot` import 前に
+設定する。
+
+## ユニット分割
+
+責務を分離し、ネットワーク非依存でテストできるようにする。
+
+```python
+# src/charts/price_comparison.py
+
+import matplotlib
+matplotlib.use("Agg")  # headless backend; must precede pyplot import
+import matplotlib.pyplot as plt
+import pandas as pd
+import yfinance as yf
+from pathlib import Path
+from datetime import datetime
+from src.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def normalize_to_index(close_df: pd.DataFrame) -> pd.DataFrame:
+    """Rebase each column to 100 at the first row so differently-priced
+    tickers share one comparable axis. Columns whose first value is NaN or
+    zero are dropped (cannot be rebased)."""
+
+
+def render_price_comparison(close_df: pd.DataFrame, out_path: Path) -> Path:
+    """Render a normalized multi-line price comparison chart from a Close
+    DataFrame (index = dates, columns = tickers) and save it as PNG to
+    out_path. Creates the parent directory if needed. Returns out_path."""
+
+
+def generate_price_comparison(
+    tickers: list[str],
+    output_dir: Path,
+    period: str = "3mo",
+) -> Path:
+    """Fetch Close prices via yfinance, normalize, render, and save to
+    output_dir/price-comparison-YYYYMMDD.png. Returns the saved path.
+    Raises ValueError if no usable ticker data was fetched."""
+```
+
+### 各ユニットの責務・インターフェース・依存
+
+- `normalize_to_index(close_df) -> df`: 純関数。始点=100 へ正規化。yfinance/IO に
+  依存しない。先頭値が NaN / 0 の列は除外。
+- `render_price_comparison(close_df, out_path) -> Path`: DataFrame を受け取り PNG を
+  保存。matplotlib (Agg) のみに依存。yfinance に依存しない。
+- `generate_price_comparison(tickers, output_dir, period="3mo") -> Path`:
+  取得 → 正規化 → 描画のオーケストレーション。yfinance に依存。
+
+呼び出し側は `tickers` を明示的に渡す（テスト容易性）。実運用では
+`src.config.CONFIG` の `portfolio.tickers` を渡すことを想定するが、本 PR では関数の
+提供までとし、設定読み込みは呼び出し側の責務とする。
+
+## データフロー
+
+1. 呼び出し側が `tickers`（例: `["PLTR", "NVDA", "CBRS"]`）と `output_dir` を渡す。
+2. `yf.download(tickers, period=period, progress=False)` で取得し `Close` を抽出。
+   - 単一銘柄でも複数銘柄でも `DataFrame`（columns = tickers）に正規化する。
+     yfinance は単一銘柄時に列構造が変わるため、`tickers` で `reindex` して
+     列名を揃える。
+3. `normalize_to_index` で始点=100 に正規化。
+4. `render_price_comparison` で折れ線描画 → PNG 保存。
+5. 保存先 `Path` を返す。
+
+ファイル名は `price-comparison-YYYYMMDD.png`（`datetime.now()` のローカル日付）。
+保存先 `output/charts/` は `mkdir(parents=True, exist_ok=True)` で作成。`output/` は
+既に `.gitignore` 済み。
+
+## チャート仕様
+
+- 1 本/銘柄の折れ線。凡例に ticker 名。
+- Y 軸: 正規化指数（始点=100）。X 軸: 日付。
+- タイトル: `Price comparison (normalized, last {period})`。
+- グリッド表示。`fig.savefig(out_path, dpi=120, bbox_inches="tight")` 後に
+  `plt.close(fig)` で確実に解放（メモリリーク防止）。
+
+## エラーハンドリング
+
+- yfinance 取得失敗・空データ: `logger.warning` でログ。
+- 正規化後に有効列が 0 本（全銘柄が NaN / 取得失敗）: `generate_price_comparison` が
+  `ValueError("no usable ticker data for chart")` を送出し、呼び出し側に委ねる
+  （既存 `fetcher/stocks.py` のエラー文字列方式とは異なり、生成不能は例外とする）。
+- 一部銘柄のみ欠損: 取得できた銘柄だけで描画を続行。
+
+## テスト
+
+`apps/python/tests/test_charts_price_comparison.py`:
+
+1. `normalize_to_index`: 既知の小さな DataFrame（2 銘柄 × 3 日）で、各列の先頭が
+   100.0 になり、以降が `value / first * 100` になることを検証（ネットワーク不要）。
+2. `normalize_to_index`: 先頭値が 0 / NaN の列が除外されることを検証。
+3. `render_price_comparison`: スタブ DataFrame を渡し、`tmp_path` に PNG が生成され
+   ファイルサイズ > 0 であることを確認（matplotlib Agg、ネットワーク不要）。
+4. `generate_price_comparison`: `yfinance.download` を monkeypatch でスタブし、
+   end-to-end でファイルが生成され Path が返ることを確認。
+5. `generate_price_comparison`: スタブが空 / 全 NaN を返すとき `ValueError` が
+   送出されることを確認。
+
+すべてネットワーク非依存（yfinance はテストで monkeypatch）。
+
+## テスト計画
+
+- [ ] `.venv/bin/pytest tests/test_charts_price_comparison.py -v` green
+- [ ] `requirements.txt` が `requirements.in` から再生成され matplotlib を含む
+- [ ] 手動: 実銘柄で `generate_price_comparison` を 1 回実行し PNG を目視確認
+      （動作検証フェーズ）


### PR DESCRIPTION
## Summary
- Issue #14 の MVP: 複数銘柄の3ヶ月終値を始点=100 に正規化した価格比較チャート (PNG) を生成しローカル保存する機能を追加
- 新パッケージ `apps/python/src/charts/`（yfinance 取得・正規化・matplotlib(Agg) 描画を責務分離）
- CLI エントリポイント `python -m src.charts price` と `bin/chart.sh` ラッパーを追加（tickers 省略時は config の `portfolio.tickers`）
- 投稿連携 (Discord / Notion) と他チャート種別は別 PR（非ゴール）

## Changes
- `src/charts/price_comparison.py`: `normalize_to_index`, `render_price_comparison`, `_extract_close`, `generate_price_comparison`
- `src/charts/__main__.py`: `price` サブコマンド（`--tickers` / `--output-dir` / `--period`）
- `bin/chart.sh`, `apps/python/bin/chart.sh`: 既存2段ラッパー方式に準拠
- `requirements.in` に matplotlib 追加 → `requirements.txt` 再生成
- テスト: 価格比較6件 + CLI 2件（すべてネットワーク非依存、yfinance は monkeypatch）

## Test plan
- [x] `.venv/bin/pytest -q`（apps/python）: 674 passed
- [x] `.venv/bin/pytest tests/test_charts_price_comparison.py tests/test_charts_cli.py -v`: 8 passed
- [x] 手動: `./bin/chart.sh price --tickers PLTR NVDA` で PNG 生成・目視確認済み

設計書: `docs/superpowers/specs/2026-06-29-stock-price-chart-design.md`
実装計画: `docs/superpowers/plans/2026-06-29-stock-price-chart.md`

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a stock price comparison chart feature that generates normalized multi-ticker PNG charts and exposes them via a CLI and shell wrappers.

New Features:
- Add charts package with functions to normalize multi-ticker close prices and render comparison charts to PNG files.
- Provide a yfinance-backed generator that fetches recent close prices for given tickers and saves a dated price comparison chart in an output directory.
- Add a CLI entrypoint for chart generation with a `price` subcommand supporting tickers, output directory, and period options, plus top-level `chart.sh` shell wrappers.

Enhancements:
- Ensure chart generation uses a headless matplotlib Agg backend suitable for CI and non-GUI environments.

Build:
- Add matplotlib and its dependencies to the Python requirements to support chart rendering.

Documentation:
- Add design and implementation plan documents describing the stock price comparison chart architecture, behavior, and testing approach.

Tests:
- Add unit tests for price normalization, chart rendering, yfinance orchestration, and the CLI behavior, including error handling and configuration-driven defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new chart command to generate and save stock price comparison charts from the command line.
  * Charts now support multiple tickers and use the app’s configured portfolio tickers when none are provided.
  * Added chart generation output as a dated PNG file in the selected folder.

* **Bug Fixes**
  * Improved chart generation to handle missing or unusable price data more reliably.
  * Ensured chart output directories are created automatically before saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->