### PR TITLE
Align page layout by removing outer border margins

### DIFF
--- a/apps/web/app/(main)/briefing/page.tsx
+++ b/apps/web/app/(main)/briefing/page.tsx
@@ -4,7 +4,7 @@ import { BriefingDashboard } from "@/components/screens/BriefingDashboard"
 
 export default function BriefingPage() {
   return (
-    <div>
+    <div className="flex h-full flex-col gap-4">
       <h1 className="text-lg font-semibold">Briefing</h1>
       <div className="min-h-0 flex-1 overflow-hidden">
         <BriefingDashboard />

--- a/apps/web/app/(main)/briefing/page.tsx
+++ b/apps/web/app/(main)/briefing/page.tsx
@@ -4,7 +4,7 @@ import { BriefingDashboard } from "@/components/screens/BriefingDashboard"
 
 export default function BriefingPage() {
   return (
-    <div className="flex h-full flex-col gap-4 p-6">
+    <div>
       <h1 className="text-lg font-semibold">Briefing</h1>
       <div className="min-h-0 flex-1 overflow-hidden">
         <BriefingDashboard />


### PR DESCRIPTION
…moved

## Summary by Sourcery

Enhancements:
- Simplify the Briefing page root container by removing flex layout, gap, and padding to align its content with the overall page layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Briefing page container styling, removing the previous outer layout classes. The page structure and briefing content remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->