### PR TITLE
feat: self-profile generator (weekly report + profile diff)

### DIFF
--- a/apps/python/src/generator/self_profile.py
+++ b/apps/python/src/generator/self_profile.py
@@ -1,0 +1,81 @@
+"""Generate a weekly self-reflection report and profile diff via the claude CLI."""
+from __future__ import annotations
+
+import json
+import logging
+
+from src.claude_runner import run_claude
+
+logger = logging.getLogger(__name__)
+
+TIMEOUT = 300
+REPORT_MARKER = "## WEEKLY_REPORT"
+DIFF_MARKER = "## PROFILE_DIFF"
+
+
+def _build_prompt(new_entries: list[dict], existing_profile: str | None) -> str:
+    entries_json = json.dumps(new_entries, ensure_ascii=False, indent=2)
+    profile_section = existing_profile or "(no existing profile yet)"
+    return (
+        "You are analyzing a personal judgment-log (rejections/corrections/notes) "
+        "to surface thinking patterns and underlying motivations for a "
+        "self-reflection agent.\n\n"
+        f"New log entries this week:\n{entries_json}\n\n"
+        f"Existing persona profile:\n{profile_section}\n\n"
+        "Do not force conclusions from thin evidence -- it is fine to say there "
+        "is no notable pattern this week.\n\n"
+        "Output exactly two sections, in this order, with no other text:\n"
+        f"{REPORT_MARKER}\n<this week's observations, in Japanese>\n\n"
+        f"{DIFF_MARKER}\n<proposed durable additions/updates to the profile, in "
+        "Japanese; leave empty if nothing durable this week>\n"
+    )
+
+
+def parse_response(raw: str) -> tuple[str, str]:
+    """Split a raw model response into (weekly_report, profile_diff).
+
+    Raises ValueError if either section marker is missing, so the caller can
+    retry with the parse error fed back into the prompt.
+    """
+    if REPORT_MARKER not in raw or DIFF_MARKER not in raw:
+        raise ValueError("response missing required section markers")
+    report_part, _, diff_part = raw.partition(DIFF_MARKER)
+    report = report_part.split(REPORT_MARKER, 1)[1].strip()
+    diff = diff_part.strip()
+    return report, diff
+
+
+def generate_self_profile_update(
+    new_entries: list[dict],
+    existing_profile: str | None = None,
+    max_retries: int = 2,
+) -> tuple[str, str] | None:
+    """Return (weekly_report, profile_diff), or None when there are no new entries.
+
+    Skipping empty weeks avoids generating a hollow "nothing happened" report
+    every time the judgment log hasn't grown.
+    """
+    if not new_entries:
+        return None
+
+    prompt = _build_prompt(new_entries, existing_profile)
+    last_error: Exception | None = None
+    for attempt in range(1, max_retries + 1):
+        raw = run_claude(prompt, "self-agent profile update", timeout=TIMEOUT)
+        try:
+            return parse_response(raw)
+        except ValueError as exc:
+            last_error = exc
+            logger.warning(
+                "self-profile attempt %d/%d failed: %s", attempt, max_retries, exc
+            )
+            prompt = (
+                _build_prompt(new_entries, existing_profile)
+                + f"\n\nYour previous output was invalid: {exc}\n"
+                "Return the two sections exactly as specified."
+            )
+            continue
+
+    raise ValueError(
+        f"failed to parse self-profile response after {max_retries} attempts: {last_error}"
+    )

--- a/apps/python/src/generator/self_profile.py
+++ b/apps/python/src/generator/self_profile.py
@@ -37,11 +37,12 @@ def parse_response(raw: str) -> tuple[str, str]:
     Raises ValueError if either section marker is missing, so the caller can
     retry with the parse error fed back into the prompt.
     """
-    if REPORT_MARKER not in raw or DIFF_MARKER not in raw:
-        raise ValueError("response missing required section markers")
-    report_part, _, diff_part = raw.partition(DIFF_MARKER)
-    report = report_part.split(REPORT_MARKER, 1)[1].strip()
-    diff = diff_part.strip()
+    report_idx = raw.find(REPORT_MARKER)
+    diff_idx = raw.find(DIFF_MARKER)
+    if report_idx == -1 or diff_idx == -1 or diff_idx < report_idx:
+        raise ValueError("response missing required section markers in the expected order")
+    report = raw[report_idx + len(REPORT_MARKER) : diff_idx].strip()
+    diff = raw[diff_idx + len(DIFF_MARKER) :].strip()
     return report, diff
 
 
@@ -55,6 +56,8 @@ def generate_self_profile_update(
     Skipping empty weeks avoids generating a hollow "nothing happened" report
     every time the judgment log hasn't grown.
     """
+    if max_retries < 1:
+        raise ValueError(f"max_retries must be >= 1 (got {max_retries})")
     if not new_entries:
         return None
 

--- a/apps/python/tests/generator/test_self_profile.py
+++ b/apps/python/tests/generator/test_self_profile.py
@@ -1,0 +1,60 @@
+from unittest.mock import patch
+
+import pytest
+
+from src.generator.self_profile import (
+    DIFF_MARKER,
+    REPORT_MARKER,
+    generate_self_profile_update,
+    parse_response,
+)
+
+
+def _valid_response(report="今週の気づき", diff="恒常的な傾向"):
+    return f"{REPORT_MARKER}\n{report}\n\n{DIFF_MARKER}\n{diff}\n"
+
+
+def test_parse_response_splits_sections():
+    report, diff = parse_response(_valid_response("report text", "diff text"))
+    assert report == "report text"
+    assert diff == "diff text"
+
+
+def test_parse_response_raises_on_missing_markers():
+    with pytest.raises(ValueError):
+        parse_response("no markers here")
+
+
+def test_generate_self_profile_update_returns_none_for_no_new_entries():
+    with patch("src.generator.self_profile.run_claude") as mock_run:
+        result = generate_self_profile_update([], existing_profile="existing")
+    assert result is None
+    mock_run.assert_not_called()
+
+
+def test_generate_self_profile_update_calls_run_claude_and_parses():
+    with patch(
+        "src.generator.self_profile.run_claude", return_value=_valid_response()
+    ) as mock_run:
+        result = generate_self_profile_update([{"id": "j_1"}], existing_profile=None)
+    assert result == ("今週の気づき", "恒常的な傾向")
+    mock_run.assert_called_once()
+
+
+def test_generate_self_profile_update_retries_then_succeeds():
+    with patch(
+        "src.generator.self_profile.run_claude",
+        side_effect=["garbage", _valid_response()],
+    ) as mock_run:
+        result = generate_self_profile_update([{"id": "j_1"}])
+    assert result == ("今週の気づき", "恒常的な傾向")
+    assert mock_run.call_count == 2
+
+
+def test_generate_self_profile_update_raises_after_max_retries():
+    with patch(
+        "src.generator.self_profile.run_claude", return_value="garbage"
+    ) as mock_run:
+        with pytest.raises(ValueError):
+            generate_self_profile_update([{"id": "j_1"}], max_retries=2)
+    assert mock_run.call_count == 2

--- a/apps/python/tests/generator/test_self_profile.py
+++ b/apps/python/tests/generator/test_self_profile.py
@@ -25,6 +25,12 @@ def test_parse_response_raises_on_missing_markers():
         parse_response("no markers here")
 
 
+def test_parse_response_raises_when_markers_are_out_of_order():
+    reversed_response = f"{DIFF_MARKER}\ndiff text\n\n{REPORT_MARKER}\nreport text\n"
+    with pytest.raises(ValueError):
+        parse_response(reversed_response)
+
+
 def test_generate_self_profile_update_returns_none_for_no_new_entries():
     with patch("src.generator.self_profile.run_claude") as mock_run:
         result = generate_self_profile_update([], existing_profile="existing")
@@ -49,6 +55,8 @@ def test_generate_self_profile_update_retries_then_succeeds():
         result = generate_self_profile_update([{"id": "j_1"}])
     assert result == ("今週の気づき", "恒常的な傾向")
     assert mock_run.call_count == 2
+    retry_prompt = mock_run.call_args_list[1][0][0]
+    assert "Your previous output was invalid" in retry_prompt
 
 
 def test_generate_self_profile_update_raises_after_max_retries():
@@ -58,3 +66,10 @@ def test_generate_self_profile_update_raises_after_max_retries():
         with pytest.raises(ValueError):
             generate_self_profile_update([{"id": "j_1"}], max_retries=2)
     assert mock_run.call_count == 2
+
+
+def test_generate_self_profile_update_rejects_max_retries_below_one():
+    with patch("src.generator.self_profile.run_claude") as mock_run:
+        with pytest.raises(ValueError):
+            generate_self_profile_update([{"id": "j_1"}], max_retries=0)
+    mock_run.assert_not_called()

--- a/docs/superpowers/specs/2026-07-01-self-agent-design.md
+++ b/docs/superpowers/specs/2026-07-01-self-agent-design.md
@@ -10,7 +10,7 @@
 
 ## アーキテクチャ
 
-```
+```bash
 apps/python/bin/self_agent.py → apps/python/src/self_agent_handler.py
   ├── src/fetcher/judgment_log.py      # judgments.jsonl を読み込み、前回watermark以降の新規ログを抽出
   ├── src/generator/self_profile.py    # プロンプト構築 → run_claude() → 週次気づき生成 → プロファイル差分抽出
@@ -28,9 +28,11 @@ apps/python/output/
 
 - `${JUDGMENT_LOOP_DIR:-~/.local/share/judgment-loop}/judgments.jsonl`(read-only。書き込みは行わない。dotfiles-claude側の`judgment-distill`スキルが別途rules.jsonlへ書き込むが、self-agentはそれと独立)
 - 既存の`self_agent_profile.md`(前回までの蓄積プロファイル。初回はなし)
+- **初回シード**: Claude Codeのプロジェクト別メモリとして既に存在する人格メモリファイル(`auto-agent-llm`リポジトリの`worldview-3d` POCが参照しているもの。会話ログ+リポジトリ観測から抽出済み)。実際のファイルパスは`.claude/projects/`配下にユーザー名・リポジトリパスを含む個人環境依存の絶対パスになるため、本書には記載しない。初回セットアップ時に手元で`self_agent_profile.md`の初期値としてコピーするのみで、以降の自動処理では再読み込みしない(手動更新分の反映が必要な場合はセットアップ時の再コピーで対応)
 
 ## データフロー
 
+0. **(初回セットアップのみ)** `kazusa-thinking-patterns.md`を`config/self_agent_profile.md`にコピーして初期値とする。以降のステップでは触れない
 1. `judgments.jsonl`を読み込み、`.self-agent-watermark`ファイル(`$JUDGMENT_LOOP_DIR`配下)以降の新規ログのみ抽出
 2. 新規ログ0件なら何もせず終了(ログなし週はスキップ)
 3. 新規ログ + 既存`self_agent_profile.md`(あれば)をプロンプトに渡し、`run_claude()`で以下2種を生成:
@@ -65,4 +67,5 @@ apps/python/output/
 
 - Discord配信
 - judgment-distillのルール抽出ロジックへの変更
-- judgments.jsonl以外のデータソース(Claude Code会話ログ全体、手動テキスト等)の取り込み — 将来の拡張候補として保留
+- judgments.jsonl以外のデータソース(Claude Code会話ログ全体、手動テキスト等)の継続的な取り込み — 将来の拡張候補として保留(初回シードとなる人格メモリファイルは対象外)
+- `worldview-3d`(auto-agent-llmリポジトリ)との連携・データ形式の統合 — 将来の拡張候補として保留

--- a/docs/superpowers/specs/2026-07-01-self-agent-design.md
+++ b/docs/superpowers/specs/2026-07-01-self-agent-design.md
@@ -1,0 +1,68 @@
+# 自分専用エージェント「self-agent」— 設計書
+
+- 日付: 2026-07-01
+- 対象: judgment-loop のログを材料に、思考パターン・根底の欲求を言語化し、Notionへ週次配信しつつ人格プロファイルを蓄積するエージェント
+
+## 背景・動機
+
+普段のやりとり(judgment-loopのログ: 拒否/修正/確認の記録)から、自分がどんな思考で何を作っているか、なぜそれを作っているか、市場価値を上げたい・人の役に立ちたいといった根底の欲求を言語化・整理したい。
+本リポジトリには `run_claude()` とfetcher/generator/notifierの3層アーキテクチャ(`briefing`)が既にあるため、同じ型で構築する。
+
+## アーキテクチャ
+
+```
+apps/python/bin/self_agent.py → apps/python/src/self_agent_handler.py
+  ├── src/fetcher/judgment_log.py      # judgments.jsonl を読み込み、前回watermark以降の新規ログを抽出
+  ├── src/generator/self_profile.py    # プロンプト構築 → run_claude() → 週次気づき生成 → プロファイル差分抽出
+  └── src/notifier/notion.py           # 既存Notifierを流用してNotionページへ配信
+config/
+  self_agent_profile.md          # 蓄積される人格プロファイル(gitignore対象)
+  self_agent_profile.md.example  # スキーマ・記載例(トラッキング対象)
+apps/python/output/
+  self_agent_report_<ts>.md      # 週次レポートのローカル控え(既存output/慣習に合わせる)
+```
+
+責務分離: `briefing`と同型。fetcherはjudgments.jsonlの読み込みのみ、generatorはプロンプト構築とrun_claude呼び出し、notifierはNotion配信のみを担う。
+
+## データソース
+
+- `${JUDGMENT_LOOP_DIR:-~/.local/share/judgment-loop}/judgments.jsonl`(read-only。書き込みは行わない。dotfiles-claude側の`judgment-distill`スキルが別途rules.jsonlへ書き込むが、self-agentはそれと独立)
+- 既存の`self_agent_profile.md`(前回までの蓄積プロファイル。初回はなし)
+
+## データフロー
+
+1. `judgments.jsonl`を読み込み、`.self-agent-watermark`ファイル(`$JUDGMENT_LOOP_DIR`配下)以降の新規ログのみ抽出
+2. 新規ログ0件なら何もせず終了(ログなし週はスキップ)
+3. 新規ログ + 既存`self_agent_profile.md`(あれば)をプロンプトに渡し、`run_claude()`で以下2種を生成:
+   - **週次レポート**: 今週のログから読み取れる思考パターン・関心・欲求の言語化(一時的な気づき含む)
+   - **プロファイル差分**: 恒常的な傾向と判断できるものだけを`self_agent_profile.md`に追記・更新する提案
+4. 週次レポートは`output/self_agent_report_<ts>.md`に保存しつつ、Notionページに追記
+5. プロファイル差分は`self_agent_profile.md`に反映
+6. watermarkを最新処理済みログidに更新
+
+## 設計上の決定事項
+
+- **プロファイルファイルはgitignore**: `config/briefing.json`と同様の扱い(個人の思考・欲求という機微情報)。`.example`にはダミーのスキーマのみ残す
+- **量が少ない前提の運用**: 現状`judgments.jsonl`は4件のみ。無理に一般化せず、材料が薄い週は「気づきなし」と正直に出す(過学習・こじつけの禁止)
+- **judgment-distillとは独立**: dotfiles-claude側の`judgment-distill`(ログ→ルール抽出)とは目的が異なる別ツール。データソースを共有するが書き込み先・出力先は分離
+- **Discordは対象外**: Notionのみに配信
+- **新規ログ0件はスキップ**: 空のレポートを毎週生成しない
+
+## エラーハンドリング
+
+- `judgments.jsonl`が存在しない/空 → 新規ログ0件として正常終了(エラーにしない)
+- `run_claude`由来の例外(CLI不在・タイムアウト等)はそのまま伝播
+- Notion配信失敗 → ローカルの`output/self_agent_report_<ts>.md`は既に書き出し済みなので、レポート自体は失われない。エラーはログに残す
+
+## テスト
+
+- fetcherの新規ログ抽出(watermark境界)のユニットテスト
+- `run_claude`をモックし、「レポート生成 → プロファイル差分反映」の制御フローを検証(実コールはしない)
+- watermark更新ロジックのユニットテスト
+- 実コール1回の疎通確認は手動で別途実施(`feedback_model_selection_verification`方針)
+
+## 非スコープ
+
+- Discord配信
+- judgment-distillのルール抽出ロジックへの変更
+- judgments.jsonl以外のデータソース(Claude Code会話ログ全体、手動テキスト等)の取り込み — 将来の拡張候補として保留


### PR DESCRIPTION
## Summary
- Add `src/generator/self_profile.py`: builds a prompt from new judgment-log entries + existing profile, calls `run_claude()`, and parses a two-section response (weekly report / profile diff) with retry-on-parse-failure (max 2 attempts, matching the wordset generator's pattern).
- No new entries -> returns `None` without calling `run_claude`, avoiding hollow "nothing happened" reports.

Closes #339

## Test plan
- [x] `pytest apps/python/tests/generator/test_self_profile.py -v` — 6 passed

## Summary by Sourcery

Introduce a generator for weekly self-reflection reports and profile diffs powered by Claude and document the self-agent design.

New Features:
- Add self-profile generator that builds prompts from new judgment-log entries and existing persona profile to produce a weekly report and profile diff.
- Return no report when there are no new judgment-log entries to avoid generating empty weekly outputs.

Documentation:
- Add a design spec for the self-agent, detailing architecture, data sources, data flow, and error handling.

Tests:
- Add unit tests for self-profile response parsing, empty-week behavior, Claude invocation and retry logic, and failure after exhausting retries.