### PR TITLE
feat: derive Notion tags from source judgment-log entries

### DIFF
--- a/apps/python/src/self_agent_handler.py
+++ b/apps/python/src/self_agent_handler.py
@@ -42,6 +42,19 @@ def _apply_profile_diff(diff: str, path: pathlib.Path) -> None:
         f.write("\n\n" + diff + "\n")
 
 
+def _collect_tags(entries: list[dict]) -> list[str]:
+    """Aggregate the unique judgment-log tags covered by this run's entries.
+
+    Tags come straight from the source log (`judge --tags`), not from the
+    LLM: the log entries already carry accurate, human-assigned tags, so
+    reusing them is more reliable than asking the model to invent new ones.
+    """
+    tags: set[str] = set()
+    for entry in entries:
+        tags.update(entry.get("tags") or [])
+    return sorted(tags)
+
+
 def run(
     profile_path: pathlib.Path = PROFILE_PATH,
     output_dir: pathlib.Path = OUTPUT_DIR,
@@ -68,6 +81,7 @@ def run(
                 CONFIG.notion_api_key,
                 CONFIG.notion_database_id,
                 title="Self-Agent Weekly Report",
+                tags=_collect_tags(new_entries),
             )
         except Exception as exc:
             logger.warning(

--- a/apps/python/tests/test_self_agent_handler.py
+++ b/apps/python/tests/test_self_agent_handler.py
@@ -26,7 +26,10 @@ def test_run_skips_when_no_new_entries(tmp_path):
 def test_run_writes_report_and_delivers_to_notion(tmp_path):
     profile_path = tmp_path / "profile.md"
     output_dir = tmp_path / "out"
-    entries = [{"id": "j_1"}, {"id": "j_2"}]
+    entries = [
+        {"id": "j_1", "tags": ["verification", "external-cli"]},
+        {"id": "j_2", "tags": ["model-selection", "verification"]},
+    ]
 
     with patch.object(self_agent_handler, "fetch_new_entries", return_value=entries), \
          patch.object(self_agent_handler, "generate_self_profile_update", return_value=("report body", "diff body")), \
@@ -41,6 +44,11 @@ def test_run_writes_report_and_delivers_to_notion(tmp_path):
     assert report_path.read_text(encoding="utf-8") == "report body"
     assert profile_path.read_text(encoding="utf-8") == "\n\ndiff body\n"
     mock_notion.assert_called_once()
+    assert mock_notion.call_args.kwargs["tags"] == [
+        "external-cli",
+        "model-selection",
+        "verification",
+    ]
     mock_write_wm.assert_called_once_with("j_2")
 
 
@@ -84,3 +92,12 @@ def test_apply_profile_diff_noop_on_empty_diff(tmp_path):
     profile_path = tmp_path / "profile.md"
     self_agent_handler._apply_profile_diff("", profile_path)
     assert not profile_path.exists()
+
+
+def test_collect_tags_dedupes_and_sorts_across_entries():
+    entries = [
+        {"id": "j_1", "tags": ["security", "docs"]},
+        {"id": "j_2", "tags": ["docs"]},
+        {"id": "j_3"},  # no tags field
+    ]
+    assert self_agent_handler._collect_tags(entries) == ["docs", "security"]

--- a/bin/self_agent.sh
+++ b/bin/self_agent.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+ENV_FILE="$PROJECT_ROOT/.env"
+if [ -f "$ENV_FILE" ]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "$ENV_FILE"
+    set +a
+fi
+
+exec "$PROJECT_ROOT/apps/python/bin/self_agent.sh" "$@"


### PR DESCRIPTION
## Summary
- Self-agent's Notion delivery previously omitted the `Tags` property. Instead of asking the LLM to invent tags, aggregate the unique `tags` already present on each new judgment-log entry (`judge --tags`) and pass them to `send_to_notion(tags=...)`.
- More reliable than model-generated tags since the log entries already carry accurate, human-assigned tags.

## Test plan
- [x] `pytest apps/python/tests/test_self_agent_handler.py -v` — 6 passed
- [x] `pytest -q` (full suite) — 723 passed
- [x] Verified manually against the report from today's real `bin/self_agent.sh` run

## Summary by Sourcery

Aggregate judgment-log tags for self-agent runs and include them when delivering reports to Notion.

Enhancements:
- Add helper to collect and de-duplicate tags from judgment-log entries before sending to Notion.

Tests:
- Extend self-agent handler tests to verify Notion receives aggregated tags and that tag collection deduplicates and sorts across entries.