### PR TITLE
feat: add Journal ↔ Notion sync with best-effort append

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ CLAUDE_MODEL=
 DISCORD_TOKEN=your_discord_bot_token_here
 NOTION_API_KEY=your_notion_integration_token_here
 NOTION_DATABASE_ID=your_notion_database_id_here
+# Journal ↔ Notion sync (docs/superpowers/specs/2026-07-03-journal-notion-sync-design.md).
+# Separate database from NOTION_DATABASE_ID above.
+NOTION_DATABASE_ID_JOURNAL=your_notion_journal_database_id_here
 
 # Briefing archive (bin/archive.sh, POST /api/archive). See docs/briefing-archive.md.
 # rclone remote name (default: gdrive) and remote path (default: ai-agent/briefing).

--- a/apps/python/src/config.py
+++ b/apps/python/src/config.py
@@ -122,6 +122,18 @@ def load_config() -> BriefingConfig:
         ) from e
 
 
+def get_journal_notion_credentials() -> tuple[str, str]:
+    """Return (api_key, database_id) for Journal <-> Notion sync.
+
+    Unlike CONFIG, this reads credentials directly and does not require
+    briefing.json to exist — Journal sync is independent of the briefing batch.
+    """
+    return (
+        get_credential("NOTION_API_KEY") or "",
+        get_credential("NOTION_DATABASE_ID_JOURNAL") or "",
+    )
+
+
 _CONFIG_CACHE: BriefingConfig | None = None
 
 

--- a/apps/python/src/credentials.py
+++ b/apps/python/src/credentials.py
@@ -19,6 +19,7 @@ ALLOWED_KEYS: tuple[str, ...] = (
     "CHANNEL_ID",
     "NOTION_API_KEY",
     "NOTION_DATABASE_ID",
+    "NOTION_DATABASE_ID_JOURNAL",
     "ANTHROPIC_API_KEY",
 )
 

--- a/apps/python/src/journal_store.py
+++ b/apps/python/src/journal_store.py
@@ -59,30 +59,57 @@ def _item_path(entry_id: str) -> Path:
     return JOURNAL_DIR / f"{entry_id}.json"
 
 
-def save_item(entry_id: str, item: str) -> None:
-    """Persist a short item label (≤20 chars) alongside the entry markdown."""
+def _read_sidecar(path: Path) -> dict:
     import json
 
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def _merge_sidecar(entry_id: str, updates: dict) -> None:
+    """Merge ``updates`` into the entry's JSON sidecar, preserving other keys.
+
+    ``item`` (short label) and ``notion_page_id`` (Notion sync) share this same
+    file, so a write from one must not clobber a value written by the other.
+    """
+    import json
+
+    path = _item_path(entry_id)
+    data = _read_sidecar(path)
+    data.update(updates)
+    path.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+
+
+def save_item(entry_id: str, item: str) -> None:
+    """Persist a short item label (≤20 chars) alongside the entry markdown."""
     if not _ENTRY_RE.match(entry_id):
         raise ValueError(f"Invalid journal entry id: {entry_id!r}")
-    _item_path(entry_id).write_text(
-        json.dumps({"item": item[:20]}, ensure_ascii=False), encoding="utf-8"
-    )
+    _merge_sidecar(entry_id, {"item": item[:20]})
 
 
 def get_item(entry_id: str) -> str:
     """Return the stored item label for an active entry, or empty string if absent."""
-    import json
-
     if not _ENTRY_RE.match(entry_id):
         return ""
-    p = _item_path(entry_id)
-    if not p.exists():
+    return _read_sidecar(_item_path(entry_id)).get("item", "")
+
+
+def save_notion_meta(entry_id: str, page_id: str) -> None:
+    """Persist the Notion page id created for this entry, alongside the sidecar."""
+    if not _ENTRY_RE.match(entry_id):
+        raise ValueError(f"Invalid journal entry id: {entry_id!r}")
+    _merge_sidecar(entry_id, {"notion_page_id": page_id})
+
+
+def get_notion_meta(entry_id: str) -> str:
+    """Return the entry's synced Notion page id, or empty string if not yet synced."""
+    if not _ENTRY_RE.match(entry_id):
         return ""
-    try:
-        return json.loads(p.read_text(encoding="utf-8")).get("item", "")
-    except Exception:
-        return ""
+    return _read_sidecar(_item_path(entry_id)).get("notion_page_id", "")
 
 
 def get_trashed_item(entry_id: str) -> str:

--- a/apps/python/src/journal_store.py
+++ b/apps/python/src/journal_store.py
@@ -14,10 +14,19 @@ old files are picked up on read, new entries use the per-entry naming.
 notes are never committed (matches the briefing output convention).
 """
 import re
+import threading
 from datetime import datetime
 from pathlib import Path
 
+from src.logger import get_logger
+
+logger = get_logger(__name__)
+
 JOURNAL_DIR = Path(__file__).parents[1] / "output" / "journal"
+
+# Serializes sidecar read-modify-write so concurrent save_item/save_notion_meta
+# calls for the same entry can't clobber each other's update.
+_SIDECAR_LOCK = threading.Lock()
 
 # Entry id: a date, optionally followed by "_<suffix>" (time and/or collision
 # counter). Legacy day files (bare "YYYY-MM-DD") match with no suffix.
@@ -65,8 +74,14 @@ def _read_sidecar(path: Path) -> dict:
     if not path.exists():
         return {}
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except Exception:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        logger.warning("failed to read journal sidecar at %s; treating as empty", path, exc_info=True)
+        return {}
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning("failed to decode journal sidecar JSON at %s; treating as empty", path, exc_info=True)
         return {}
 
 
@@ -75,13 +90,17 @@ def _merge_sidecar(entry_id: str, updates: dict) -> None:
 
     ``item`` (short label) and ``notion_page_id`` (Notion sync) share this same
     file, so a write from one must not clobber a value written by the other.
+    The read-modify-write is serialized by ``_SIDECAR_LOCK`` so concurrent
+    updates (e.g. an item label saved while a background Notion sync writes
+    the page id) can't race each other.
     """
     import json
 
     path = _item_path(entry_id)
-    data = _read_sidecar(path)
-    data.update(updates)
-    path.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+    with _SIDECAR_LOCK:
+        data = _read_sidecar(path)
+        data.update(updates)
+        path.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
 
 
 def save_item(entry_id: str, item: str) -> None:

--- a/apps/python/src/journal_store.py
+++ b/apps/python/src/journal_store.py
@@ -117,11 +117,14 @@ def get_item(entry_id: str) -> str:
     return _read_sidecar(_item_path(entry_id)).get("item", "")
 
 
-def save_notion_meta(entry_id: str, page_id: str) -> None:
-    """Persist the Notion page id created for this entry, alongside the sidecar."""
+def save_notion_meta(entry_id: str, page_id: str, url: str = "") -> None:
+    """Persist the Notion page id (and page url, for UI display) for this entry."""
     if not _ENTRY_RE.match(entry_id):
         raise ValueError(f"Invalid journal entry id: {entry_id!r}")
-    _merge_sidecar(entry_id, {"notion_page_id": page_id})
+    updates = {"notion_page_id": page_id}
+    if url:
+        updates["notion_url"] = url
+    _merge_sidecar(entry_id, updates)
 
 
 def get_notion_meta(entry_id: str) -> str:
@@ -129,6 +132,13 @@ def get_notion_meta(entry_id: str) -> str:
     if not _ENTRY_RE.match(entry_id):
         return ""
     return _read_sidecar(_item_path(entry_id)).get("notion_page_id", "")
+
+
+def get_notion_url(entry_id: str) -> str:
+    """Return the entry's synced Notion page URL, or empty string if not yet synced."""
+    if not _ENTRY_RE.match(entry_id):
+        return ""
+    return _read_sidecar(_item_path(entry_id)).get("notion_url", "")
 
 
 def get_trashed_item(entry_id: str) -> str:

--- a/apps/python/src/notifier/journal_sync.py
+++ b/apps/python/src/notifier/journal_sync.py
@@ -1,0 +1,58 @@
+"""Journal <-> Notion sync (best-effort, no retry).
+
+One journal entry maps to one Notion page: new entries create a page; edits
+append to the page created for that entry (falling back to creating one if
+the entry predates sync, per docs/superpowers/specs/2026-07-03-journal-notion-sync-design.md).
+"""
+import re
+
+from notion_client import Client
+
+from src import journal_store
+from src.logger import get_logger
+from src.notifier.markdown import markdown_to_notion_blocks
+from src.notifier.notion import _append_blocks, _create_page
+
+logger = get_logger(__name__)
+
+_LEADING_MARKS_RE = re.compile(r"^[\s#\-*]+")
+_TITLE_MAX_LEN = 60
+
+
+def title_from_content(content: str, fallback: str) -> str:
+    """Derive a Notion page title from an entry's first non-blank line.
+
+    Strips leading heading/list markers, then falls back to ``fallback`` (the
+    entry's date) if nothing remains, and truncates to 60 chars.
+    """
+    first_line = next((line for line in content.splitlines() if line.strip()), "")
+    title = _LEADING_MARKS_RE.sub("", first_line).strip()
+    return (title or fallback)[:_TITLE_MAX_LEN]
+
+
+def sync_new_entry(entry_id: str, content: str, api_key: str, database_id: str) -> None:
+    """Create a Notion page for a newly created journal entry."""
+    if not api_key or not database_id:
+        return
+    notion = Client(auth=api_key)
+    title = title_from_content(content, journal_store.date_of(entry_id))
+    response = _create_page(notion, database_id, title, markdown_to_notion_blocks(content))
+    if response:
+        journal_store.save_notion_meta(entry_id, response["id"])
+
+
+def sync_append(entry_id: str, content: str, api_key: str, database_id: str) -> None:
+    """Append to the journal entry's Notion page, creating one if it has none yet."""
+    if not api_key or not database_id:
+        return
+    notion = Client(auth=api_key)
+    blocks = markdown_to_notion_blocks(content)
+    page_id = journal_store.get_notion_meta(entry_id)
+    if page_id:
+        _append_blocks(notion, page_id, blocks)
+        return
+
+    title = title_from_content(content, journal_store.date_of(entry_id))
+    response = _create_page(notion, database_id, title, blocks)
+    if response:
+        journal_store.save_notion_meta(entry_id, response["id"])

--- a/apps/python/src/notifier/journal_sync.py
+++ b/apps/python/src/notifier/journal_sync.py
@@ -38,7 +38,7 @@ def sync_new_entry(entry_id: str, content: str, api_key: str, database_id: str) 
     title = title_from_content(content, journal_store.date_of(entry_id))
     response = _create_page(notion, database_id, title, markdown_to_notion_blocks(content))
     if response:
-        journal_store.save_notion_meta(entry_id, response["id"])
+        journal_store.save_notion_meta(entry_id, response["id"], response.get("url", ""))
 
 
 def sync_append(entry_id: str, content: str, api_key: str, database_id: str) -> None:
@@ -55,4 +55,4 @@ def sync_append(entry_id: str, content: str, api_key: str, database_id: str) -> 
     title = title_from_content(content, journal_store.date_of(entry_id))
     response = _create_page(notion, database_id, title, blocks)
     if response:
-        journal_store.save_notion_meta(entry_id, response["id"])
+        journal_store.save_notion_meta(entry_id, response["id"], response.get("url", ""))

--- a/apps/python/src/notifier/notion.py
+++ b/apps/python/src/notifier/notion.py
@@ -39,6 +39,73 @@ def _resolve_title_prop(notion: Client, database_id: str, sample_title: str) -> 
 # Public API
 # ---------------------------------------------------------------------------
 
+def _append_blocks(notion: Client, page_id: str, blocks: list[dict]) -> None:
+    """Append blocks to an existing page, batching at the Notion 100-block limit."""
+    for i in range(0, len(blocks), 100):
+        try:
+            notion.blocks.children.append(
+                block_id=page_id,
+                children=blocks[i:i + 100],
+            )
+        except Exception:
+            logger.exception("failed to append Notion blocks (page_id=%s, index=%d)", page_id, i)
+
+
+def _create_page(
+    notion: Client,
+    database_id: str,
+    title: str,
+    blocks: list[dict],
+    tags: list[str] | None = None,
+    extra_properties: dict | None = None,
+) -> dict | None:
+    """Create a page with title/blocks in a Notion database. Return the created page, or None on failure."""
+    # Get the title property key via databases.retrieve. On failure, try name candidates in order.
+    title_prop_name: str | None = None
+    try:
+        db = notion.databases.retrieve(database_id)
+        properties = db.get("properties") or {}
+        title_prop_name = next(
+            (k for k, v in properties.items() if v.get("type") == "title"),
+            None,
+        )
+    except Exception:
+        logger.exception("failed to retrieve Notion database schema (database_id=%s)", database_id)
+
+    if title_prop_name is None:
+        title_prop_name = _resolve_title_prop(notion, database_id, title)
+    if title_prop_name is None:
+        logger.error("failed to identify the Notion title property (database_id=%s)", database_id)
+        return None
+
+    # The Notion API only accepts children 100 blocks at a time.
+    first_batch = blocks[:100]
+    remaining = blocks[100:]
+
+    properties: dict = {
+        title_prop_name: {
+            "title": [{"type": "text", "text": {"content": title}}]
+        }
+    }
+    if tags:
+        properties["Tags"] = {"multi_select": [{"name": t} for t in tags]}
+    if extra_properties:
+        properties.update(extra_properties)
+
+    try:
+        response = notion.pages.create(
+            parent={"database_id": database_id},
+            properties=properties,
+            children=first_batch,
+        )
+    except Exception:
+        logger.exception("failed to create Notion page (database_id=%s, title=%s)", database_id, title)
+        return None
+
+    _append_blocks(notion, response["id"], remaining)
+    return response
+
+
 def send_to_notion(
     text: str,
     api_key: str,
@@ -56,58 +123,9 @@ def send_to_notion(
     page_title = title or f"Report — {date.today().strftime('%Y-%m-%d')}"
     blocks = markdown_to_notion_blocks(text)
 
-    # Get the title property key via databases.retrieve. On failure, try name candidates in order.
-    title_prop_name: str | None = None
-    try:
-        db = notion.databases.retrieve(database_id)
-        properties = db.get("properties") or {}
-        title_prop_name = next(
-            (k for k, v in properties.items() if v.get("type") == "title"),
-            None,
-        )
-    except Exception:
-        logger.exception("failed to retrieve Notion database schema (database_id=%s)", database_id)
-
-    if title_prop_name is None:
-        title_prop_name = _resolve_title_prop(notion, database_id, page_title)
-    if title_prop_name is None:
-        logger.error("failed to identify the Notion title property (database_id=%s)", database_id)
+    response = _create_page(notion, database_id, page_title, blocks, tags, extra_properties)
+    if not response:
         return ""
-
-    # The Notion API only accepts children 100 blocks at a time.
-    first_batch = blocks[:100]
-    remaining = blocks[100:]
-
-    properties: dict = {
-        title_prop_name: {
-            "title": [{"type": "text", "text": {"content": page_title}}]
-        }
-    }
-    if tags:
-        properties["Tags"] = {"multi_select": [{"name": t} for t in tags]}
-    if extra_properties:
-        properties.update(extra_properties)
-
-    try:
-        response = notion.pages.create(
-            parent={"database_id": database_id},
-            properties=properties,
-            children=first_batch,
-        )
-    except Exception:
-        logger.exception("failed to create Notion page (database_id=%s, title=%s)", database_id, page_title)
-        return ""
-
-    page_id = response["id"]
-
-    for i in range(0, len(remaining), 100):
-        try:
-            notion.blocks.children.append(
-                block_id=page_id,
-                children=remaining[i:i + 100],
-            )
-        except Exception:
-            logger.exception("failed to append Notion blocks (page_id=%s, index=%d)", page_id, i)
 
     page_url = response.get("url", "")
     logger.info("Notion page created: %s", page_url)

--- a/apps/python/tests/conftest.py
+++ b/apps/python/tests/conftest.py
@@ -8,11 +8,19 @@ os.environ.setdefault("BRIEFING_CONFIG_PATH", str(Path(__file__).parent / "confi
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from src import credentials, state as state_mod
+from src import credentials, journal_store, state as state_mod
 from web import auth
 from web.app import app
 
 TEST_TOKEN = "test-token-123"
+
+
+@pytest.fixture
+def journal_dir(tmp_path, monkeypatch):
+    """Point the journal store at a tmp dir."""
+    d = tmp_path / "journal"
+    monkeypatch.setattr(journal_store, "JOURNAL_DIR", d)
+    return d
 
 
 @pytest.fixture

--- a/apps/python/tests/test_api_journal.py
+++ b/apps/python/tests/test_api_journal.py
@@ -8,6 +8,8 @@ Contract:
 - Auth is required (Bearer) on all endpoints.
 - Legacy day-based files (YYYY-MM-DD.md) remain listable and readable.
 """
+from unittest.mock import patch
+
 import pytest
 
 from src import journal_store
@@ -280,3 +282,75 @@ async def test_trash_empty_when_nothing_deleted(authed_client, journal_dir):
 async def test_trash_requires_auth(async_client, journal_dir):
     resp = await async_client.get("/api/journal/trash")
     assert resp.status_code == 401
+
+
+class TestNotionSync:
+    """Notion sync is triggered when configured, and never breaks the API (best-effort)."""
+
+    def _creds(self, database_id):
+        return ("key", database_id)
+
+    async def test_no_database_id_skips_sync(self, authed_client, journal_dir):
+        with patch("web.routers.journal.config.get_journal_notion_credentials", return_value=("", "")), \
+             patch("web.routers.journal.journal_sync.sync_new_entry") as mock_sync:
+            response = await authed_client.post(
+                "/api/journal", json={"content": "hi", "date": "2026-07-03"}
+            )
+        assert response.status_code == 200
+        mock_sync.assert_not_called()
+
+    async def test_new_entry_triggers_sync(self, authed_client, journal_dir):
+        with patch(
+            "web.routers.journal.config.get_journal_notion_credentials",
+            return_value=self._creds("db-id"),
+        ), patch("web.routers.journal.journal_sync.sync_new_entry") as mock_sync:
+            response = await authed_client.post(
+                "/api/journal", json={"content": "hi", "date": "2026-07-03"}
+            )
+        assert response.status_code == 200
+        entry_id = response.json()["id"]
+        mock_sync.assert_called_once_with(entry_id, "hi", "key", "db-id")
+
+    async def test_sync_failure_does_not_break_create(self, authed_client, journal_dir):
+        with patch(
+            "web.routers.journal.config.get_journal_notion_credentials",
+            return_value=self._creds("db-id"),
+        ), patch(
+            "web.routers.journal.journal_sync.sync_new_entry", side_effect=Exception("boom")
+        ):
+            response = await authed_client.post(
+                "/api/journal", json={"content": "hi", "date": "2026-07-03"}
+            )
+        assert response.status_code == 200
+        assert (journal_dir / f"{response.json()['id']}.md").exists()
+
+    async def test_append_triggers_sync(self, authed_client, journal_dir):
+        post = await authed_client.post(
+            "/api/journal", json={"content": "hi", "date": "2026-07-03"}
+        )
+        entry_id = post.json()["id"]
+        with patch(
+            "web.routers.journal.config.get_journal_notion_credentials",
+            return_value=self._creds("db-id"),
+        ), patch("web.routers.journal.journal_sync.sync_append") as mock_sync:
+            response = await authed_client.patch(
+                f"/api/journal/{entry_id}", json={"content": "more"}
+            )
+        assert response.status_code == 204
+        mock_sync.assert_called_once_with(entry_id, "more", "key", "db-id")
+
+    async def test_append_sync_failure_does_not_break_patch(self, authed_client, journal_dir):
+        post = await authed_client.post(
+            "/api/journal", json={"content": "hi", "date": "2026-07-03"}
+        )
+        entry_id = post.json()["id"]
+        with patch(
+            "web.routers.journal.config.get_journal_notion_credentials",
+            return_value=self._creds("db-id"),
+        ), patch(
+            "web.routers.journal.journal_sync.sync_append", side_effect=Exception("boom")
+        ):
+            response = await authed_client.patch(
+                f"/api/journal/{entry_id}", json={"content": "more"}
+            )
+        assert response.status_code == 204

--- a/apps/python/tests/test_api_journal.py
+++ b/apps/python/tests/test_api_journal.py
@@ -344,3 +344,28 @@ class TestNotionSync:
                 f"/api/journal/{entry_id}", json={"content": "more"}
             )
         assert response.status_code == 204
+
+    async def test_list_exposes_notion_url_once_synced(self, authed_client, journal_dir):
+        """The UI needs a link to the synced Notion page so users don't reach for
+        the unrelated /notion-import skill (which targets the Briefing DB)."""
+        from src import journal_store
+
+        post = await authed_client.post(
+            "/api/journal", json={"content": "hi", "date": "2026-07-03"}
+        )
+        entry_id = post.json()["id"]
+        journal_store.save_notion_meta(entry_id, "page-1", "https://notion.so/page-1")
+
+        response = await authed_client.get("/api/journal")
+        entry = next(e for e in response.json()["entries"] if e["id"] == entry_id)
+        assert entry["notion_url"] == "https://notion.so/page-1"
+
+    async def test_list_notion_url_empty_when_not_synced(self, authed_client, journal_dir):
+        post = await authed_client.post(
+            "/api/journal", json={"content": "hi", "date": "2026-07-03"}
+        )
+        entry_id = post.json()["id"]
+
+        response = await authed_client.get("/api/journal")
+        entry = next(e for e in response.json()["entries"] if e["id"] == entry_id)
+        assert entry["notion_url"] == ""

--- a/apps/python/tests/test_api_journal.py
+++ b/apps/python/tests/test_api_journal.py
@@ -10,17 +10,7 @@ Contract:
 """
 from unittest.mock import patch
 
-import pytest
-
 from src import journal_store
-
-
-@pytest.fixture
-def journal_dir(tmp_path, monkeypatch):
-    """Point the journal store at a tmp dir."""
-    d = tmp_path / "journal"
-    monkeypatch.setattr(journal_store, "JOURNAL_DIR", d)
-    return d
 
 
 async def test_list_requires_auth(async_client, journal_dir):

--- a/apps/python/tests/test_journal_notion_sync.py
+++ b/apps/python/tests/test_journal_notion_sync.py
@@ -1,0 +1,119 @@
+"""Tests for Journal <-> Notion sync (docs/superpowers/specs/2026-07-03-journal-notion-sync-design.md).
+
+Contract:
+- New entry -> Notion page created; its id is saved as ``notion_page_id``.
+- Append to an entry with a saved ``notion_page_id`` -> blocks appended to that page.
+- Append to an entry without one (pre-sync entry) -> falls back to creating a page.
+- Notion failures are best-effort: the local journal write always succeeds.
+- Title is derived from the entry's first line (heading/list markers stripped,
+  truncated to 60 chars, falls back to the entry's date when empty).
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src import journal_store
+from src.notifier import journal_sync
+
+
+@pytest.fixture
+def journal_dir(tmp_path, monkeypatch):
+    d = tmp_path / "journal"
+    monkeypatch.setattr(journal_store, "JOURNAL_DIR", d)
+    return d
+
+
+def _make_notion_mock(title_prop="Name", page_id="page-1"):
+    mock = MagicMock()
+    mock.databases.retrieve.return_value = {
+        "properties": {title_prop: {"type": "title"}}
+    }
+    mock.pages.create.return_value = {"id": page_id, "url": f"https://notion.so/{page_id}"}
+    return mock
+
+
+@pytest.fixture
+def mock_notion():
+    with patch("src.notifier.journal_sync.Client") as MockClient:
+        notion = _make_notion_mock()
+        MockClient.return_value = notion
+        yield notion
+
+
+class TestTitleFromContent:
+    def test_uses_first_line(self):
+        assert journal_sync.title_from_content("hello world\nmore", "2026-07-03") == "hello world"
+
+    def test_strips_heading_marker(self):
+        assert journal_sync.title_from_content("### Heading\nbody", "2026-07-03") == "Heading"
+
+    def test_strips_list_marker(self):
+        assert journal_sync.title_from_content("- item one", "2026-07-03") == "item one"
+
+    def test_falls_back_to_date_when_empty(self):
+        assert journal_sync.title_from_content("### \n\n", "2026-07-03") == "2026-07-03"
+
+    def test_truncated_to_60_chars(self):
+        long_line = "a" * 100
+        result = journal_sync.title_from_content(long_line, "2026-07-03")
+        assert len(result) == 60
+
+    def test_skips_leading_blank_lines(self):
+        assert journal_sync.title_from_content("\n\nfirst real line", "2026-07-03") == "first real line"
+
+
+class TestSyncNewEntry:
+    def test_no_credentials_no_op(self, journal_dir):
+        entry_id = journal_store.append_entry("hello", date="2026-07-03")
+        with patch("src.notifier.journal_sync.Client") as MockClient:
+            journal_sync.sync_new_entry(entry_id, "hello", "", "")
+            MockClient.assert_not_called()
+        assert journal_store.get_notion_meta(entry_id) == ""
+
+    def test_creates_page_and_saves_page_id(self, journal_dir, mock_notion):
+        entry_id = journal_store.append_entry("hello world", date="2026-07-03")
+        journal_sync.sync_new_entry(entry_id, "hello world", "key", "db-id")
+
+        mock_notion.pages.create.assert_called_once()
+        assert journal_store.get_notion_meta(entry_id) == "page-1"
+
+    def test_page_creation_failure_does_not_raise(self, journal_dir, mock_notion):
+        mock_notion.pages.create.side_effect = Exception("boom")
+        entry_id = journal_store.append_entry("hello", date="2026-07-03")
+        journal_sync.sync_new_entry(entry_id, "hello", "key", "db-id")
+        assert journal_store.get_notion_meta(entry_id) == ""
+
+    def test_item_label_preserved_alongside_notion_meta(self, journal_dir, mock_notion):
+        entry_id = journal_store.append_entry("hello", date="2026-07-03")
+        journal_store.save_item(entry_id, "label")
+        journal_sync.sync_new_entry(entry_id, "hello", "key", "db-id")
+
+        assert journal_store.get_item(entry_id) == "label"
+        assert journal_store.get_notion_meta(entry_id) == "page-1"
+
+
+class TestSyncAppend:
+    def test_no_credentials_no_op(self, journal_dir):
+        entry_id = journal_store.append_entry("hello", date="2026-07-03")
+        with patch("src.notifier.journal_sync.Client") as MockClient:
+            journal_sync.sync_append(entry_id, "more", "", "")
+            MockClient.assert_not_called()
+
+    def test_appends_blocks_to_existing_page(self, journal_dir, mock_notion):
+        entry_id = journal_store.append_entry("hello", date="2026-07-03")
+        journal_store.save_notion_meta(entry_id, "existing-page")
+
+        journal_sync.sync_append(entry_id, "more content", "key", "db-id")
+
+        mock_notion.blocks.children.append.assert_called_once()
+        _, kwargs = mock_notion.blocks.children.append.call_args
+        assert kwargs["block_id"] == "existing-page"
+        mock_notion.pages.create.assert_not_called()
+
+    def test_falls_back_to_create_when_no_page_id(self, journal_dir, mock_notion):
+        entry_id = journal_store.append_entry("hello", date="2026-07-03")
+
+        journal_sync.sync_append(entry_id, "more content", "key", "db-id")
+
+        mock_notion.pages.create.assert_called_once()
+        assert journal_store.get_notion_meta(entry_id) == "page-1"

--- a/apps/python/tests/test_journal_notion_sync.py
+++ b/apps/python/tests/test_journal_notion_sync.py
@@ -16,13 +16,6 @@ from src import journal_store
 from src.notifier import journal_sync
 
 
-@pytest.fixture
-def journal_dir(tmp_path, monkeypatch):
-    d = tmp_path / "journal"
-    monkeypatch.setattr(journal_store, "JOURNAL_DIR", d)
-    return d
-
-
 def _make_notion_mock(title_prop="Name", page_id="page-1"):
     mock = MagicMock()
     mock.databases.retrieve.return_value = {

--- a/apps/python/tests/test_journal_notion_sync.py
+++ b/apps/python/tests/test_journal_notion_sync.py
@@ -69,6 +69,7 @@ class TestSyncNewEntry:
 
         mock_notion.pages.create.assert_called_once()
         assert journal_store.get_notion_meta(entry_id) == "page-1"
+        assert journal_store.get_notion_url(entry_id) == "https://notion.so/page-1"
 
     def test_page_creation_failure_does_not_raise(self, journal_dir, mock_notion):
         mock_notion.pages.create.side_effect = Exception("boom")

--- a/apps/python/web/routers/journal.py
+++ b/apps/python/web/routers/journal.py
@@ -27,6 +27,7 @@ class JournalEntry(BaseModel):
     date: str  # YYYY-MM-DD
     size: int  # bytes
     item: str  # short label ≤20 chars, empty for legacy entries
+    notion_url: str  # synced Notion page URL, empty if not yet synced
 
 
 class JournalListResponse(BaseModel):
@@ -61,6 +62,7 @@ def _to_entries(files: list[tuple[str, Path]]) -> list[JournalEntry]:
             date=journal_store.date_of(entry_id),
             size=path.stat().st_size,
             item=journal_store.get_item(entry_id),
+            notion_url=journal_store.get_notion_url(entry_id),
         )
         for entry_id, path in files
     ]
@@ -82,6 +84,7 @@ def list_trash() -> JournalListResponse:
             date=journal_store.date_of(entry_id),
             size=path.stat().st_size,
             item=journal_store.get_trashed_item(entry_id),
+            notion_url="",  # trashed entries aren't sync-linked in the UI
         )
         for entry_id, path in files
     ]

--- a/apps/python/web/routers/journal.py
+++ b/apps/python/web/routers/journal.py
@@ -12,8 +12,12 @@ from pydantic import BaseModel, Field
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from src import journal_store
+from src import config, journal_store
+from src.logger import get_logger
+from src.notifier import journal_sync
 from web.auth import require_bearer
+
+logger = get_logger(__name__)
 
 router = APIRouter(dependencies=[Depends(require_bearer)])
 
@@ -108,6 +112,12 @@ def append_journal(req: AppendEntryRequest) -> AppendEntryResponse:
             journal_store.save_item(entry_id, req.item)
         except Exception:
             pass  # item label is best-effort; entry is already committed
+    api_key, database_id = config.get_journal_notion_credentials()
+    if database_id:
+        try:
+            journal_sync.sync_new_entry(entry_id, req.content, api_key, database_id)
+        except Exception:
+            logger.exception("Notion journal sync failed for new entry %s", entry_id)
     return AppendEntryResponse(id=entry_id, date=journal_store.date_of(entry_id))
 
 
@@ -123,6 +133,12 @@ def patch_journal(entry_id: str, req: PatchEntryRequest) -> None:
     ok = journal_store.append_to_entry(entry_id, req.content)
     if not ok:
         raise HTTPException(status_code=404, detail=f"Journal not found: {entry_id}")
+    api_key, database_id = config.get_journal_notion_credentials()
+    if database_id:
+        try:
+            journal_sync.sync_append(entry_id, req.content, api_key, database_id)
+        except Exception:
+            logger.exception("Notion journal sync failed for append %s", entry_id)
 
 
 @router.get("/journal/{entry_id}", response_model=JournalEntryResponse)

--- a/apps/python/web/routers/journal.py
+++ b/apps/python/web/routers/journal.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from pydantic import BaseModel, Field
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 
 from src import config, journal_store
 from src.logger import get_logger
@@ -100,8 +100,28 @@ def get_trashed_journal(entry_id: str) -> JournalEntryResponse:
     )
 
 
+def _sync_new_entry_task(entry_id: str, content: str) -> None:
+    """Best-effort background sync: credential lookup and Notion call both guarded."""
+    try:
+        api_key, database_id = config.get_journal_notion_credentials()
+        if database_id:
+            journal_sync.sync_new_entry(entry_id, content, api_key, database_id)
+    except Exception:
+        logger.exception("Notion journal sync failed for new entry %s", entry_id)
+
+
+def _sync_append_task(entry_id: str, content: str) -> None:
+    """Best-effort background sync: credential lookup and Notion call both guarded."""
+    try:
+        api_key, database_id = config.get_journal_notion_credentials()
+        if database_id:
+            journal_sync.sync_append(entry_id, content, api_key, database_id)
+    except Exception:
+        logger.exception("Notion journal sync failed for append %s", entry_id)
+
+
 @router.post("/journal", response_model=AppendEntryResponse)
-def append_journal(req: AppendEntryRequest) -> AppendEntryResponse:
+def append_journal(req: AppendEntryRequest, background_tasks: BackgroundTasks) -> AppendEntryResponse:
     """Create a new journal entry file and return its id."""
     try:
         entry_id = journal_store.append_entry(req.content, req.date)
@@ -112,17 +132,12 @@ def append_journal(req: AppendEntryRequest) -> AppendEntryResponse:
             journal_store.save_item(entry_id, req.item)
         except Exception:
             pass  # item label is best-effort; entry is already committed
-    api_key, database_id = config.get_journal_notion_credentials()
-    if database_id:
-        try:
-            journal_sync.sync_new_entry(entry_id, req.content, api_key, database_id)
-        except Exception:
-            logger.exception("Notion journal sync failed for new entry %s", entry_id)
+    background_tasks.add_task(_sync_new_entry_task, entry_id, req.content)
     return AppendEntryResponse(id=entry_id, date=journal_store.date_of(entry_id))
 
 
 @router.patch("/journal/{entry_id}", status_code=204)
-def patch_journal(entry_id: str, req: PatchEntryRequest) -> None:
+def patch_journal(entry_id: str, req: PatchEntryRequest, background_tasks: BackgroundTasks) -> None:
     """Append additional content to an existing journal entry.
 
     Used when a brainstorm session continues: subsequent turns are appended to
@@ -133,12 +148,7 @@ def patch_journal(entry_id: str, req: PatchEntryRequest) -> None:
     ok = journal_store.append_to_entry(entry_id, req.content)
     if not ok:
         raise HTTPException(status_code=404, detail=f"Journal not found: {entry_id}")
-    api_key, database_id = config.get_journal_notion_credentials()
-    if database_id:
-        try:
-            journal_sync.sync_append(entry_id, req.content, api_key, database_id)
-        except Exception:
-            logger.exception("Notion journal sync failed for append %s", entry_id)
+    background_tasks.add_task(_sync_append_task, entry_id, req.content)
 
 
 @router.get("/journal/{entry_id}", response_model=JournalEntryResponse)

--- a/apps/web/components/screens/CredentialsForm.tsx
+++ b/apps/web/components/screens/CredentialsForm.tsx
@@ -26,6 +26,7 @@ const FIELDS: Field[] = [
   { name: "CHANNEL_ID", label: "Discord channel id", secret: false },
   { name: "NOTION_API_KEY", label: "Notion integration key", secret: true },
   { name: "NOTION_DATABASE_ID", label: "Notion database id", secret: false },
+  { name: "NOTION_DATABASE_ID_JOURNAL", label: "Notion journal database id", secret: false },
   { name: "ANTHROPIC_API_KEY", label: "Anthropic API key", secret: true },
 ]
 

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -12,7 +12,7 @@ import { useResizable } from "@/lib/hooks/useResizable"
 import type { ImageAttachment } from "@/lib/types/image"
 import { cn } from "@/lib/utils"
 
-type JournalEntry = { id: string; date: string; size: number; item: string }
+type JournalEntry = { id: string; date: string; size: number; item: string; notion_url: string }
 type Turn = { question: string; answer: string }
 
 const PROSE =
@@ -545,6 +545,22 @@ export function JournalScreen() {
                   </span>
                   {selectedMeta && (
                     <span>{(selectedMeta.size / 1024).toFixed(1)} KB</span>
+                  )}
+                  {selectedMeta?.notion_url ? (
+                    <a
+                      href={selectedMeta.notion_url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-blue-600 hover:underline dark:text-blue-400"
+                    >
+                      Synced to Notion ↗
+                    </a>
+                  ) : (
+                    selectedMeta && (
+                      <span title="Syncs automatically once NOTION_DATABASE_ID_JOURNAL is configured">
+                        Not synced to Notion
+                      </span>
+                    )
                   )}
                 </>
               )}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,6 +47,7 @@ cp .env.example .env
 | `CHANNEL_ID` | Right-click channel → Copy ID | Target channel |
 | `NOTION_API_KEY` | Notion integrations page | API authentication |
 | `NOTION_DATABASE_ID` | Database URL | Target database |
+| `NOTION_DATABASE_ID_JOURNAL` | Database URL | Target database for Journal ↔ Notion sync (separate from `NOTION_DATABASE_ID`) |
 | `BRAVE_API_KEY` | [api-dashboard.search.brave.com](https://api-dashboard.search.brave.com/) | Local LLM briefing web search |
 
 ### Credential Management

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,6 +62,7 @@ cd apps/python
 from src.credentials import set_credential
 set_credential('NOTION_API_KEY', 'ntn_xxx...')
 set_credential('NOTION_DATABASE_ID', 'xxx...')
+set_credential('NOTION_DATABASE_ID_JOURNAL', 'xxx...')
 "
 ```
 


### PR DESCRIPTION
Implement bidirectional sync between journal entries and Notion pages, allowing new entries to create pages and appends to update existing pages.

**Summary**
- New journal entries automatically create Notion pages; the page ID is persisted in a JSON sidecar
- Appending to an entry updates its Notion page, or creates one if the entry predates sync
- Sync is best-effort: local journal writes always succeed even if Notion operations fail
- Page titles are derived from the entry's first line (with heading/list markers stripped, truncated to 60 chars, falling back to the entry's date)

**Key changes**
- **`src/notifier/journal_sync.py`** (new): Core sync logic with `sync_new_entry()` and `sync_append()` functions, plus `title_from_content()` for title derivation
- **`src/journal_store.py`**: Refactored sidecar JSON handling to support both `item` labels and `notion_page_id` in the same file via `_merge_sidecar()`, added `save_notion_meta()` and `get_notion_meta()`
- **`src/notifier/notion.py`**: Extracted `_create_page()` and `_append_blocks()` as reusable helpers for journal sync to use
- **`web/routers/journal.py`**: Integrated sync calls into POST (new entry) and PATCH (append) endpoints with exception handling to prevent sync failures from breaking the API
- **`src/config.py`**: Added `get_journal_notion_credentials()` to read `NOTION_API_KEY` and `NOTION_DATABASE_ID_JOURNAL` independently of the briefing config
- **Configuration**: Added `NOTION_DATABASE_ID_JOURNAL` credential (separate from the existing `NOTION_DATABASE_ID` used by reports)
- **Tests**: Comprehensive test suite covering title derivation, page creation, append logic, and API integration with sync enabled/disabled

**Implementation notes**
- Sync uses a separate Notion database from the existing report sync to avoid conflicts
- The sidecar JSON file (`{entry_id}.json`) now merges updates from both item labels and Notion sync, preventing one from clobbering the other
- All Notion operations are wrapped in try-except to ensure the journal API remains responsive even if Notion is unavailable

https://claude.ai/code/session_0182kPn5KgDjUD8PYkkfNk4s

## Summary by Sourcery

Add best-effort bidirectional Journal ↔ Notion sync triggered from journal API endpoints, using a shared JSON sidecar for per-entry metadata and reusable Notion helpers.

New Features:
- Introduce Journal ↔ Notion sync module to create and append Notion pages per journal entry.
- Expose journal-specific Notion credentials and web UI field for configuring a separate journal database.

Enhancements:
- Refactor Notion client helpers to support reusable page creation and block appends for both reports and journal sync.
- Update journal sidecar storage to merge item labels with Notion page metadata without clobbering existing data.

Documentation:
- Document the new NOTION_DATABASE_ID_JOURNAL credential and its role in Journal ↔ Notion sync configuration.

Tests:
- Add unit tests for journal-notion sync behavior, including title derivation, page creation/append logic, sidecar merging, and failure handling.
- Extend journal API tests to verify that Notion sync is conditionally triggered and never breaks create/append endpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Journal ↔ Notion sync for new entries and subsequent updates (best-effort).
  * Journal entries now expose a `notion_url` when a Notion page has been created.
* **Bug Fixes**
  * Improved journal metadata persistence to avoid clobbering and to safely handle read/write issues.
  * Sync no longer impacts journal create/edit requests, even if Notion operations fail.
* **Documentation**
  * Documented the new Journal Notion database setting and how to configure it.
* **Chores**
  * Added the Journal Notion credential field to the settings UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->