### PR TITLE
feat(web): label user vs AI roles in saved Journal chat markdown

### DIFF
--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -8,6 +8,7 @@ import { ResizeHandle } from "@/components/ResizeHandle"
 import { ImageAttachArea } from "@/components/ui/ImageAttachArea"
 import { useImageDrop } from "@/lib/hooks/useImageDrop"
 import { insertAtCursor } from "@/lib/insertAtCursor"
+import { formatQaBlock } from "@/lib/journalQa"
 import { useResizable } from "@/lib/hooks/useResizable"
 import type { ImageAttachment } from "@/lib/types/image"
 import { cn } from "@/lib/utils"
@@ -302,7 +303,7 @@ export function JournalScreen() {
         dropPendingTurn()
         return
       }
-      const qaBlock = `${q}\n\n${answer}`
+      const qaBlock = formatQaBlock(q, answer)
       let saveRes: Response
       if (targetEntryId) {
         // Append to the entry this session was bound to when it started.

--- a/apps/web/lib/journalQa.ts
+++ b/apps/web/lib/journalQa.ts
@@ -1,0 +1,14 @@
+/** Markdown labels marking who wrote each part of a saved Q&A block. */
+export const USER_LABEL = "**You:**"
+export const AI_LABEL = "**AI:**"
+
+/**
+ * Format one brainstorm turn as role-labelled Markdown for journal storage.
+ *
+ * Saved entries are plain Markdown files (also synced to Notion), so without
+ * labels a question and its answer read as one undifferentiated block. The
+ * labels keep the transcript readable anywhere the raw Markdown is viewed.
+ */
+export function formatQaBlock(question: string, answer: string): string {
+  return `${USER_LABEL}\n\n${question}\n\n${AI_LABEL}\n\n${answer}`
+}

--- a/apps/web/tests/journal-qa.test.ts
+++ b/apps/web/tests/journal-qa.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest"
+
+import { AI_LABEL, formatQaBlock, USER_LABEL } from "@/lib/journalQa"
+
+describe("formatQaBlock", () => {
+  it("labels the question and answer with their roles", () => {
+    const block = formatQaBlock("What next?", "Focus on tests.")
+    expect(block).toBe("**You:**\n\nWhat next?\n\n**AI:**\n\nFocus on tests.")
+  })
+
+  it("keeps multi-line markdown answers intact", () => {
+    const answer = "- point one\n- point two"
+    const block = formatQaBlock("q", answer)
+    expect(block).toContain(`${AI_LABEL}\n\n${answer}`)
+    expect(block.startsWith(USER_LABEL)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Saved brainstorm turns now use `**You:** / **AI:**` markers via new `formatQaBlock` helper, so stored markdown (and Notion sync) stays readable. Existing entries render unchanged.

## Test plan
- [x] `vitest run` — 218 tests pass (incl. new `journal-qa.test.ts`)
- [x] `tsc --noEmit` clean

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QxFVXAAgBeip7r3VXkhEQt

## Summary by Sourcery

Label saved journal brainstorm question/answer blocks with explicit user and AI markers to keep stored markdown transcripts readable across surfaces like raw files and Notion sync.

New Features:
- Add role-labelled markdown formatting for saved journal Q&A turns using a shared helper.

Tests:
- Add unit tests covering journal Q&A markdown formatting, including multi-line answers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Journal entries now save brainstorm Q&A content in a clearer labeled format.
  * Added consistent “You” and “AI” labels for saved question-and-answer blocks.

* **Tests**
  * Added coverage to ensure Q&A formatting is preserved, including multi-line answers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->