### PR TITLE
feat(web): cancel in-flight Journal chat message

### DIFF
--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -285,6 +285,9 @@ export function JournalScreen() {
         signal: controller.signal,
       })
       if (!stream.ok || !stream.body) {
+        // The job was created but its stream is unusable — terminate it so it
+        // doesn't keep running (and burning tokens) unattended.
+        void fetch(`/api/chat/${job_id}`, { method: "DELETE", cache: "no-store" })
         setChatError(`Stream failed (HTTP ${stream.status})`)
         dropPendingTurn()
         return

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -270,6 +270,13 @@ export function JournalScreen() {
         return
       }
       const { job_id } = (await post.json()) as { job_id: string }
+      // Cancelled between POST and job id arrival: cancelBrainstorm couldn't
+      // send DELETE (jobId was still null), so terminate the job here.
+      if (controller.signal.aborted) {
+        void fetch(`/api/chat/${job_id}`, { method: "DELETE", cache: "no-store" })
+        handleAbort()
+        return
+      }
       if (brainstormAbort.current?.controller === controller) {
         brainstormAbort.current.jobId = job_id
       }

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -9,6 +9,7 @@ import { ImageAttachArea } from "@/components/ui/ImageAttachArea"
 import { useImageDrop } from "@/lib/hooks/useImageDrop"
 import { insertAtCursor } from "@/lib/insertAtCursor"
 import { formatQaBlock } from "@/lib/journalQa"
+import { readSseEvents } from "@/lib/sse"
 import { useResizable } from "@/lib/hooks/useResizable"
 import type { ImageAttachment } from "@/lib/types/image"
 import { cn } from "@/lib/utils"
@@ -27,43 +28,6 @@ const HEADER_BTN =
 function entryTime(id: string): string | null {
   const m = id.match(/^\d{4}-\d{2}-\d{2}_(\d{2})(\d{2})(\d{2})/)
   return m ? `${m[1]}:${m[2]}:${m[3]}` : null
-}
-
-/** Join the `data:` lines of one raw SSE event block into text. */
-function parseSseEvent(raw: string): string {
-  return raw
-    .split("\n")
-    .filter((l) => l.startsWith("data:"))
-    .map((l) => l.slice(5).replace(/^ /, ""))
-    .join("\n")
-}
-
-/** Parse a Server-Sent Events stream, yielding the joined `data:` text per event.
- *
- * When `signal` aborts, the reader is cancelled so the pending read resolves
- * and the generator ends cleanly (callers check `signal.aborted` afterwards).
- */
-async function* readSse(
-  body: ReadableStream<Uint8Array>,
-  signal?: AbortSignal,
-): AsyncGenerator<string> {
-  const reader = body.getReader()
-  signal?.addEventListener("abort", () => void reader.cancel().catch(() => {}))
-  const decoder = new TextDecoder()
-  let buffer = ""
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done) break
-    buffer += decoder.decode(value, { stream: true })
-    let sep: number
-    while ((sep = buffer.indexOf("\n\n")) !== -1) {
-      const data = parseSseEvent(buffer.slice(0, sep))
-      buffer = buffer.slice(sep + 2)
-      if (data) yield data
-    }
-  }
-  const tail = parseSseEvent(buffer)
-  if (tail) yield tail
 }
 
 export function JournalScreen() {
@@ -319,9 +283,12 @@ export function JournalScreen() {
         return
       }
       let answer = ""
-      for await (const chunk of readSse(stream.body, controller.signal)) {
-        answer = answer ? `${answer}\n${chunk}` : chunk
-        appendToLastAnswer(chunk)
+      for await (const ev of readSseEvents(stream.body, controller.signal)) {
+        // Only default "message" events carry answer text; control events
+        // (e.g. stale_session) are ignored here.
+        if (ev.type !== "message" || !ev.data) continue
+        answer = answer ? `${answer}\n${ev.data}` : ev.data
+        appendToLastAnswer(ev.data)
       }
       if (controller.signal.aborted) {
         handleAbort()

--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -38,9 +38,17 @@ function parseSseEvent(raw: string): string {
     .join("\n")
 }
 
-/** Parse a Server-Sent Events stream, yielding the joined `data:` text per event. */
-async function* readSse(body: ReadableStream<Uint8Array>): AsyncGenerator<string> {
+/** Parse a Server-Sent Events stream, yielding the joined `data:` text per event.
+ *
+ * When `signal` aborts, the reader is cancelled so the pending read resolves
+ * and the generator ends cleanly (callers check `signal.aborted` afterwards).
+ */
+async function* readSse(
+  body: ReadableStream<Uint8Array>,
+  signal?: AbortSignal,
+): AsyncGenerator<string> {
   const reader = body.getReader()
+  signal?.addEventListener("abort", () => void reader.cancel().catch(() => {}))
   const decoder = new TextDecoder()
   let buffer = ""
   while (true) {
@@ -83,6 +91,9 @@ export function JournalScreen() {
   // Tracks the journal entry id for the current brainstorm session so that
   // subsequent turns append to the same entry instead of creating new ones.
   const brainstormEntryId = useRef<string | null>(null)
+  // Abort handle + backend job id for the in-flight brainstorm, so the user
+  // can cancel an accidentally sent question before the answer lands.
+  const brainstormAbort = useRef<{ controller: AbortController; jobId: string | null } | null>(null)
 
   const { width: listWidth, startResize } = useResizable({
     storageKey: "ai-agent:journal-list-width:v1",
@@ -267,6 +278,13 @@ export function JournalScreen() {
     // toggleTrash) can't retarget this in-flight save to a different entry.
     const targetEntryId = brainstormEntryId.current
     const dropPendingTurn = () => setTurns((prev) => prev.slice(0, -1))
+    const controller = new AbortController()
+    brainstormAbort.current = { controller, jobId: null }
+    // Cancelled: drop the pending turn and restore the question for re-edit.
+    const handleAbort = () => {
+      dropPendingTurn()
+      setQuestion(q)
+    }
     try {
       const post = await fetch("/api/journal/chat", {
         method: "POST",
@@ -275,6 +293,7 @@ export function JournalScreen() {
           question: q,
           ...(brainstormImage ? { image_path: brainstormImage.path } : {}),
         }),
+        signal: controller.signal,
       })
       if (!post.ok) {
         const body = await post.text()
@@ -287,16 +306,26 @@ export function JournalScreen() {
         return
       }
       const { job_id } = (await post.json()) as { job_id: string }
-      const stream = await fetch(`/api/chat/${job_id}/stream`, { cache: "no-store" })
+      if (brainstormAbort.current?.controller === controller) {
+        brainstormAbort.current.jobId = job_id
+      }
+      const stream = await fetch(`/api/chat/${job_id}/stream`, {
+        cache: "no-store",
+        signal: controller.signal,
+      })
       if (!stream.ok || !stream.body) {
         setChatError(`Stream failed (HTTP ${stream.status})`)
         dropPendingTurn()
         return
       }
       let answer = ""
-      for await (const chunk of readSse(stream.body)) {
+      for await (const chunk of readSse(stream.body, controller.signal)) {
         answer = answer ? `${answer}\n${chunk}` : chunk
         appendToLastAnswer(chunk)
+      }
+      if (controller.signal.aborted) {
+        handleAbort()
+        return
       }
       if (!answer) {
         setChatError("Brainstorm returned an empty answer.")
@@ -341,12 +370,43 @@ export function JournalScreen() {
       // The brainstorm answer is saved as its own entry; the transcript above
       // already shows it, so leave the current selection untouched.
     } catch (e) {
-      setChatError(String(e))
+      if (controller.signal.aborted) {
+        handleAbort()
+      } else {
+        setChatError(String(e))
+      }
     } finally {
+      brainstormAbort.current = null
       setBrainstorming(false)
-      setBrainstormImage(null)
+      // Keep the attached image on cancel so the restored question can be
+      // resent as-is; clear it only after a completed turn.
+      if (!controller.signal.aborted) setBrainstormImage(null)
     }
   }, [question, brainstorming, brainstormImage, appendToLastAnswer, loadDates])
+
+  // Abort the in-flight brainstorm and terminate the backend job. DELETE is
+  // fire-and-forget — the UI switches immediately, cleanup is best-effort.
+  const cancelBrainstorm = useCallback(() => {
+    const inflight = brainstormAbort.current
+    if (!inflight) return
+    if (inflight.jobId) {
+      void fetch(`/api/chat/${inflight.jobId}`, { method: "DELETE", cache: "no-store" })
+    }
+    inflight.controller.abort()
+  }, [])
+
+  // Esc cancels the in-flight brainstorm (matches Q&A ChatForm behavior).
+  useEffect(() => {
+    if (!brainstorming) return
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault()
+        cancelBrainstorm()
+      }
+    }
+    window.addEventListener("keydown", onKeyDown)
+    return () => window.removeEventListener("keydown", onKeyDown)
+  }, [brainstorming, cancelBrainstorm])
 
   const sortedEntries = [...entries].sort((a, b) => b.id.localeCompare(a.id))
   const selectedMeta = sortedEntries.find((e) => e.id === selected)
@@ -669,6 +729,16 @@ export function JournalScreen() {
                     >
                       {brainstorming ? "Thinking…" : "Brainstorm"}
                     </button>
+                    {brainstorming && (
+                      <button
+                        type="button"
+                        onClick={cancelBrainstorm}
+                        className="rounded-md border px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-destructive"
+                        title="Cancel (Esc)"
+                      >
+                        Stop
+                      </button>
+                    )}
                     {chatError && <span className="text-sm text-destructive">{chatError}</span>}
                   </div>
                 </div>

--- a/apps/web/lib/chatJobStore.tsx
+++ b/apps/web/lib/chatJobStore.tsx
@@ -2,6 +2,7 @@
 import type { ReactNode } from "react"
 
 import { createJobStoreProvider } from "./createJobStoreProvider"
+import { parseSseChunk } from "./sse"
 
 /**
  * Chat-flavored job-backed store. Owns the *currently in-flight* chat turn
@@ -60,27 +61,6 @@ const initialState: ChatJobState = {
 
 const isInFlightStatus = (s: ChatJobStatus) =>
   s === "pending" || s === "running"
-
-type SSEEvent = { type: string; data: string }
-
-// Streaming SSE parser: events end at "\n\n"; multi-line ``data:`` fields join with "\n".
-function parseSSE(buffer: string): { events: SSEEvent[]; rest: string } {
-  const events: SSEEvent[] = []
-  let rest = buffer
-  let idx
-  while ((idx = rest.indexOf("\n\n")) !== -1) {
-    const raw = rest.slice(0, idx)
-    rest = rest.slice(idx + 2)
-    let type = "message"
-    const data: string[] = []
-    for (const line of raw.split("\n")) {
-      if (line.startsWith("event: ")) type = line.slice(7)
-      else if (line.startsWith("data: ")) data.push(line.slice(6))
-    }
-    events.push({ type, data: data.join("\n") })
-  }
-  return { events, rest }
-}
 
 const { Provider, useStore } = createJobStoreProvider<
   ChatJobState,
@@ -213,7 +193,7 @@ const { Provider, useStore } = createJobStoreProvider<
         if (done) break
         if (signal.aborted) return
         buffer += decoder.decode(value, { stream: true })
-        const { events, rest } = parseSSE(buffer)
+        const { events, rest } = parseSseChunk(buffer)
         buffer = rest
         for (const ev of events) {
           if (signal.aborted) return

--- a/apps/web/lib/sse.ts
+++ b/apps/web/lib/sse.ts
@@ -14,7 +14,10 @@ export function parseSseChunk(buffer: string): { events: SseEvent[]; rest: strin
   while ((idx = rest.indexOf("\n\n")) !== -1) {
     const event = parseSseEventBlock(rest.slice(0, idx))
     rest = rest.slice(idx + 2)
-    events.push(event)
+    // Skip fully-empty blocks (stray separators / comment-only blocks) so
+    // consumers don't see spurious `{type: "message", data: ""}` events.
+    // Typed events are kept even with empty data — they carry control meaning.
+    if (event.data || event.type !== "message") events.push(event)
   }
   return { events, rest }
 }

--- a/apps/web/lib/sse.ts
+++ b/apps/web/lib/sse.ts
@@ -65,9 +65,11 @@ export async function* readSseEvents(
       buffer = rest
       for (const ev of events) yield ev
     }
-    // Flush a final event that arrived without a trailing "\n\n".
+    // Flush a final event that arrived without a trailing "\n\n". Keep the
+    // same filter as parseSseChunk so a trailing typed control event with no
+    // data (e.g. `event: stale_session`) isn't silently dropped.
     const tail = parseSseEventBlock(buffer)
-    if (tail.data) yield tail
+    if (tail.data || tail.type !== "message") yield tail
   } finally {
     signal?.removeEventListener("abort", onAbort)
   }

--- a/apps/web/lib/sse.ts
+++ b/apps/web/lib/sse.ts
@@ -1,0 +1,71 @@
+/** Shared Server-Sent Events parsing (used by chatJobStore and JournalScreen). */
+
+export type SseEvent = { type: string; data: string }
+
+/**
+ * Streaming SSE parser: events end at "\n\n"; multi-line `data:` fields join
+ * with "\n". Returns completed events plus the unconsumed tail of the buffer.
+ * Events without an `event:` line get the SSE default type "message".
+ */
+export function parseSseChunk(buffer: string): { events: SseEvent[]; rest: string } {
+  const events: SseEvent[] = []
+  let rest = buffer
+  let idx: number
+  while ((idx = rest.indexOf("\n\n")) !== -1) {
+    const event = parseSseEventBlock(rest.slice(0, idx))
+    rest = rest.slice(idx + 2)
+    events.push(event)
+  }
+  return { events, rest }
+}
+
+/** Parse one raw SSE event block (the text between "\n\n" separators). */
+function parseSseEventBlock(raw: string): SseEvent {
+  let type = "message"
+  const data: string[] = []
+  for (const line of raw.split("\n")) {
+    if (line.startsWith("event:")) type = line.slice(6).replace(/^ /, "")
+    else if (line.startsWith("data:")) data.push(line.slice(5).replace(/^ /, ""))
+  }
+  return { type, data: data.join("\n") }
+}
+
+/**
+ * Read an SSE body as an async generator of events.
+ *
+ * When `signal` aborts, the reader is cancelled so the pending read resolves
+ * and the generator ends cleanly — callers check `signal.aborted` afterwards.
+ * An AbortError surfacing from the read while aborted is swallowed (it is the
+ * expected way a cancelled fetch body terminates); other errors propagate.
+ */
+export async function* readSseEvents(
+  body: ReadableStream<Uint8Array>,
+  signal?: AbortSignal,
+): AsyncGenerator<SseEvent> {
+  const reader = body.getReader()
+  const onAbort = () => void reader.cancel().catch(() => {})
+  signal?.addEventListener("abort", onAbort, { once: true })
+  const decoder = new TextDecoder()
+  let buffer = ""
+  try {
+    while (true) {
+      let chunk: ReadableStreamReadResult<Uint8Array>
+      try {
+        chunk = await reader.read()
+      } catch (e) {
+        if (signal?.aborted && e instanceof DOMException && e.name === "AbortError") return
+        throw e
+      }
+      if (chunk.done) break
+      buffer += decoder.decode(chunk.value, { stream: true })
+      const { events, rest } = parseSseChunk(buffer)
+      buffer = rest
+      for (const ev of events) yield ev
+    }
+    // Flush a final event that arrived without a trailing "\n\n".
+    const tail = parseSseEventBlock(buffer)
+    if (tail.data) yield tail
+  } finally {
+    signal?.removeEventListener("abort", onAbort)
+  }
+}

--- a/apps/web/tests/journal-cancel.test.tsx
+++ b/apps/web/tests/journal-cancel.test.tsx
@@ -79,6 +79,46 @@ describe("JournalScreen brainstorm cancel", () => {
     expect(screen.queryByText(/failed|error/i)).toBeNull()
   })
 
+  it("cancelling before the job id arrives still DELETEs the job", async () => {
+    // Hold the POST response until after Stop is clicked, so cancel runs
+    // while jobId is still unknown.
+    let releasePost: (r: Response) => void = () => {}
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url === "/api/journal" && (!init || !init.method || init.method === "GET")) {
+        return Promise.resolve(jsonResponse({ entries: [] }))
+      }
+      if (url === "/api/journal/chat") {
+        return new Promise<Response>((resolve) => {
+          releasePost = resolve
+        })
+      }
+      if (url === "/api/chat/job-1" && init?.method === "DELETE") {
+        return Promise.resolve(new Response(null, { status: 204 }))
+      }
+      return Promise.resolve(jsonResponse({}, 404))
+    })
+
+    render(<JournalScreen />)
+    fireEvent.click(screen.getByRole("button", { name: /new/i }))
+    const textarea = screen.getByPlaceholderText(/what should i focus on/i)
+    fireEvent.change(textarea, { target: { value: "race me" } })
+    fireEvent.click(screen.getByRole("button", { name: "Brainstorm" }))
+
+    const stopBtn = await screen.findByRole("button", { name: "Stop" })
+    fireEvent.click(stopBtn)
+    // POST resolves only after the cancel — the job id was unknown at cancel time.
+    releasePost(jsonResponse({ job_id: "job-1" }, 202))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/chat/job-1",
+        expect.objectContaining({ method: "DELETE" }),
+      )
+      expect((textarea as HTMLTextAreaElement).value).toBe("race me")
+    })
+  })
+
   it("Esc cancels the in-flight brainstorm", async () => {
     render(<JournalScreen />)
     fireEvent.click(screen.getByRole("button", { name: /new/i }))

--- a/apps/web/tests/journal-cancel.test.tsx
+++ b/apps/web/tests/journal-cancel.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { JournalScreen } from "@/components/screens/JournalScreen"
+
+// A stream that stays open (never closes) so the brainstorm stays in the
+// "Thinking…" state until the test aborts it.
+function pendingSseResponse(): Response {
+  const stream = new ReadableStream<Uint8Array>({ start() {} })
+  return new Response(stream, { status: 200 })
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  })
+}
+
+describe("JournalScreen brainstorm cancel", () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock)
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url === "/api/journal" && (!init || !init.method || init.method === "GET")) {
+        return Promise.resolve(jsonResponse({ entries: [] }))
+      }
+      if (url === "/api/journal/chat") {
+        return Promise.resolve(jsonResponse({ job_id: "job-1" }, 202))
+      }
+      if (url === "/api/chat/job-1/stream") {
+        // Reject on abort like a real fetch would.
+        return new Promise<Response>((resolve, reject) => {
+          const signal = init?.signal
+          if (signal) {
+            signal.addEventListener("abort", () =>
+              reject(new DOMException("aborted", "AbortError")),
+            )
+          }
+          resolve(pendingSseResponse())
+        })
+      }
+      if (url === "/api/chat/job-1" && init?.method === "DELETE") {
+        return Promise.resolve(new Response(null, { status: 204 }))
+      }
+      return Promise.resolve(jsonResponse({}, 404))
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it("Stop aborts the stream, deletes the job, and restores the question", async () => {
+    render(<JournalScreen />)
+    fireEvent.click(screen.getByRole("button", { name: /new/i }))
+
+    const textarea = screen.getByPlaceholderText(/what should i focus on/i)
+    fireEvent.change(textarea, { target: { value: "cancel me" } })
+    fireEvent.click(screen.getByRole("button", { name: "Brainstorm" }))
+
+    const stopBtn = await screen.findByRole("button", { name: "Stop" })
+    fireEvent.click(stopBtn)
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/chat/job-1",
+        expect.objectContaining({ method: "DELETE" }),
+      )
+    })
+    // Pending turn dropped, question restored, composer editable again.
+    await waitFor(() => {
+      expect(screen.queryAllByText("Thinking…")).toHaveLength(0)
+      expect((textarea as HTMLTextAreaElement).value).toBe("cancel me")
+    })
+    expect(screen.queryByText(/failed|error/i)).toBeNull()
+  })
+
+  it("Esc cancels the in-flight brainstorm", async () => {
+    render(<JournalScreen />)
+    fireEvent.click(screen.getByRole("button", { name: /new/i }))
+
+    const textarea = screen.getByPlaceholderText(/what should i focus on/i)
+    fireEvent.change(textarea, { target: { value: "esc me" } })
+    fireEvent.click(screen.getByRole("button", { name: "Brainstorm" }))
+    await screen.findByRole("button", { name: "Stop" })
+
+    fireEvent.keyDown(window, { key: "Escape" })
+
+    await waitFor(() => {
+      expect((textarea as HTMLTextAreaElement).value).toBe("esc me")
+      expect(screen.queryByRole("button", { name: "Stop" })).toBeNull()
+    })
+  })
+})

--- a/apps/web/tests/sse.test.ts
+++ b/apps/web/tests/sse.test.ts
@@ -62,6 +62,44 @@ describe("readSseEvents", () => {
     expect(events).toEqual([{ type: "message", data: "a" }])
   })
 
+  it("flushes a trailing typed control event with no data and no separator", async () => {
+    const events = await collect(
+      readSseEvents(streamOf(["data: a\n\n", "event: stale_session"])),
+    )
+    expect(events).toEqual([
+      { type: "message", data: "a" },
+      { type: "stale_session", data: "" },
+    ])
+  })
+
+  it("swallows AbortError from reader.read after the signal is aborted", async () => {
+    const abortController = new AbortController()
+    const abortError = new DOMException("The operation was aborted.", "AbortError")
+    const stream = {
+      getReader: () => ({
+        read: () => Promise.reject(abortError),
+        cancel: () => Promise.resolve(),
+      }),
+    } as unknown as ReadableStream<Uint8Array>
+
+    abortController.abort()
+
+    const events = await collect(readSseEvents(stream, abortController.signal))
+    expect(events).toEqual([])
+  })
+
+  it("propagates non-AbortError rejections from reader.read", async () => {
+    const error = new Error("boom")
+    const stream = {
+      getReader: () => ({
+        read: () => Promise.reject(error),
+        cancel: () => Promise.resolve(),
+      }),
+    } as unknown as ReadableStream<Uint8Array>
+
+    await expect(collect(readSseEvents(stream))).rejects.toBe(error)
+  })
+
   it("ends cleanly when the signal aborts mid-stream", async () => {
     const controller = new AbortController()
     // A stream that emits one event then stays open.

--- a/apps/web/tests/sse.test.ts
+++ b/apps/web/tests/sse.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest"
+
+import { parseSseChunk, readSseEvents, type SseEvent } from "@/lib/sse"
+
+function streamOf(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder()
+  return new ReadableStream({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(encoder.encode(c))
+      controller.close()
+    },
+  })
+}
+
+async function collect(gen: AsyncGenerator<SseEvent>): Promise<SseEvent[]> {
+  const out: SseEvent[] = []
+  for await (const ev of gen) out.push(ev)
+  return out
+}
+
+describe("parseSseChunk", () => {
+  it("parses typed and default events, keeping the unconsumed tail", () => {
+    const { events, rest } = parseSseChunk(
+      "data: hello\n\nevent: error\ndata: boom\n\ndata: partial",
+    )
+    expect(events).toEqual([
+      { type: "message", data: "hello" },
+      { type: "error", data: "boom" },
+    ])
+    expect(rest).toBe("data: partial")
+  })
+
+  it("joins multi-line data and tolerates a missing space after the colon", () => {
+    const { events } = parseSseChunk("data:line1\ndata: line2\n\n")
+    expect(events).toEqual([{ type: "message", data: "line1\nline2" }])
+  })
+})
+
+describe("readSseEvents", () => {
+  it("yields events across chunk boundaries and flushes the tail", async () => {
+    const events = await collect(
+      readSseEvents(streamOf(["data: a\n\nda", "ta: b"])),
+    )
+    expect(events).toEqual([
+      { type: "message", data: "a" },
+      { type: "message", data: "b" },
+    ])
+  })
+
+  it("ends cleanly when the signal aborts mid-stream", async () => {
+    const controller = new AbortController()
+    // A stream that emits one event then stays open.
+    const encoder = new TextEncoder()
+    const stream = new ReadableStream<Uint8Array>({
+      start(c) {
+        c.enqueue(encoder.encode("data: first\n\n"))
+      },
+    })
+    const seen: SseEvent[] = []
+    for await (const ev of readSseEvents(stream, controller.signal)) {
+      seen.push(ev)
+      controller.abort()
+    }
+    expect(seen).toEqual([{ type: "message", data: "first" }])
+    expect(controller.signal.aborted).toBe(true)
+  })
+})

--- a/apps/web/tests/sse.test.ts
+++ b/apps/web/tests/sse.test.ts
@@ -47,6 +47,21 @@ describe("readSseEvents", () => {
     ])
   })
 
+  it("skips empty blocks and keeps typed control events without data", async () => {
+    const { events } = parseSseChunk("\n\ndata: a\n\n\n\nevent: stale_session\n\n")
+    expect(events).toEqual([
+      { type: "message", data: "a" },
+      { type: "stale_session", data: "" },
+    ])
+  })
+
+  it("emits nothing for a stream ending in a trailing separator or comments", async () => {
+    const events = await collect(
+      readSseEvents(streamOf(["data: a\n\n", ": keep-alive comment\n\n", "\n\n"])),
+    )
+    expect(events).toEqual([{ type: "message", data: "a" }])
+  })
+
   it("ends cleanly when the signal aborts mid-stream", async () => {
     const controller = new AbortController()
     // A stream that emits one event then stays open.


### PR DESCRIPTION
## Summary
- Stop button + Esc cancel an in-flight brainstorm: aborts the SSE fetch, fires `DELETE /api/chat/{job_id}` (existing backend cancel), drops the pending turn, and restores the question/image for re-edit.
- `readSse` now cancels its reader on abort so the stream ends cleanly.

## Test plan
- [x] New `journal-cancel.test.tsx` (Stop + Esc paths); `vitest run` 220 pass
- [x] `tsc --noEmit` clean

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QxFVXAAgBeip7r3VXkhEQt

## Summary by Sourcery

Add client-side support for cancelling in-flight Journal brainstorm chats and centralize SSE stream parsing.

New Features:
- Allow users to cancel an in-flight Journal brainstorm via a Stop button and Escape key, restoring the original question for editing.

Enhancements:
- Track in-flight journal brainstorm jobs with abort controllers so cancelled requests cleanly terminate both the POST and stream phases.
- Introduce a shared SSE parsing utility and update existing chat streaming code to use it for consistent event handling.
- Ensure SSE readers end cleanly on abort, avoiding stray errors and dropping only meaningful control/message events.

Tests:
- Add JournalScreen cancel tests covering Stop button, pre-job-id cancellation, and Escape key behavior.
- Add unit tests for the shared SSE parsing and streaming helpers, including chunking, control events, and abort/error handling.