### PR TITLE
fix(python): derive proper Notion page title for Journal entries

### DIFF
--- a/apps/python/src/notifier/journal_sync.py
+++ b/apps/python/src/notifier/journal_sync.py
@@ -16,18 +16,26 @@ from src.notifier.notion import _append_blocks, _create_page
 logger = get_logger(__name__)
 
 _LEADING_MARKS_RE = re.compile(r"^[\s#\-*]+")
-_TITLE_MAX_LEN = 60
+_ROLE_LABEL_RE = re.compile(r"^\*\*(You|AI):\*\*$")
+_TITLE_MAX_LEN = 50
 
 
 def title_from_content(content: str, fallback: str) -> str:
-    """Derive a Notion page title from an entry's first non-blank line.
+    """Derive a Notion page title from an entry's first non-blank content line.
 
-    Strips leading heading/list markers, then falls back to ``fallback`` (the
-    entry's date) if nothing remains, and truncates to 60 chars.
+    Skips role-label lines (e.g. ``**You:**``, ``**AI:**``) produced by
+    apps/web/lib/journalQa.ts, strips leading heading/list markers from the
+    first remaining line, falls back to ``fallback`` (the entry's date) if
+    nothing remains, and truncates to 50 chars.
     """
-    first_line = next((line for line in content.splitlines() if line.strip()), "")
-    title = _LEADING_MARKS_RE.sub("", first_line).strip()
-    return (title or fallback)[:_TITLE_MAX_LEN]
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped or _ROLE_LABEL_RE.match(stripped):
+            continue
+        title = _LEADING_MARKS_RE.sub("", stripped).strip()
+        if title:
+            return title[:_TITLE_MAX_LEN]
+    return fallback[:_TITLE_MAX_LEN]
 
 
 def sync_new_entry(entry_id: str, content: str, api_key: str, database_id: str) -> None:

--- a/apps/python/tests/test_journal_notion_sync.py
+++ b/apps/python/tests/test_journal_notion_sync.py
@@ -5,8 +5,9 @@ Contract:
 - Append to an entry with a saved ``notion_page_id`` -> blocks appended to that page.
 - Append to an entry without one (pre-sync entry) -> falls back to creating a page.
 - Notion failures are best-effort: the local journal write always succeeds.
-- Title is derived from the entry's first line (heading/list markers stripped,
-  truncated to 60 chars, falls back to the entry's date when empty).
+- Title is derived from the entry's first non-blank, non-role-label line
+  (heading/list markers stripped, truncated to 50 chars, falls back to the
+  entry's date when empty).
 """
 from unittest.mock import MagicMock, patch
 
@@ -46,13 +47,25 @@ class TestTitleFromContent:
     def test_falls_back_to_date_when_empty(self):
         assert journal_sync.title_from_content("### \n\n", "2026-07-03") == "2026-07-03"
 
-    def test_truncated_to_60_chars(self):
+    def test_truncated_to_50_chars(self):
         long_line = "a" * 100
         result = journal_sync.title_from_content(long_line, "2026-07-03")
-        assert len(result) == 60
+        assert len(result) == 50
 
     def test_skips_leading_blank_lines(self):
         assert journal_sync.title_from_content("\n\nfirst real line", "2026-07-03") == "first real line"
+
+    def test_skips_user_role_label(self):
+        content = "**You:**\n\nwhat should I focus on today?\n\n**AI:**\n\nfocus on X"
+        assert journal_sync.title_from_content(content, "2026-07-03") == "what should I focus on today?"
+
+    def test_skips_ai_role_label_only(self):
+        content = "**AI:**\n\nhere is my answer"
+        assert journal_sync.title_from_content(content, "2026-07-03") == "here is my answer"
+
+    def test_falls_back_to_date_when_only_role_labels(self):
+        content = "**You:**\n\n**AI:**\n\n"
+        assert journal_sync.title_from_content(content, "2026-07-03") == "2026-07-03"
 
 
 class TestSyncNewEntry:


### PR DESCRIPTION
## Summary
- Skip \`**You:**\`/\`**AI:**\` role-label lines in \`title_from_content()\` and use the actual first content line for the Notion page title.
- Cap title length at 50 chars (was 60).

## Test plan
- [x] \`pytest tests/test_journal_notion_sync.py -v\` — 16 passed

Closes #358

## Summary by Sourcery

Adjust Notion journal title derivation to ignore role-label lines and shorten titles.

Bug Fixes:
- Ensure journal titles use the first actual content line instead of '**You:**'/'**AI:**' role-label lines when syncing to Notion.

Enhancements:
- Reduce the maximum derived title length from 60 to 50 characters for Notion journal entries.

Tests:
- Extend journal title derivation tests to cover role-label skipping, updated length limit, and fallback behavior when only role labels are present.