### PR TITLE
feat(web): add voice input to Journal chat composer

### DIFF
--- a/apps/web/components/screens/JournalScreen.tsx
+++ b/apps/web/components/screens/JournalScreen.tsx
@@ -11,6 +11,7 @@ import { insertAtCursor } from "@/lib/insertAtCursor"
 import { useJournalChatJobState } from "@/lib/journalChatJobStore"
 import { useJournalChatState } from "@/lib/journalChatStore"
 import { useResizable } from "@/lib/hooks/useResizable"
+import { useSpeechRecognition } from "@/lib/hooks/useSpeechRecognition"
 import type { ImageAttachment } from "@/lib/types/image"
 import { cn } from "@/lib/utils"
 
@@ -48,6 +49,9 @@ export function JournalScreen() {
   const trashReqSeq = useRef(0)
 
   const [question, setQuestion] = useState("")
+  const { supportsMic, listening, toggle: toggleMic } = useSpeechRecognition({
+    onTranscript: setQuestion,
+  })
   const journalChat = useJournalChatState()
   const job = useJournalChatJobState()
   const brainstorming = job.status === "pending" || job.status === "running"
@@ -607,6 +611,24 @@ export function JournalScreen() {
                     >
                       {brainstorming ? "Thinking…" : "Brainstorm"}
                     </button>
+                    {supportsMic && (
+                      <button
+                        type="button"
+                        onClick={() => toggleMic(question)}
+                        data-testid="mic-button"
+                        aria-label={listening ? "音声入力停止" : "音声入力開始"}
+                        aria-pressed={listening}
+                        title={listening ? "音声入力停止" : "音声入力開始 (ja-JP)"}
+                        className={cn(
+                          "rounded-md border px-3 py-2 text-sm transition-colors",
+                          listening
+                            ? "border-destructive bg-destructive text-destructive-foreground"
+                            : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+                        )}
+                      >
+                        {listening ? "🛑" : "🎤"}
+                      </button>
+                    )}
                     {brainstorming && (
                       <button
                         type="button"
@@ -619,6 +641,14 @@ export function JournalScreen() {
                     )}
                     {chatError && <span className="text-sm text-destructive">{chatError}</span>}
                   </div>
+                  {!supportsMic && (
+                    <p
+                      className="text-xs text-muted-foreground"
+                      data-testid="mic-unsupported"
+                    >
+                      Voice input is unavailable in this browser (Chrome / Edge supported).
+                    </p>
+                  )}
                 </div>
               </section>
             </div>

--- a/apps/web/tests/journal-voice-input.test.tsx
+++ b/apps/web/tests/journal-voice-input.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { JournalScreen } from "@/components/screens/JournalScreen"
+import { JournalChatJobStateProvider } from "@/lib/journalChatJobStore"
+import { JournalChatStateProvider } from "@/lib/journalChatStore"
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  })
+}
+
+function renderJournalScreen() {
+  return render(
+    <JournalChatStateProvider>
+      <JournalChatJobStateProvider>
+        <JournalScreen />
+      </JournalChatJobStateProvider>
+    </JournalChatStateProvider>,
+  )
+}
+
+describe("JournalScreen voice input", () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    window.sessionStorage.clear()
+    vi.stubGlobal("fetch", fetchMock)
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url === "/api/journal" && (!init || !init.method || init.method === "GET")) {
+        return Promise.resolve(jsonResponse({ entries: [] }))
+      }
+      return Promise.resolve(jsonResponse({}, 404))
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+    window.sessionStorage.clear()
+  })
+
+  it("shows the fallback message when SpeechRecognition is unsupported", () => {
+    renderJournalScreen()
+    fireEvent.click(screen.getByRole("button", { name: /new/i }))
+
+    expect(screen.queryByTestId("mic-button")).toBeNull()
+    expect(screen.getByTestId("mic-unsupported")).toBeInTheDocument()
+  })
+
+  it("inserts recognized speech into the brainstorm textarea", () => {
+    class FakeRecognition {
+      lang = ""
+      continuous = false
+      interimResults = false
+      onresult: ((e: { results: ArrayLike<ArrayLike<{ transcript: string }>> }) => void) | null = null
+      onend: (() => void) | null = null
+      onerror: ((e: { error: string }) => void) | null = null
+      start() {
+        this.onresult?.({ results: [[{ transcript: "hello from voice" }]] })
+      }
+      stop() {
+        this.onend?.()
+      }
+    }
+    vi.stubGlobal("SpeechRecognition", FakeRecognition)
+
+    renderJournalScreen()
+    fireEvent.click(screen.getByRole("button", { name: /new/i }))
+
+    const micButton = screen.getByTestId("mic-button")
+    fireEvent.click(micButton)
+
+    const textarea = screen.getByPlaceholderText(
+      /what should i focus on/i,
+    ) as HTMLTextAreaElement
+    expect(textarea.value).toBe("hello from voice")
+  })
+})

--- a/apps/web/tests/journal-voice-input.test.tsx
+++ b/apps/web/tests/journal-voice-input.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react"
+import { fireEvent, render, screen, within } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { JournalScreen } from "@/components/screens/JournalScreen"
@@ -72,11 +72,30 @@ describe("JournalScreen voice input", () => {
     fireEvent.click(screen.getByRole("button", { name: /new/i }))
 
     const micButton = screen.getByTestId("mic-button")
+
+    // Initial state: not listening.
+    expect(micButton).toHaveAttribute("aria-pressed", "false")
+    expect(micButton).toHaveAttribute("aria-label", "音声入力開始")
+    expect(within(micButton).getByText("🎤")).toBeInTheDocument()
+
     fireEvent.click(micButton)
+
+    // FakeRecognition.start() emits synchronously, so the transcript lands
+    // before we assert the toggled-on state below.
+    expect(micButton).toHaveAttribute("aria-pressed", "true")
+    expect(micButton).toHaveAttribute("aria-label", "音声入力停止")
+    expect(within(micButton).getByText("🛑")).toBeInTheDocument()
 
     const textarea = screen.getByPlaceholderText(
       /what should i focus on/i,
     ) as HTMLTextAreaElement
     expect(textarea.value).toBe("hello from voice")
+
+    // Toggle off again and confirm the state resets.
+    fireEvent.click(micButton)
+
+    expect(micButton).toHaveAttribute("aria-pressed", "false")
+    expect(micButton).toHaveAttribute("aria-label", "音声入力開始")
+    expect(within(micButton).getByText("🎤")).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- Reuse the existing `useSpeechRecognition` hook (already shared by Briefing Q&A Chat) in `JournalScreen`'s brainstorm composer
- Add a mic button (🎤/🛑) with the same aria labels/testids as Q&A Chat; shows the unsupported-browser fallback message when SpeechRecognition is unavailable

## Test plan
- [x] `vitest run tests/journal-voice-input.test.tsx` — mic button toggles and inserts transcript into the textarea; fallback message shown when unsupported
- [x] `vitest run tests/journal-cancel.test.tsx` — no regression
- [x] `tsc --noEmit`

Closes #354

## Summary by Sourcery

Add speech recognition-based voice input to the Journal brainstorm chat composer, including UI controls and browser support handling.

New Features:
- Introduce voice input for the Journal brainstorm composer using the shared speech recognition hook.
- Add a microphone toggle button to control voice recording in the Journal chat composer.

Enhancements:
- Show a browser compatibility fallback message when speech recognition is unavailable in Journal.
- Share the existing speech recognition infrastructure between Briefing Q&A Chat and Journal to reduce duplication.

Tests:
- Add integration tests covering mic availability, fallback messaging, and transcript insertion into the Journal brainstorm textarea.